### PR TITLE
Stage 2 - PR2: Standardize BYE policy and disable BYE winner selection

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.Results.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Results.cs
@@ -37,11 +37,13 @@ namespace RCDragManagerProd.Controllers
             var loser = firstOption ? match.Driver2 : match.Driver1;
 
             // Universal block — no BYE as winner
-            if (winner == null || string.Equals(winner.Name?.Trim(), "BYE", StringComparison.OrdinalIgnoreCase))
+            if (ByePolicy.IsBye(winner) || string.Equals(winner?.Name?.Trim(), "BYE", StringComparison.OrdinalIgnoreCase))
             {
                 Logger.Log($"[WINNER] Reject — cannot select BYE as winner for M{matchId}.");
                 return;
             }
+            if (ByePolicy.IsBye(loser))
+                Logger.Log($"[WINNER][BYE] Auto-advance M{matchId} -> {winner.Name}");
 
             Logger.Log($"[WINNER] M{matchId} {match.RoundLabel}: {winner.Name} over {(loser?.Name ?? "BYE")}");
 
@@ -129,7 +131,7 @@ namespace RCDragManagerProd.Controllers
             var newWinner = firstOption ? match.Driver1 : match.Driver2;
             var newLoser = firstOption ? match.Driver2 : match.Driver1;
 
-            if (newWinner == null || string.Equals(newWinner.Name?.Trim(), "BYE", StringComparison.OrdinalIgnoreCase))
+            if (ByePolicy.IsBye(newWinner) || string.Equals(newWinner?.Name?.Trim(), "BYE", StringComparison.OrdinalIgnoreCase))
             {
                 Logger.Log($"[CTRL][EDIT] Reject edit — cannot set BYE as winner (M{matchId}).");
                 return false;

--- a/src/RCDragManagerProd/Domain/ByePolicy.cs
+++ b/src/RCDragManagerProd/Domain/ByePolicy.cs
@@ -1,0 +1,7 @@
+namespace RCDragManagerProd.Domain
+{
+    public static class ByePolicy
+    {
+        public static bool IsBye(Driver d) => d == null;
+    }
+}

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Domain\Ladders\ProLadder.Ladders.L22.cs" />
     <Compile Include="Domain\Ladders\ProLadder.Ladders.L23.cs" />
     <Compile Include="Domain\Ladders\ProLadder.Ladders.L24.cs" />
+    <Compile Include="Domain\ByePolicy.cs" />
     <Compile Include="Domain\ProLadder.Ladders.Common.cs" />
     <Compile Include="Domain\ProLadder.Structures.cs" />
     <Compile Include="Helpers\AssetPath.cs" />

--- a/src/RCDragManagerProd/RaceEngines/MatchEngine.cs
+++ b/src/RCDragManagerProd/RaceEngines/MatchEngine.cs
@@ -75,7 +75,7 @@ public (Driver, Driver) ResolveDriversForMatch(ProLadder.LadderMatch match)
 {
     var d1 = ResolveDriver(match.Seed1, match.FromMatch1);
     var d2 = ResolveDriver(match.Seed2, match.FromMatch2);
-    return (d1 ?? new Driver { Name = "BYE" }, d2 ?? new Driver { Name = "BYE" });
+    return (d1, d2);
 }
 
         

--- a/src/RCDragManagerProd/RaceEngines/ProLadderEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/ProLadderEngineAdapter.cs
@@ -84,20 +84,18 @@ namespace RCDragManagerProd.RaceEngines
         }
 
         private static bool IsBye(Driver d) =>
-            d == null || string.Equals(d.Name?.Trim(), "BYE", StringComparison.OrdinalIgnoreCase);
+            ByePolicy.IsBye(d);
 
         private EngineMatch MapToDto(ProLadder.LadderMatch src)
         {
             // Let the MatchEngine resolve seeds/upstream winners; then normalize BYEs
             var (rd1, rd2) = _engine.ResolveDriversForMatch(src);
-            var d1 = rd1 ?? new Driver { Name = "BYE" };
-            var d2 = rd2 ?? new Driver { Name = "BYE" };
 
             return new EngineMatch
             {
                 MatchId = src.MatchId,
-                Driver1 = d1,
-                Driver2 = d2,
+                Driver1 = rd1,
+                Driver2 = rd2,
                 RoundLabel = src.RoundLabel,
                 FromMatch1 = src.FromMatch1,
                 FromMatch2 = src.FromMatch2,

--- a/src/RCDragManagerProd/RaceEngines/RandomEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/RandomEngineAdapter.cs
@@ -287,8 +287,7 @@ namespace RCDragManagerProd.RaceEngines
 
         private static bool IsBye(Driver d)
         {
-            var name = d?.Name ?? "";
-            return string.Equals(name.Trim(), "BYE", StringComparison.OrdinalIgnoreCase);
+            return ByePolicy.IsBye(d);
         }
     }
 }

