### PR TITLE
Chore: Fix build warnings

### DIFF
--- a/src/RCDragManagerProd/RaceEngines/MatchEngine.cs
+++ b/src/RCDragManagerProd/RaceEngines/MatchEngine.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using RCDragManagerProd.Domain;
 using RCDragManagerProd.ViewModels;    // only if returning VM rows
 using RCDragManagerProd.Logging;

--- a/src/RCDragManagerProd/RandomMode/LosersBracketEngine.cs
+++ b/src/RCDragManagerProd/RandomMode/LosersBracketEngine.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -87,3 +88,5 @@ namespace RCDragManagerProd.RandomMode
         }
     }
 }
+#nullable disable
+

--- a/src/RCDragManagerProd/UI/Forms/Results/BuybackDriverSelectionForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Results/BuybackDriverSelectionForm.Designer.cs
@@ -2,7 +2,9 @@
 {
     partial class BuybackDriverSelectionForm
     {
+#pragma warning disable CS0169
         private System.ComponentModel.IContainer components;
+#pragma warning restore CS0169
         private System.Windows.Forms.CheckedListBox checkedListBoxDrivers;
         private System.Windows.Forms.Button btnConfirm;
         private System.Windows.Forms.Button btnNoBuyback;

--- a/src/RCDragManagerProd/UI/Forms/Session/SessionSetupForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/SessionSetupForm.Designer.cs
@@ -32,7 +32,9 @@ namespace RCDragManagerProd.UI.Forms
 
         private GroupBox grpDriverSelection;
         private Button btnAddNewDriver;
+#pragma warning disable CS0169
         private Button btnAddDriverFromList;
+#pragma warning restore CS0169
         private ListView lvEventRoster;
 
         private Button btnStartRace;


### PR DESCRIPTION
## Summary
- Removed duplicate `using` directives in `RaceEngines/MatchEngine.cs` (CS0105).
- Enabled nullable context in `RandomMode/LosersBracketEngine.cs` to legitimize existing nullable annotations (CS8632) without logic changes.
- Added narrow `#pragma warning disable/restore CS0169` around unused designer-only fields in:
  - `UI/Forms/Results/BuybackDriverSelectionForm.Designer.cs`
  - `UI/Forms/Session/SessionSetupForm.Designer.cs`

## Checklist
- [x] No behavior changes intended.
- [x] No bracket logic changes.
- [x] No UI behavior changes.
- [x] Build warnings reduced to zero.

## Build output
Command:
`MSBuild.exe .\\RCDragManagerProd.sln /t:Build /m`

Result:
- Build succeeded
- `0 Warning(s)`
- `0 Error(s)`