### PR TITLE
Stage 2 - PR1: Standardize round label vocabulary across engines/UI

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -408,7 +408,7 @@ namespace RCDragManagerProd.Controllers
             }
 
             // ── Legacy fallback (if LB Final manually checked) ────────────
-            if (_session.RaceType == "Losers Bracket" && _revealedRounds.Contains("Losers Bracket Final"))
+            if (_session.RaceType == "Losers Bracket" && _revealedRounds.Any(r => string.Equals(RoundLabels.Normalize(r), "LB-F", StringComparison.OrdinalIgnoreCase)))
             {
                 var finalMatch = _engine.GetMatches().LastOrDefault();
                 if (finalMatch != null && finalMatch.HasResult)

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Finals.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Finals.cs
@@ -71,7 +71,8 @@ namespace RCDragManagerProd.Controllers
             }
 
             var preserveLb = _revealedRounds
-                .Where(r => r.StartsWith("Losers Bracket", StringComparison.OrdinalIgnoreCase))
+                .Where(r => string.Equals(RoundLabels.Normalize(r), "LB-F", StringComparison.OrdinalIgnoreCase) ||
+                            RoundLabels.Normalize(r).StartsWith("LB-R", StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
             _revealedRounds.Clear();

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Losers.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Losers.cs
@@ -80,8 +80,8 @@ namespace RCDragManagerProd.Controllers
             Logger.Log("[LB] Engine swapped to LB adapter; LB phase entered; session type='Losers Bracket'.");
 
             _revealedRounds.Clear();
-            _revealedRounds.Add("Losers Bracket R1");
-            Logger.Log("🎬 Revealed: Losers Bracket R1");
+            _revealedRounds.Add(RoundLabels.Normalize("LB-R1"));
+            Logger.Log("🎬 Revealed: LB-R1");
 
             var rows = BuildCurrentBracketRows();
             BracketRedrawn?.Invoke(rows);

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.View.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.View.cs
@@ -79,11 +79,12 @@ namespace RCDragManagerProd.Controllers
 
                 foreach (var round in rList)
                 {
-                    if (filterByRevealed && !_revealedRounds.Contains(round)) continue;
+                    var normalizedRound = RoundLabels.Normalize(round);
+                    if (filterByRevealed && !_revealedRounds.Contains(round) && !_revealedRounds.Contains(normalizedRound)) continue;
 
-                    rows.Add(new PairingRow { IsHeader = true, RoundLabel = round });
+                    rows.Add(new PairingRow { IsHeader = true, RoundLabel = normalizedRound });
 
-                    foreach (var m in mList.Where(x => x.RoundLabel == round))
+                    foreach (var m in mList.Where(x => string.Equals(RoundLabels.Normalize(x.RoundLabel), normalizedRound, StringComparison.OrdinalIgnoreCase)))
                     {
                         string leftName;
                         string rightName;
@@ -96,7 +97,7 @@ namespace RCDragManagerProd.Controllers
                             MatchId = m.MatchId,
                             Driver1 = leftName,
                             Driver2 = rightName,
-                            RoundLabel = m.RoundLabel
+                            RoundLabel = RoundLabels.Normalize(m.RoundLabel)
                         });
                     }
                 }

