### PR TITLE
Stage 4 - PR1: Engine isolation via IRaceEngine

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.Persistence.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Persistence.cs
@@ -63,11 +63,13 @@ namespace RCDragManagerProd.Controllers
 
                 if (string.IsNullOrWhiteSpace(_session.RaceType) && _engine != null)
                 {
-                    _session.RaceType =
-                        _engine is ProLadderEngineAdapter ? "Finals" :
-                        _engine is RoundRobinEngineAdapter ? "Round Robin" :
-                        _engine is RandomEngineAdapter ? "Losers Bracket" :
-                        _engine.GetType().Name;
+                    var roundOrder = _engine.GetRoundOrder() ?? Array.Empty<string>();
+                    if (roundOrder.Any(r => RoundLabels.Normalize(r).StartsWith("RR", StringComparison.OrdinalIgnoreCase)))
+                        _session.RaceType = "Round Robin";
+                    else if (roundOrder.Any(r => RoundLabels.Normalize(r).StartsWith("LB-", StringComparison.OrdinalIgnoreCase)))
+                        _session.RaceType = "Losers Bracket";
+                    else
+                        _session.RaceType = "Finals";
                 }
 
                 if (_session.Drivers == null && _drivers != null)

--- a/src/RCDragManagerProd/Controllers/RaceController.Results.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Results.cs
@@ -20,8 +20,7 @@ namespace RCDragManagerProd.Controllers
         {
             EnsureReady();
 
-            var match = _engine.GetMatches().FirstOrDefault(m => m.MatchId == matchId);
-            if (match == null)
+            if (!_engine.TryGetMatch(matchId, out var match))
             {
                 Logger.Log($"[WINNER] Reject — match {matchId} not found.");
                 return;
@@ -47,7 +46,8 @@ namespace RCDragManagerProd.Controllers
 
             Logger.Log($"[WINNER] M{matchId} {match.RoundLabel}: {winner.Name} over {(loser?.Name ?? "BYE")}");
 
-            _engine.SetWinner(matchId, winner);
+            Logger.Log($"[ENGINE-CALL] {_engine.GetType().Name}.SubmitWinner(M{matchId}, winner={winner?.Name ?? "null"}, loser={loser?.Name ?? "BYE"})");
+            _engine.SubmitWinner(matchId, winner);
             _matchResult.SetWinner(matchId, winner, loser);
 
             _winners.Add(new WinnerRow
@@ -113,8 +113,7 @@ namespace RCDragManagerProd.Controllers
         {
             EnsureReady();
 
-            var match = _engine.GetMatches().FirstOrDefault(m => m.MatchId == matchId);
-            if (match == null)
+            if (!_engine.TryGetMatch(matchId, out var match))
             {
                 Logger.Log($"[CTRL][EDIT] M{matchId} not found.");
                 return false;
@@ -137,7 +136,8 @@ namespace RCDragManagerProd.Controllers
                 return false;
             }
 
-            _engine.SetWinner(matchId, newWinner);
+            Logger.Log($"[ENGINE-CALL] {_engine.GetType().Name}.SubmitWinner(M{matchId}, winner={newWinner?.Name ?? "null"}, loser={newLoser?.Name ?? "BYE"})");
+            _engine.SubmitWinner(matchId, newWinner);
             _matchResult.SetWinner(matchId, newWinner, newLoser);
             Logger.Log($"[CTRL][EDIT] SetWinner applied: M{matchId}, winner='{newWinner.Name}', loser='{newLoser?.Name ?? "BYE"}'");
 

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -392,7 +392,8 @@ namespace RCDragManagerProd.Controllers
             // ── Losers Bracket complete → gate Finals ─────────────────────
             if (_inLosersPhase && _losersEngine != null)
             {
-                bool isLbComplete = _losersEngine.GetMatches().All(m => _losersEngine.HasWinner(m.MatchId));
+                Logger.Log($"[ENGINE-CALL] {_losersEngine.GetType().Name}.IsComplete");
+                bool isLbComplete = _losersEngine.IsComplete;
                 Logger.Log($"[DEBUG] PushAdvanceState (LB): inLosersPhase={_inLosersPhase}, resolvedLB={isLbComplete}");
 
                 if (isLbComplete)
@@ -490,7 +491,8 @@ namespace RCDragManagerProd.Controllers
                 return null;
             }
 
-            var match = _engine.GetMatches().FirstOrDefault(m => m.MatchId == matchId);
+            Logger.Log($"[ENGINE-CALL] {_engine.GetType().Name}.TryGetMatch(matchId={matchId})");
+            _engine.TryGetMatch(matchId, out var match);
             Logger.Log(match != null
                 ? $"[LOOKUP] GetMatch({matchId}) → Round={match.RoundLabel}"
                 : $"[LOOKUP] GetMatch({matchId}) → NOT FOUND");

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.View.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.View.cs
@@ -110,14 +110,9 @@ namespace RCDragManagerProd.Controllers
             {
                 AppendFrom(_rrMatchesSnapshot, _rrRoundOrderSnapshot, "RR-snapshot", filterByRevealed: false);
             }
-            else if (_engine is RoundRobinEngineAdapter rrLive)
+            else if (_engine != null)
             {
-                AppendFrom(rrLive.GetMatches(), rrLive.GetRoundOrder(), "RR-live", filterByRevealed: true);
-            }
-            // 2) Randomized — show only revealed rounds
-            else if (_engine is RandomEngineAdapter rndLive)
-            {
-                AppendFrom(rndLive.GetMatches(), rndLive.GetRoundOrder(), "Random-live", filterByRevealed: true);
+                AppendFrom(_engine.GetMatches(), _engine.GetRoundOrder(), "Engine-live", filterByRevealed: true);
             }
 
             // 3) Losers Bracket — during Finals show all LB rounds; otherwise only revealed
@@ -127,12 +122,6 @@ namespace RCDragManagerProd.Controllers
                 filterLb = !string.Equals(_session?.RaceType, "Finals", StringComparison.OrdinalIgnoreCase);
 
                 AppendFrom(_losersEngine.GetMatches(), _losersEngine.GetRoundOrder(), "Losers", filterByRevealed: filterLb);
-            }
-
-            // 4) Finals (Pro Ladder) — only revealed (SF, then F)
-            if (_engine is ProLadderEngineAdapter pro)
-            {
-                AppendFrom(pro.GetMatches(), pro.GetRoundOrder(), "Finals(Pro)", filterByRevealed: true);
             }
 
             int displayNo = 1;

--- a/src/RCDragManagerProd/RaceEngines/IRaceEngine.cs
+++ b/src/RCDragManagerProd/RaceEngines/IRaceEngine.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using RCDragManagerProd.Domain;
 
 namespace RCDragManagerProd.RaceEngines
@@ -25,12 +26,40 @@ namespace RCDragManagerProd.RaceEngines
         /// <summary>Ordered list of round labels (e.g., R1, R2, …, SF, F).</summary>
         IReadOnlyList<string> GetRoundOrder();
 
+        /// <summary>Matches belonging to a single round label.</summary>
+        IReadOnlyList<EngineMatch> GetRoundMatches(string roundLabel);
+
+        /// <summary>Try get one match by id.</summary>
+        bool TryGetMatch(int matchId, out EngineMatch match);
+
         // ── results ───────────────────────────────────────────────────
         /// <summary>Record the winner for a given match.</summary>
+        void SubmitWinner(int matchId, Driver winner);
+
+        /// <summary>Legacy bridge for existing controller paths.</summary>
+        [Obsolete("Use SubmitWinner(matchId, winner)")]
         void SetWinner(int matchId, Driver winner);
 
         /// <summary>True if a winner has been recorded for the given match.</summary>
         bool HasWinner(int matchId);
+
+        /// <summary>Winner for the match, if resolved.</summary>
+        Driver GetWinner(int matchId);
+
+        /// <summary>Loser for the match, if resolved.</summary>
+        Driver GetLoser(int matchId);
+
+        /// <summary>True when engine has reached its terminal match state.</summary>
+        bool IsComplete { get; }
+
+        /// <summary>Champion, if complete/resolvable.</summary>
+        Driver GetChampion();
+
+        /// <summary>Runner-up, if complete/resolvable.</summary>
+        Driver GetRunnerUp();
+
+        /// <summary>Engine-consistent BYE check helper.</summary>
+        bool IsBye(Driver driver);
     }
 
     /// <summary>

--- a/src/RCDragManagerProd/RaceEngines/ProLadderEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/ProLadderEngineAdapter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using RCDragManagerProd.Domain;
+using RCDragManagerProd.Logging;
 
 namespace RCDragManagerProd.RaceEngines
 {
@@ -18,12 +19,14 @@ namespace RCDragManagerProd.RaceEngines
         // ────────────────  IRaceEngine  ────────────────
         public void LoadDrivers(List<Driver> drivers)
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.LoadDrivers(count={drivers?.Count ?? 0})");
             _drivers = drivers ?? throw new ArgumentNullException(nameof(drivers));
             _ready = false; // must call GenerateBracket afterwards
         }
 
         public void GenerateBracket()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GenerateBracket()");
             if (_drivers == null || _drivers.Count < 2)
                 throw new InvalidOperationException("LoadDrivers must be called with two or more drivers.");
 
@@ -34,6 +37,7 @@ namespace RCDragManagerProd.RaceEngines
         public IReadOnlyList<EngineMatch> GetMatches()
         {
             EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetMatches()");
 
             // Map engine matches to neutral DTO; skip BYE-vs-BYE
             return _engine.GetBracketMatches()
@@ -46,6 +50,7 @@ namespace RCDragManagerProd.RaceEngines
         public IReadOnlyList<string> GetRoundOrder()
         {
             EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRoundOrder()");
 
             // Distinct by label, ordered by bracket progression
             return _engine.GetBracketMatches()
@@ -55,23 +60,100 @@ namespace RCDragManagerProd.RaceEngines
                           .ToList();
         }
 
-        public void SetWinner(int matchId, Driver winner)
+        public void SubmitWinner(int matchId, Driver winner)
         {
             EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.SubmitWinner(matchId={matchId}, winnerId={winner?.Id}, winner='{winner?.Name ?? "null"}')");
             if (winner == null || IsBye(winner))
                 throw new InvalidOperationException("Cannot set BYE as a match winner.");
 
             _engine.SetWinner(matchId, winner);
         }
 
+        public void SetWinner(int matchId, Driver winner)
+        {
+            SubmitWinner(matchId, winner);
+        }
+
         public bool HasWinner(int matchId)
         {
             EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.HasWinner(matchId={matchId})");
             return _engine.Results.HasResult(matchId);
+        }
+
+        public Driver GetWinner(int matchId)
+        {
+            EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetWinner(matchId={matchId})");
+            return _engine.Results.GetWinner(matchId);
+        }
+
+        public Driver GetLoser(int matchId)
+        {
+            EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetLoser(matchId={matchId})");
+            return _engine.Results.GetLoser(matchId);
+        }
+
+        public bool IsComplete
+        {
+            get
+            {
+                EnsureReady();
+                Logger.Log($"[ENGINE-API] {GetType().Name}.IsComplete");
+                return _engine.IsTournamentComplete();
+            }
+        }
+
+        public Driver GetChampion()
+        {
+            EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetChampion()");
+            var final = GetMatches()
+                .FirstOrDefault(m => string.Equals(m.RoundLabel, "F", StringComparison.OrdinalIgnoreCase))
+                ?? GetMatches().OrderBy(m => m.MatchId).LastOrDefault();
+            return final == null ? null : _engine.Results.GetWinner(final.MatchId);
+        }
+
+        public Driver GetRunnerUp()
+        {
+            EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRunnerUp()");
+            var final = GetMatches()
+                .FirstOrDefault(m => string.Equals(m.RoundLabel, "F", StringComparison.OrdinalIgnoreCase))
+                ?? GetMatches().OrderBy(m => m.MatchId).LastOrDefault();
+            if (final == null) return null;
+
+            var winner = _engine.Results.GetWinner(final.MatchId);
+            if (winner == null) return null;
+            if (final.Driver1 != null && final.Driver1.Id == winner.Id) return final.Driver2;
+            if (final.Driver2 != null && final.Driver2.Id == winner.Id) return final.Driver1;
+            return null;
+        }
+
+        public IReadOnlyList<EngineMatch> GetRoundMatches(string roundLabel)
+        {
+            EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRoundMatches(roundLabel='{roundLabel}')");
+            var normalized = RoundLabels.Normalize(roundLabel);
+            return GetMatches()
+                .Where(m => string.Equals(RoundLabels.Normalize(m.RoundLabel), normalized, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(m => m.MatchId)
+                .ToList();
+        }
+
+        public bool TryGetMatch(int matchId, out EngineMatch match)
+        {
+            EnsureReady();
+            Logger.Log($"[ENGINE-API] {GetType().Name}.TryGetMatch(matchId={matchId})");
+            match = GetMatches().FirstOrDefault(m => m.MatchId == matchId);
+            return match != null;
         }
 
         public void Reset()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.Reset()");
             _engine = new MatchEngine(); // simplest way to clear internal state
             _drivers = null;
             _ready = false;
@@ -83,7 +165,7 @@ namespace RCDragManagerProd.RaceEngines
             if (!_ready) throw new InvalidOperationException("Bracket not generated — call GenerateBracket() first.");
         }
 
-        private static bool IsBye(Driver d) =>
+        public bool IsBye(Driver d) =>
             ByePolicy.IsBye(d);
 
         private EngineMatch MapToDto(ProLadder.LadderMatch src)

--- a/src/RCDragManagerProd/RaceEngines/RandomEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/RandomEngineAdapter.cs
@@ -30,6 +30,7 @@ namespace RCDragManagerProd.RaceEngines
         // ── IRaceEngine ───────────────────────────────────────────────
         public void LoadDrivers(List<Driver> drivers)
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.LoadDrivers(count={drivers?.Count ?? 0})");
             _byeCount.Clear();
             _lastByeRecipient = null;
 
@@ -39,6 +40,7 @@ namespace RCDragManagerProd.RaceEngines
 
         public void GenerateBracket()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GenerateBracket()");
             _engine.GenerateBracket();
             Logger.Log("[RND] GenerateBracket → underlying engine produced initial rounds.");
             RecomputeByeCountsFromSchedule();
@@ -46,6 +48,7 @@ namespace RCDragManagerProd.RaceEngines
 
         public void Reset()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.Reset()");
             _engine.Reset();
             _byeCount.Clear();
             _lastByeRecipient = null;
@@ -54,6 +57,7 @@ namespace RCDragManagerProd.RaceEngines
 
         public IReadOnlyList<EngineMatch> GetMatches()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetMatches()");
             // Project engine's match objects to the IRaceEngine surface model
             var src = _engine.GetMatches() ?? new List<RandomMatch>();
             var list = new List<EngineMatch>(src.Count);
@@ -73,21 +77,90 @@ namespace RCDragManagerProd.RaceEngines
             return list;
         }
 
-        public IReadOnlyList<string> GetRoundOrder() =>
-            _engine.GetRoundOrder()
-                   .Select(RoundLabels.Normalize)
-                   .Distinct(StringComparer.OrdinalIgnoreCase)
-                   .OrderBy(x => RoundLabels.CompareKey(x))
-                   .ToList();
-
-        public void SetWinner(int matchId, Driver winner)
+        public IReadOnlyList<string> GetRoundOrder()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRoundOrder()");
+            return _engine.GetRoundOrder()
+                          .Select(RoundLabels.Normalize)
+                          .Distinct(StringComparer.OrdinalIgnoreCase)
+                          .OrderBy(x => RoundLabels.CompareKey(x))
+                          .ToList();
+        }
+
+        public void SubmitWinner(int matchId, Driver winner)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.SubmitWinner(matchId={matchId}, winnerId={winner?.Id}, winner='{winner?.Name ?? "null"}')");
             if (winner == null || IsBye(winner))
                 throw new InvalidOperationException("Cannot set BYE as a match winner.");
             _engine.SetWinner(matchId, winner);
         }
 
-        public bool HasWinner(int matchId) => _engine.HasWinner(matchId);
+        public void SetWinner(int matchId, Driver winner) => SubmitWinner(matchId, winner);
+
+        public bool HasWinner(int matchId)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.HasWinner(matchId={matchId})");
+            return _engine.HasWinner(matchId);
+        }
+
+        public Driver GetWinner(int matchId)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetWinner(matchId={matchId})");
+            return _engine.GetWinner(matchId);
+        }
+
+        public Driver GetLoser(int matchId)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetLoser(matchId={matchId})");
+            return _engine.GetLoser(matchId);
+        }
+
+        public bool IsComplete
+        {
+            get
+            {
+                Logger.Log($"[ENGINE-API] {GetType().Name}.IsComplete");
+                return _engine.IsTournamentComplete();
+            }
+        }
+
+        public Driver GetChampion()
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetChampion()");
+            return GetWinner();
+        }
+
+        public Driver GetRunnerUp()
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRunnerUp()");
+            var all = (_engine.GetMatches() ?? new List<RandomMatch>()).ToList();
+            if (all.Count == 0) return null;
+
+            var final = all.FirstOrDefault(m =>
+                string.Equals(RoundLabels.Normalize(m.RoundLabel), "F", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(RoundLabels.Normalize(m.RoundLabel), "LB-F", StringComparison.OrdinalIgnoreCase))
+                ?? all.OrderBy(m => m.MatchId).LastOrDefault();
+
+            if (final == null || !_engine.HasWinner(final.MatchId)) return null;
+            return _engine.GetLoser(final.MatchId);
+        }
+
+        public IReadOnlyList<EngineMatch> GetRoundMatches(string roundLabel)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRoundMatches(roundLabel='{roundLabel}')");
+            var normalized = RoundLabels.Normalize(roundLabel);
+            return GetMatches()
+                .Where(m => string.Equals(RoundLabels.Normalize(m.RoundLabel), normalized, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(m => m.MatchId)
+                .ToList();
+        }
+
+        public bool TryGetMatch(int matchId, out EngineMatch match)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.TryGetMatch(matchId={matchId})");
+            match = GetMatches().FirstOrDefault(m => m.MatchId == matchId);
+            return match != null;
+        }
 
         // ── extras used by controller flow ────────────────────────────
         public void InjectMatches(List<RandomMatch> matches)
