### PR TITLE
Stage 2 - PR3: Enforce canonical round ordering everywhere

### DIFF
--- a/src/RCDragManagerProd/Domain/RoundLabels.cs
+++ b/src/RCDragManagerProd/Domain/RoundLabels.cs
@@ -79,11 +79,16 @@ namespace RCDragManagerProd.Domain
             var na = Normalize(a);
             var nb = Normalize(b);
 
-            int ka = SortKey(na);
-            int kb = SortKey(nb);
+            int ka = CompareKey(na);
+            int kb = CompareKey(nb);
             if (ka != kb) return ka.CompareTo(kb);
 
             return string.Compare(na, nb, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static int CompareKey(string label)
+        {
+            return SortKey(Normalize(label));
         }
 
         public static bool TryParse(string label, out (bool IsLosers, int? RoundNumber, bool IsSemiFinal, bool IsFinal) parsed)

--- a/src/RCDragManagerProd/RaceEngines/RandomEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/RandomEngineAdapter.cs
@@ -77,7 +77,7 @@ namespace RCDragManagerProd.RaceEngines
             _engine.GetRoundOrder()
                    .Select(RoundLabels.Normalize)
                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                   .OrderBy(x => x, Comparer<string>.Create(RoundLabels.Compare))
+                   .OrderBy(x => RoundLabels.CompareKey(x))
                    .ToList();
 
         public void SetWinner(int matchId, Driver winner)

--- a/src/RCDragManagerProd/RandomMode/RandomMatchEngine.cs
+++ b/src/RCDragManagerProd/RandomMode/RandomMatchEngine.cs
@@ -201,7 +201,7 @@ namespace RCDragManagerProd.RandomMode
         {
             return bracketMatches.Select(m => RoundLabels.Normalize(m.RoundLabel))
                                 .Distinct(StringComparer.OrdinalIgnoreCase)
-                                .OrderBy(x => x, Comparer<string>.Create(RoundLabels.Compare))
+                                .OrderBy(x => RoundLabels.CompareKey(x))
                                 .ToList();
         }
 

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
@@ -244,7 +244,7 @@ namespace RCDragManagerProd.RoundRobinMode
         {
             return matches.Select(m => m.RoundLabel)
                           .Distinct()
-                          .OrderBy(x => x, Comparer<string>.Create(RoundLabels.Compare))
+                          .OrderBy(x => RoundLabels.CompareKey(x))
                           .ToList();
         }
 

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinScorecardLogger/RoundRobinScorecardFormatter.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinScorecardLogger/RoundRobinScorecardFormatter.cs
@@ -173,7 +173,7 @@ namespace RCDragManagerProd.RoundRobinMode
 
                 if (lines.TryGetValue(d.Id, out var lnz))
                 {
-                    foreach (var ln in lnz.OrderBy(x => RoundLabels.Normalize(x.RoundLabel), Comparer<string>.Create(RoundLabels.Compare)))
+                    foreach (var ln in lnz.OrderBy(x => RoundLabels.CompareKey(x.RoundLabel)))
                         sb.AppendLine($"   {ln.RoundLabel}: {ln.Outcome}(+{ln.Points:0.00}) vs {ln.Opponent}");
                 }
 

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinScorecardLogger/RoundRobinScorecardLogger.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinScorecardLogger/RoundRobinScorecardLogger.cs
@@ -48,7 +48,7 @@ namespace RCDragManagerProd.RoundRobinMode
             var idToName = drivers.ToDictionary(d => d.Id, d => d.Name);
             var rounds = matches.Select(m => RoundLabels.Normalize(m.RoundLabel))
                                .Distinct(StringComparer.OrdinalIgnoreCase)
-                               .OrderBy(x => x, Comparer<string>.Create(RoundLabels.Compare))
+                               .OrderBy(x => RoundLabels.CompareKey(x))
                                .ToList();
 
             // Points schedule
@@ -182,7 +182,7 @@ namespace RCDragManagerProd.RoundRobinMode
 
                 if (lines.TryGetValue(d.Id, out var lns))
                 {
-                    foreach (var ln in lns.OrderBy(x => RoundLabels.Normalize(x.RoundLabel), Comparer<string>.Create(RoundLabels.Compare)))
+                    foreach (var ln in lns.OrderBy(x => RoundLabels.CompareKey(x.RoundLabel)))
                         Logger.Log($"      {ln.RoundLabel}: {ln.Outcome}(+{ln.Points:0.00}) vs {ln.Opponent}");
                 }
                 Logger.Log($"      Defeated: {defNames}");

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Display.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Display.cs
@@ -261,9 +261,10 @@ namespace RCDragManagerProd.UI.Forms
                 }
 
                 var ordered = rows
-                    .OrderBy(w => RoundLabels.Normalize(w.RoundLabel ?? string.Empty), Comparer<string>.Create(RoundLabels.Compare))
+                    .OrderBy(w => RoundLabels.CompareKey(w.RoundLabel ?? string.Empty))
                     .ThenBy(w => w.MatchId)
                     .ToList();
+                Logger.Log("[RoundOrdering] Applied canonical ordering");
 
                 string currentHeader = null;
                 int displayNo = 1;


### PR DESCRIPTION
## Summary
Enforces canonical round ordering by using RoundLabels.CompareKey in all remaining round label sort paths and applies canonical ordering log marker.

## Notes
- Keeps ProLadder ladder definitions unchanged.
- No persistence schema changes.
- Adds log: [RoundOrdering] Applied canonical ordering.