--- a/src/RCDragManagerProd/Domain/RoundLabels.cs
+++ b/src/RCDragManagerProd/Domain/RoundLabels.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Text.RegularExpressions;
+using RCDragManagerProd.Logging;
+
+namespace RCDragManagerProd.Domain
+{
+    public static class RoundLabels
+    {
+        private static readonly Regex WinnersRoundRx = new Regex(@"^R(\d+)$", RegexOptions.IgnoreCase);
+        private static readonly Regex LosersRoundRx = new Regex(@"^LB-R(\d+)$", RegexOptions.IgnoreCase);
+        private static readonly Regex RoundRobinRoundRx = new Regex(@"^RR(\d+)$", RegexOptions.IgnoreCase);
+        private static readonly Regex LegacyLosersRoundRx = new Regex(@"^LOSERS BRACKET R(\d+)$", RegexOptions.IgnoreCase);
+
+        public static string Normalize(string label)
+        {
+            var raw = (label ?? string.Empty).Trim();
+            if (raw.Length == 0) return raw;
+
+            var mRr = RoundRobinRoundRx.Match(raw);
+            if (mRr.Success)
+            {
+                var canonical = "RR" + mRr.Groups[1].Value;
+                LogConversion(raw, canonical);
+                return canonical;
+            }
+
+            var mLb = LosersRoundRx.Match(raw);
+            if (mLb.Success)
+            {
+                var canonical = "LB-R" + mLb.Groups[1].Value;
+                LogConversion(raw, canonical);
+                return canonical;
+            }
+
+            var mLegacyLb = LegacyLosersRoundRx.Match(raw);
+            if (mLegacyLb.Success)
+            {
+                var canonical = "LB-R" + mLegacyLb.Groups[1].Value;
+                LogConversion(raw, canonical);
+                return canonical;
+            }
+
+            if (string.Equals(raw, "LOSERS BRACKET FINAL", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(raw, "LBF", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(raw, "LB-F", StringComparison.OrdinalIgnoreCase))
+            {
+                LogConversion(raw, "LB-F");
+                return "LB-F";
+            }
+
+            if (string.Equals(raw, "SF", StringComparison.OrdinalIgnoreCase) ||
+                raw.StartsWith("SEMI", StringComparison.OrdinalIgnoreCase))
+            {
+                LogConversion(raw, "SF");
+                return "SF";
+            }
+
+            if (string.Equals(raw, "F", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(raw, "FINAL", StringComparison.OrdinalIgnoreCase))
+            {
+                LogConversion(raw, "F");
+                return "F";
+            }
+
+            var mW = WinnersRoundRx.Match(raw);
+            if (mW.Success)
+            {
+                var canonical = "R" + mW.Groups[1].Value;
+                LogConversion(raw, canonical);
+                return canonical;
+            }
+
+            Logger.Log($"[RoundLabels][WARN] Unknown round label '{raw}'");
+            return raw;
+        }
+
+        public static int Compare(string a, string b)
+        {
+            var na = Normalize(a);
+            var nb = Normalize(b);
+
+            int ka = SortKey(na);
+            int kb = SortKey(nb);
+            if (ka != kb) return ka.CompareTo(kb);
+
+            return string.Compare(na, nb, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool TryParse(string label, out (bool IsLosers, int? RoundNumber, bool IsSemiFinal, bool IsFinal) parsed)
+        {
+            var n = Normalize(label);
+
+            var mLb = LosersRoundRx.Match(n);
+            if (mLb.Success)
+            {
+                parsed = (true, ParseInt(mLb.Groups[1].Value), false, false);
+                return true;
+            }
+
+            var mRr = RoundRobinRoundRx.Match(n);
+            if (mRr.Success)
+            {
+                parsed = (false, ParseInt(mRr.Groups[1].Value), false, false);
+                return true;
+            }
+
+            var mW = WinnersRoundRx.Match(n);
+            if (mW.Success)
+            {
+                parsed = (false, ParseInt(mW.Groups[1].Value), false, false);
+                return true;
+            }
+
+            if (string.Equals(n, "SF", StringComparison.OrdinalIgnoreCase))
+            {
+                parsed = (false, null, true, false);
+                return true;
+            }
+
+            if (string.Equals(n, "F", StringComparison.OrdinalIgnoreCase))
+            {
+                parsed = (false, null, false, true);
+                return true;
+            }
+
+            if (string.Equals(n, "LB-F", StringComparison.OrdinalIgnoreCase))
+            {
+                parsed = (true, null, false, true);
+                return true;
+            }
+
+            parsed = default;
+            return false;
+        }
+
+        private static int SortKey(string normalized)
+        {
+            if (normalized == null) return 10000;
+
+            var mRr = RoundRobinRoundRx.Match(normalized);
+            if (mRr.Success) return 100 + ParseInt(mRr.Groups[1].Value);
+
+            var mW = WinnersRoundRx.Match(normalized);
+            if (mW.Success) return 200 + ParseInt(mW.Groups[1].Value);
+
+            if (string.Equals(normalized, "SF", StringComparison.OrdinalIgnoreCase)) return 290;
+            if (string.Equals(normalized, "F", StringComparison.OrdinalIgnoreCase)) return 299;
+
+            var mLb = LosersRoundRx.Match(normalized);
+            if (mLb.Success) return 400 + ParseInt(mLb.Groups[1].Value);
+
+            if (string.Equals(normalized, "LB-F", StringComparison.OrdinalIgnoreCase)) return 499;
+
+            return 10000;
+        }
+
+        private static int ParseInt(string s)
+        {
+            int.TryParse(s, out var n);
+            return n;
+        }
+
+        private static void LogConversion(string original, string canonical)
+        {
+            if (!string.Equals(original, canonical, StringComparison.Ordinal))
+                Logger.Log($"[RoundLabels] Normalize '{original}' -> '{canonical}'");
+        }
+    }
+}

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Domain\Ladders\ProLadder.Ladders.L24.cs" />
     <Compile Include="Domain\ProLadder.Ladders.Common.cs" />
     <Compile Include="Domain\ProLadder.Structures.cs" />
+    <Compile Include="Domain\RoundLabels.cs" />
     <Compile Include="Helpers\AssetPath.cs" />
     <Compile Include="RoundRobinMode\RoundRobinScorecardLogger\RoundRobinScorecardDebug.cs" />
     <Compile Include="RoundRobinMode\RoundRobinScorecardLogger\RoundRobinScorecardFormatter.cs" />

--- a/src/RCDragManagerProd/RaceEngines/RandomEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/RandomEngineAdapter.cs
@@ -64,7 +64,7 @@ namespace RCDragManagerProd.RaceEngines
                     MatchId = m.MatchId,
                     Driver1 = m.Seed1,
                     Driver2 = m.Seed2,
-                    RoundLabel = m.RoundLabel,
+                    RoundLabel = RoundLabels.Normalize(m.RoundLabel),
                     FromMatch1 = m.FromMatch1,
                     FromMatch2 = m.FromMatch2,
                     HasResult = _engine.HasWinner(m.MatchId)
@@ -73,7 +73,12 @@ namespace RCDragManagerProd.RaceEngines
             return list;
         }
 
-        public IReadOnlyList<string> GetRoundOrder() => _engine.GetRoundOrder();
+        public IReadOnlyList<string> GetRoundOrder() =>
+            _engine.GetRoundOrder()
+                   .Select(RoundLabels.Normalize)
+                   .Distinct(StringComparer.OrdinalIgnoreCase)
+                   .OrderBy(x => x, Comparer<string>.Create(RoundLabels.Compare))
+                   .ToList();
 
         public void SetWinner(int matchId, Driver winner)
         {
@@ -100,8 +105,8 @@ namespace RCDragManagerProd.RaceEngines
 
             // Prefer a labeled final, else the last round seen in order.
             var final = all.FirstOrDefault(m =>
-                !string.IsNullOrEmpty(m.RoundLabel) &&
-                m.RoundLabel.IndexOf("final", StringComparison.OrdinalIgnoreCase) >= 0);
+                string.Equals(RoundLabels.Normalize(m.RoundLabel), "F", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(RoundLabels.Normalize(m.RoundLabel), "LB-F", StringComparison.OrdinalIgnoreCase));
 
             if (final == null)
             {
@@ -262,16 +267,19 @@ namespace RCDragManagerProd.RaceEngines
 
         private static string LabelForNextRound(List<string> order, int lastWinnerCount)
         {
-            // Very simple scheme: Round N → Round N+1; if exactly two winners were produced, call it "Final".
-            var last = (order != null && order.Count > 0) ? order[order.Count - 1] : "Round 1";
+            var last = (order != null && order.Count > 0) ? RoundLabels.Normalize(order[order.Count - 1]) : "R1";
             var index = ParseRoundIndex(last);
-            if (lastWinnerCount == 2) return "Final";
-            return "Round " + (index + 1);
+            if (lastWinnerCount == 2) return "F";
+            return "R" + (index + 1);
         }
 
         private static int ParseRoundIndex(string roundLabel)
         {
             if (string.IsNullOrWhiteSpace(roundLabel)) return 1;
+            if (roundLabel.StartsWith("R", StringComparison.OrdinalIgnoreCase))
+            {
+                if (int.TryParse(roundLabel.Substring(1).Trim(), out var n) && n > 0) return n;
+            }
             if (roundLabel.StartsWith("Round ", StringComparison.OrdinalIgnoreCase))
             {
                 if (int.TryParse(roundLabel.Substring(6).Trim(), out var n) && n > 0) return n;

--- a/src/RCDragManagerProd/RandomMode/LosersBracketBuilder.cs
+++ b/src/RCDragManagerProd/RandomMode/LosersBracketBuilder.cs
@@ -67,7 +67,7 @@ namespace RCDragManagerProd.RandomMode
                     Seed2 = p2,                 // may be null (BYE)
                     FromMatch1 = 0,
                     FromMatch2 = 0,
-                    RoundLabel = "Losers Bracket R1"
+                    RoundLabel = RoundLabels.Normalize("LB-R1")
                 });
 
                 Logger.Log($"[LB-BUILD] R1 M{matchId}: {(p1?.Name ?? "BYE")} vs {(p2?.Name ?? "BYE")}");
@@ -98,8 +98,8 @@ namespace RCDragManagerProd.RandomMode
                             FromMatch1 = prevRound[i],
                             FromMatch2 = prevRound[i + 1],
                             RoundLabel = (prevRound.Count == 2)
-                                         ? "Losers Bracket Final"
-                                         : $"Losers Bracket R{roundIndex}"
+                                         ? RoundLabels.Normalize("LB-F")
+                                         : RoundLabels.Normalize($"LB-R{roundIndex}")
                         });
 
                         Logger.Log($"[LB-BUILD] R{roundIndex} M{matchId}: Winner M{prevRound[i]} vs Winner M{prevRound[i + 1]}");
@@ -115,7 +115,7 @@ namespace RCDragManagerProd.RandomMode
                             Seed2 = null,      // BYE
                             FromMatch1 = prevRound[i],
                             FromMatch2 = 0,
-                            RoundLabel = $"Losers Bracket R{roundIndex}"
+                            RoundLabel = RoundLabels.Normalize($"LB-R{roundIndex}")
                         });
 
                         Logger.Log($"[LB-BUILD] R{roundIndex} M{matchId}: Winner M{prevRound[i]} vs BYE (carry)");

--- a/src/RCDragManagerProd/RandomMode/RandomMatchEngine.cs
+++ b/src/RCDragManagerProd/RandomMode/RandomMatchEngine.cs
@@ -28,6 +28,10 @@ namespace RCDragManagerProd.RandomMode
         public void LoadMatches(List<RandomMatch> matches)
         {
             bracketMatches = matches ?? new List<RandomMatch>();
+            foreach (var m in bracketMatches)
+            {
+                m.RoundLabel = RoundLabels.Normalize(m.RoundLabel);
+            }
         }
 
         public IReadOnlyList<RandomMatch> GetMatches() => bracketMatches;
@@ -145,7 +149,7 @@ namespace RCDragManagerProd.RandomMode
                     MatchId = matchId++,
                     Seed1 = shuffled[i],
                     Seed2 = shuffled[i + 1],
-                    RoundLabel = "R1"
+                    RoundLabel = RoundLabels.Normalize("R1")
                 });
             }
 