@@ -293,7 +366,7 @@ namespace RCDragManagerProd.RaceEngines
             return 1;
         }
 
-        private static bool IsBye(Driver d)
+        public bool IsBye(Driver d)
         {
             return ByePolicy.IsBye(d);
         }

--- a/src/RCDragManagerProd/RaceEngines/RoundRobinEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/RoundRobinEngineAdapter.cs
@@ -26,12 +26,14 @@ namespace RCDragManagerProd.RaceEngines
 
         public void LoadDrivers(List<Driver> drivers)
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.LoadDrivers(count={drivers?.Count ?? 0})");
             Logger.Log($"[RR-ADAPTER] Loading {drivers?.Count ?? 0} driver(s)...");
             _engine.LoadDrivers(drivers ?? new List<Driver>());
         }
 
         public void GenerateBracket()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GenerateBracket()");
             Logger.Log("[RR-ADAPTER] Generating matches (circle method, clamped to n-1)...");
 
             _engine.GenerateMatches();
@@ -40,12 +42,14 @@ namespace RCDragManagerProd.RaceEngines
 
         public void Reset()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.Reset()");
             _engine.Reset();
             Logger.Log("[RR-ADAPTER] Engine reset.");
         }
 
         public IReadOnlyList<EngineMatch> GetMatches()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetMatches()");
             var rows = _engine.GetMatches()
                               .Select(m => new EngineMatch
                               {
@@ -64,13 +68,15 @@ namespace RCDragManagerProd.RaceEngines
 
         public IReadOnlyList<string> GetRoundOrder()
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRoundOrder()");
             var rounds = _engine.GetRoundLabels();
             Logger.Log($"[RR-ADAPTER] Round order: {string.Join(", ", rounds)}");
             return rounds;
         }
 
-        public void SetWinner(int matchId, Driver winner)
+        public void SubmitWinner(int matchId, Driver winner)
         {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.SubmitWinner(matchId={matchId}, winnerId={winner?.Id}, winner='{winner?.Name ?? "null"}')");
             if (winner == null || IsBye(winner))
             {
                 Logger.Log($"[RR-ADAPTER] Reject SetWinner(M{matchId}) → BYE/Null.");
@@ -81,7 +87,65 @@ namespace RCDragManagerProd.RaceEngines
             Logger.Log($"[RR-ADAPTER] Winner set for M{matchId} → {winner.Name}");
         }
 
-        public bool HasWinner(int matchId) => _engine.HasWinner(matchId);
+        public void SetWinner(int matchId, Driver winner) => SubmitWinner(matchId, winner);
+
+        public bool HasWinner(int matchId)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.HasWinner(matchId={matchId})");
+            return _engine.HasWinner(matchId);
+        }
+
+        public Driver GetWinner(int matchId)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetWinner(matchId={matchId})");
+            return _engine.GetWinner(matchId);
+        }
+
+        public Driver GetLoser(int matchId)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetLoser(matchId={matchId})");
+            return _engine.GetLoser(matchId);
+        }
+
+        public bool IsComplete
+        {
+            get
+            {
+                Logger.Log($"[ENGINE-API] {GetType().Name}.IsComplete");
+                return _engine.IsTournamentComplete();
+            }
+        }
+
+        public Driver GetChampion()
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetChampion()");
+            var standings = _engine.GetStandings();
+            return standings.Count == 0 ? null : standings[0].Driver;
+        }
+
+        public Driver GetRunnerUp()
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRunnerUp()");
+            var standings = _engine.GetStandings();
+            return standings.Count < 2 ? null : standings[1].Driver;
+        }
+
+        public IReadOnlyList<EngineMatch> GetRoundMatches(string roundLabel)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.GetRoundMatches(roundLabel='{roundLabel}')");
+            var normalized = RoundLabels.Normalize(roundLabel);
+            return GetMatches()
+                .Where(m => string.Equals(RoundLabels.Normalize(m.RoundLabel), normalized, System.StringComparison.OrdinalIgnoreCase))
+                .OrderBy(m => m.MatchId)
+                .ToList();
+        }
+
+        public bool TryGetMatch(int matchId, out EngineMatch match)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.TryGetMatch(matchId={matchId})");
+            match = GetMatches().FirstOrDefault(m => m.MatchId == matchId);
+            return match != null;
+        }
 
         // convenience for controller
         public bool IsTournamentComplete() => _engine.IsTournamentComplete();