--- a/src/RCDragManagerProd/RaceEngines/RoundRobinEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/RoundRobinEngineAdapter.cs
@@ -103,6 +103,6 @@ namespace RCDragManagerProd.RaceEngines
         }
 
         private static bool IsBye(Driver d) =>
-            d == null || string.Equals(d.Name?.Trim(), "BYE", System.StringComparison.OrdinalIgnoreCase);
+            ByePolicy.IsBye(d);
     }
 }

--- a/src/RCDragManagerProd/RandomMode/RandomMatchEngine.cs
+++ b/src/RCDragManagerProd/RandomMode/RandomMatchEngine.cs
@@ -90,10 +90,6 @@ namespace RCDragManagerProd.RandomMode
             Driver d1 = match.Seed1 ?? ResolveFrom(match.FromMatch1);
             Driver d2 = match.Seed2 ?? ResolveFrom(match.FromMatch2);
 
-            // ✅ Inject BYE placeholder
-            if (d1 != null && d2 == null) return (d1, new Driver { Name = "BYE" });
-            if (d2 != null && d1 == null) return (new Driver { Name = "BYE" }, d2);
-
             // Up-stream matches unresolved
             return (d1, d2);
         }

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
@@ -207,9 +207,6 @@ namespace RCDragManagerProd.RoundRobinMode
             var d1 = drivers.FirstOrDefault(d => d.Seed == match.Seed1);
             var d2 = drivers.FirstOrDefault(d => d.Seed == match.Seed2);
 
-            if (d1 != null && d2 == null) d2 = new Driver { Name = "BYE" };
-            if (d2 != null && d1 == null) d1 = new Driver { Name = "BYE" };
-
             return (d1, d2);
         }
 

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Display.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Display.cs
@@ -64,8 +64,8 @@ namespace RCDragManagerProd.UI.Forms
                         continue;
                     }
 
-                    bool bye1 = string.IsNullOrWhiteSpace(row.Driver1);
-                    bool bye2 = string.IsNullOrWhiteSpace(row.Driver2);
+                    bool bye1 = string.IsNullOrWhiteSpace(row.Driver1) || IsByeName(row.Driver1);
+                    bool bye2 = string.IsNullOrWhiteSpace(row.Driver2) || IsByeName(row.Driver2);
 
                     string d1 = bye1 ? "BYE" : row.Driver1;
                     string d2 = bye2 ? "BYE" : row.Driver2;
@@ -173,6 +173,8 @@ namespace RCDragManagerProd.UI.Forms
 
                 ApplyByeButtonStyle(btnWinner1, leftIsBye);
                 ApplyByeButtonStyle(btnWinner2, rightIsBye);
+                if (leftIsBye) Logger.Log("[UI][BYE] Disabled winner button: matchId=" + row.MatchId + " side=Left");
+                if (rightIsBye) Logger.Log("[UI][BYE] Disabled winner button: matchId=" + row.MatchId + " side=Right");
 
                 Logger.Log("[UI][NEXT] Buttons: leftIsBye=" + leftIsBye + " rightIsBye=" + rightIsBye +
                            " leftEnabled=" + btnWinner1.Enabled + " rightEnabled=" + btnWinner2.Enabled);

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.WinnerButtons.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.WinnerButtons.cs
@@ -64,8 +64,8 @@ namespace RCDragManagerProd.UI.Forms
             bool d1IsBye;
             bool d2IsBye;
 
-            d1IsBye = (match.Driver1 == null) || IsByeName(match.Driver1.Name);
-            d2IsBye = (match.Driver2 == null) || IsByeName(match.Driver2.Name);
+            d1IsBye = ByePolicy.IsBye(match.Driver1);
+            d2IsBye = ByePolicy.IsBye(match.Driver2);
 
             Logger.Log("[UI][WINNER] Engine snapshot: M" + matchId + " (" + round + ") " +
                        "D1=" + (match.Driver1 != null ? match.Driver1.Name : "NULL") + " bye=" + d1IsBye + " | " +


### PR DESCRIPTION
## Summary
Standardizes BYE handling for new sessions so BYE is represented as null in engine/controller/model paths and rendered as "BYE" in UI only. Winner buttons now explicitly log when BYE side is disabled, and BYE advancement is logged on winner submission.

## Checklist
- BYE button disabled/greyed
- Non-BYE side advances
- 2-driver match works