@@ -166,7 +170,7 @@ namespace RCDragManagerProd.RandomMode
                         MatchId = matchId++,
                         FromMatch1 = m1.MatchId,
                         FromMatch2 = m2?.MatchId,
-                        RoundLabel = $"R{roundNum}"
+                        RoundLabel = RoundLabels.Normalize($"R{roundNum}")
                     });
                 }
 
@@ -179,7 +183,7 @@ namespace RCDragManagerProd.RandomMode
             if (bracketMatches.Count > 0)
             {
                 var final = bracketMatches.Last();
-                final.RoundLabel = "F";
+                final.RoundLabel = RoundLabels.Normalize("F");
             }
         }
 
@@ -195,7 +199,10 @@ namespace RCDragManagerProd.RandomMode
 
         public IReadOnlyList<string> GetRoundOrder()
         {
-            return bracketMatches.Select(m => m.RoundLabel).Distinct().ToList();
+            return bracketMatches.Select(m => RoundLabels.Normalize(m.RoundLabel))
+                                .Distinct(StringComparer.OrdinalIgnoreCase)
+                                .OrderBy(x => x, Comparer<string>.Create(RoundLabels.Compare))
+                                .ToList();
         }
 
     }

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
@@ -141,7 +141,7 @@ namespace RCDragManagerProd.RoundRobinMode
                     if (isByePair)
                     {
                         var real = A ?? B;
-                        matches.Add((real, null, $"R{round}", matchIdCounter++));
+                        matches.Add((real, null, $"RR{round}", matchIdCounter++));
                         if (real != null && isOdd && byeCount.ContainsKey(real.Id))
                             byeCount[real.Id] = byeCount[real.Id] + 1;
 
@@ -163,7 +163,7 @@ namespace RCDragManagerProd.RoundRobinMode
                             Log("[RR][WARN] Duplicate head-to-head within current cycle: " + SafeName(d1Out) + " vs " + SafeName(d2Out));
 
 
-                        matches.Add((d1Out, d2Out, $"R{round}", matchIdCounter++));
+                        matches.Add((d1Out, d2Out, $"RR{round}", matchIdCounter++));
                         Log($"[RR]   M{matchIdCounter - 1:000}: {SafeName(d1Out)} vs {SafeName(d2Out)}");
                     }
 