@@ -102,7 +166,7 @@ namespace RCDragManagerProd.RaceEngines
             return top;
         }
 
-        private static bool IsBye(Driver d) =>
+        public bool IsBye(Driver d) =>
             ByePolicy.IsBye(d);
     }
 }


### PR DESCRIPTION
## Summary
- Expanded `IRaceEngine` into the single controller-facing contract for engine operations:
  - `GetRoundMatches`, `TryGetMatch`, `SubmitWinner`, `GetWinner`, `GetLoser`, `IsComplete`, `GetChampion`, `GetRunnerUp`, `IsBye`.
- Updated all engine adapters (`ProLadderEngineAdapter`, `RandomEngineAdapter`, `RoundRobinEngineAdapter`) to implement the expanded interface without changing pairing/bracket logic.
- Routed controller winner/match operations through `IRaceEngine` methods (`SubmitWinner`, `TryGetMatch`, `IsComplete`) and reduced adapter-specific row rendering paths where possible.
- Added engine boundary logging on adapter calls and controller boundary calls (engine type + match/round metadata).

## Build
- Command: `MSBuild.exe .\\RCDragManagerProd.sln /t:Build /m`
- Result: Build succeeded (`0 Warning(s)`, `0 Error(s)`).

## Smoke checklist
- [ ] Start Pro Ladder once, pick a winner, verify no crash.
- [ ] Start Random Draw once, pick a winner, verify no crash.
- [ ] Start Round Robin once, pick a winner, verify no crash.

Note: interactive WinForms smoke steps were not automated in this headless CLI session.