### PR TITLE
Stage3: Expand transactions + stat-only updates

### DIFF
--- a/src/RCDragManagerProd/Repositories/DriverRepository.cs
+++ b/src/RCDragManagerProd/Repositories/DriverRepository.cs
@@ -379,6 +379,18 @@ VALUES (@DriverId, @CarName, @ClassType, @DefaultDialIn);";
             ExecuteStatIncrement(driverId, "EventsWon", delta);
         }
 
+        public void IncrementWins(int driverId, int delta = 1)
+        {
+            Logger.Log($"[DB][DriverRepo][STATS] IncrementWins(driverId={driverId}, delta={delta})");
+            ExecuteStatIncrement(driverId, "TotalWins", delta);
+        }
+
+        public void IncrementLosses(int driverId, int delta = 1)
+        {
+            Logger.Log($"[DB][DriverRepo][STATS] IncrementLosses(driverId={driverId}, delta={delta})");
+            ExecuteStatIncrement(driverId, "TotalLosses", delta);
+        }
+
         public void IncrementWinsAndLosses(int winnerDriverId, int loserDriverId, int winDelta = 1, int lossDelta = 1)
         {
             Logger.Log($"[DB][DriverRepo][STATS] IncrementWinsAndLosses(winnerId={winnerDriverId}, loserId={loserDriverId}, winDelta={winDelta}, lossDelta={lossDelta})");

--- a/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
+++ b/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
@@ -79,7 +79,7 @@ SELECT last_insert_rowid();";
             {
                 using (var tx = cn.BeginTransaction())
                 {
-                    Logger.Log("[DB][SessionRepo][TX] SaveSession begin");
+                    Logger.Log("[TX] BEGIN SaveSession");
                     try
                     {
                         using (var cmd = new SQLiteCommand(sql, cn, tx))
@@ -94,12 +94,12 @@ SELECT last_insert_rowid();";
                         }
 
                         tx.Commit();
-                        Logger.Log("[DB][SessionRepo][TX] SaveSession commit");
+                        Logger.Log("[TX] COMMIT SaveSession");
                     }
                     catch (Exception ex)
                     {
                         try { tx.Rollback(); } catch { }
-                        Logger.Log($"[DB][SessionRepo][TX][ERROR] SaveSession rollback: {ex}");
+                        Logger.Log($"[TX] ROLLBACK SaveSession: {ex}");
                         throw;
                     }
                 }


### PR DESCRIPTION
## Summary
- `RaceSessionRepository.SaveSession(...)` is fully wrapped in one transaction with explicit log markers:
  - `[TX] BEGIN SaveSession`
  - `[TX] COMMIT SaveSession`
  - `[TX] ROLLBACK SaveSession: <ex>`
- `DriverRepository` now includes focused stat-only methods using single `UPDATE` statements:
  - `IncrementEventsEntered(driverId, delta = 1)`
  - `IncrementEventsWon(driverId, delta = 1)`
  - `IncrementWins(driverId, delta = 1)`
  - `IncrementLosses(driverId, delta = 1)`
- Checked repository-internal call paths: no internal repo sequences were found that load full drivers and call `UpdateDriver(...)` solely for counter bumps.

## Quick Checklist
- [ ] Start event, complete event, confirm counts move by exactly 1.
- [ ] Save/load session still works.
- [ ] Optional: force-close app during save and verify no DB corruption.

## Build Output
Command:
`MSBuild.exe .\\RCDragManagerProd.sln /t:Build /m`

Result:
- Build succeeded
- `0 Warning(s)`
- `0 Error(s)`