@@ -244,6 +244,7 @@ namespace RCDragManagerProd.RoundRobinMode
         {
             return matches.Select(m => m.RoundLabel)
                           .Distinct()
+                          .OrderBy(x => x, Comparer<string>.Create(RoundLabels.Compare))
                           .ToList();
         }
 

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinScorecardLogger/RoundRobinScorecardFormatter.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinScorecardLogger/RoundRobinScorecardFormatter.cs
@@ -143,7 +143,7 @@ namespace RCDragManagerProd.RoundRobinMode
             // Build popup with CompositeScore that encodes tie-breaks numerically
             var sb = new StringBuilder();
             sb.AppendLine("Round Robin — Standings");
-            sb.AppendLine($"Schedule: R1(W=4 L=1 BYE=2), R2(W=3.5 L=0.75 BYE=1.5), R3(W=3 L=0.5 BYE=1)");
+            sb.AppendLine($"Schedule: RR1(W=4 L=1 BYE=2), RR2(W=3.5 L=0.75 BYE=1.5), RR3(W=3 L=0.5 BYE=1)");
             sb.AppendLine($"Composite = Pts"
                 + $" + Wins×{WEIGHT_WINS:0.####}"
                 + $" + H2H×{WEIGHT_H2H:0.####}"
@@ -173,7 +173,7 @@ namespace RCDragManagerProd.RoundRobinMode
 
                 if (lines.TryGetValue(d.Id, out var lnz))
                 {
-                    foreach (var ln in lnz.OrderBy(x => x.RoundLabel))
+                    foreach (var ln in lnz.OrderBy(x => RoundLabels.Normalize(x.RoundLabel), Comparer<string>.Create(RoundLabels.Compare)))
                         sb.AppendLine($"   {ln.RoundLabel}: {ln.Outcome}(+{ln.Points:0.00}) vs {ln.Opponent}");
                 }
 

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinScorecardLogger/RoundRobinScorecardLogger.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinScorecardLogger/RoundRobinScorecardLogger.cs
@@ -46,7 +46,10 @@ namespace RCDragManagerProd.RoundRobinMode
                                  .ToList();
 
             var idToName = drivers.ToDictionary(d => d.Id, d => d.Name);
-            var rounds = matches.Select(m => m.RoundLabel).Distinct().OrderBy(x => x).ToList();
+            var rounds = matches.Select(m => RoundLabels.Normalize(m.RoundLabel))
+                               .Distinct(StringComparer.OrdinalIgnoreCase)
+                               .OrderBy(x => x, Comparer<string>.Create(RoundLabels.Compare))
+                               .ToList();
 
             // Points schedule
             Logger.Log("[RR-SCORE] Points schedule:");
@@ -179,7 +182,7 @@ namespace RCDragManagerProd.RoundRobinMode
 
                 if (lines.TryGetValue(d.Id, out var lns))
                 {
-                    foreach (var ln in lns.OrderBy(x => x.RoundLabel))
+                    foreach (var ln in lns.OrderBy(x => RoundLabels.Normalize(x.RoundLabel), Comparer<string>.Create(RoundLabels.Compare)))
                         Logger.Log($"      {ln.RoundLabel}: {ln.Outcome}(+{ln.Points:0.00}) vs {ln.Opponent}");
                 }
                 Logger.Log($"      Defeated: {defNames}");
@@ -217,10 +220,13 @@ namespace RCDragManagerProd.RoundRobinMode
         // ─────────────────────────────────────────────────────────────
         private static (double Win, double Loss, double Bye) PointsFor(string lbl)
         {
-            switch ((lbl ?? "").ToUpperInvariant())
+            switch (RoundLabels.Normalize(lbl).ToUpperInvariant())
             {
+                case "RR1":
                 case "R1": return (4.0, 1.0, 2.0);
+                case "RR2":
                 case "R2": return (3.5, 0.75, 1.5);
+                case "RR3":
                 case "R3": return (3.0, 0.5, 1.0);
                 default: return (0, 0, 0);
             }

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Display.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Display.cs
@@ -261,7 +261,7 @@ namespace RCDragManagerProd.UI.Forms
                 }
 
                 var ordered = rows
-                    .OrderBy(w => GetGlobalRoundOrder(w.RoundLabel ?? string.Empty))
+                    .OrderBy(w => RoundLabels.Normalize(w.RoundLabel ?? string.Empty), Comparer<string>.Create(RoundLabels.Compare))
                     .ThenBy(w => w.MatchId)
                     .ToList();
 

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.UI.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.UI.cs
@@ -42,59 +42,13 @@ namespace RCDragManagerProd.UI.Forms
 
         private int GetGlobalRoundOrder(string roundLabel)
         {
-            if (string.IsNullOrWhiteSpace(roundLabel)) return 999;
-            if (string.Equals(roundLabel, "F", StringComparison.OrdinalIgnoreCase)) return 1000;
-            if (string.Equals(roundLabel, "SF", StringComparison.OrdinalIgnoreCase)) return 990;
-
-            if (roundLabel.StartsWith("Losers Bracket", StringComparison.OrdinalIgnoreCase))
-            {
-                var label = roundLabel.Trim();
-                if (label.EndsWith("Final", StringComparison.OrdinalIgnoreCase))
-                    return 299;
-
-                string[] parts = label.Split(' ');
-                if (parts.Length >= 3)
-                {
-                    string last = parts[parts.Length - 1];
-                    if (last.Length >= 2 && (last[0] == 'R' || last[0] == 'r') &&
-                        int.TryParse(last.Substring(1), out int n))
-                    {
-                        return 200 + n;
-                    }
-                }
-
-                Logger.Log($"[UI:Winners] LB round label not recognized: '{roundLabel}' — defaulting to 290");
-                return 290;
-            }
-
-            if (roundLabel.Length >= 2 && (roundLabel[0] == 'R' || roundLabel[0] == 'r') &&
-                int.TryParse(roundLabel.Substring(1), out int n1))
-            {
-                return 100 + n1;
-            }
-
-            if (roundLabel.StartsWith("Semi", StringComparison.OrdinalIgnoreCase)) return 990;
-            if (roundLabel.StartsWith("Final", StringComparison.OrdinalIgnoreCase)) return 1000;
-
-            Logger.Log($"[UI:Winners] Unrecognized round label for ordering: '{roundLabel}' — defaulting to 800");
-            return 800;
+            return RoundLabels.Compare(roundLabel, "R1");
         }
 
 
         private string GetFullRoundLabel(string label)
         {
-            return label switch
-            {
-                "R1" => "Round 1",
-                "R2" => "Round 2",
-                "R3" => "Round 3",
-                "R4" => "Round 4",
-                "QF" => "Quarterfinals",
-                "SF" => "Semi-Finals",
-                "F" => "Final",
-                "LBF" => "Losers Bracket Final",
-                _ => label
-            };
+            return RoundLabels.Normalize(label);
         }
 
         private static bool IsByeName(string name)


### PR DESCRIPTION
## Summary
Standardizes new-session round labels via a centralized helper and applies canonical normalization + stable ordering across engine emitters and UI/scorecard display paths.

## Testing Checklist
- ProLadder: check round headers show R1/R2/SF/F in correct order.
- Random + Losers: check LB rounds show LB-R1...LB-F and appear after winners rounds where expected.
- Round Robin: RR rounds sort numerically (RR2 after RR1, RR10 after RR9).
- Ensure no crashes and existing sessions still load (even if labels remain old).