### PR TITLE
Live broadcast toggle in Settings

### DIFF
--- a/src/RCDragManagerProd/Config/AppSettings.cs
+++ b/src/RCDragManagerProd/Config/AppSettings.cs
@@ -15,6 +15,7 @@ namespace RCDragManagerProd.Config
 #else
                 false;
 #endif
+            public bool LiveBroadcastEnabled { get; set; } = false;
         }
 
         private static readonly string AppFolder =
@@ -63,6 +64,12 @@ namespace RCDragManagerProd.Config
         {
             get => _model.EnableLogging;
             set { _model.EnableLogging = value; Save(); }
+        }
+
+        public static bool LiveBroadcastEnabled
+        {
+            get => _model.LiveBroadcastEnabled;
+            set { _model.LiveBroadcastEnabled = value; Save(); }
         }
 
         public static string LogFilePath

--- a/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
+using RCDragManagerProd.Config;
 using RCDragManagerProd.Integration;
 using RCDragManagerProd.Logging;
 using RCDragManagerProd.RaceEngines;
@@ -118,8 +118,7 @@ namespace RCDragManagerProd.Controllers
         {
             try
             {
-                var enabledText = ConfigurationManager.AppSettings["LiveUpdateEnabled"];
-                if (bool.TryParse(enabledText, out var enabled) && !enabled)
+                if (!AppSettings.LiveBroadcastEnabled)
                 {
                     Logger.Log("[LIVE][SKIP] reason=" + reason + " disabled=true");
                     return;

--- a/src/RCDragManagerProd/Integration/LiveApiClient.cs
+++ b/src/RCDragManagerProd/Integration/LiveApiClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;

--- a/src/RCDragManagerProd/Integration/LiveApiClient.cs
+++ b/src/RCDragManagerProd/Integration/LiveApiClient.cs
@@ -1,10 +1,10 @@
 using System;
-using System.Configuration;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using RCDragManagerProd.Config;
 using RCDragManagerProd.Logging;
 
 namespace RCDragManagerProd.Integration
@@ -29,9 +29,7 @@ namespace RCDragManagerProd.Integration
             await SendGate.WaitAsync().ConfigureAwait(false);
             try
             {
-                var enabledValue = ConfigurationManager.AppSettings["LiveUpdateEnabled"];
-                if (!string.IsNullOrWhiteSpace(enabledValue) &&
-                    enabledValue.Equals("false", StringComparison.OrdinalIgnoreCase))
+                if (!AppSettings.LiveBroadcastEnabled)
                 {
                     Logger.Log("[LIVE][FAIL] Live updates disabled by config.");
                     return;

--- a/src/RCDragManagerProd/UI/Forms/Common/SettingsForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Common/SettingsForm.cs
@@ -57,7 +57,7 @@ namespace RCDragManagerProd.UI.Forms
             {
                 Left = 12,
                 Top = 78,
-                Width = 400,
+                Width = 300,
                 Text = "Enable Live Broadcast to stewmacrc.com",
                 Checked = AppSettings.LiveBroadcastEnabled
             };
@@ -66,8 +66,8 @@ namespace RCDragManagerProd.UI.Forms
             {
                 Name = "btnOpenLiveView",
                 Text = "Open Live View",
-                Left = 230,
-                Top = 78,
+                Left = 12,
+                Top = 106,
                 Width = 200
             };
 

--- a/src/RCDragManagerProd/UI/Forms/Common/SettingsForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Common/SettingsForm.cs
@@ -11,8 +11,8 @@ namespace RCDragManagerProd.UI.Forms
         private const string ProductionLiveViewUrl = "https://stewmacrc.com";
 
         private readonly CheckBox _chkLogging;
+        private readonly CheckBox _chkLiveBroadcast;
         private readonly TextBox _txtPath;
-        private readonly Button _btnStartLocalLiveServer;
         private readonly Button _btnOpenLiveView;
         private readonly Button _btnOk;
         private readonly Button _btnCancel;
@@ -53,14 +53,13 @@ namespace RCDragManagerProd.UI.Forms
                 Text = AppSettings.LogFilePath
             };
 
-            _btnStartLocalLiveServer = new Button
+            _chkLiveBroadcast = new CheckBox
             {
-                Name = "btnStartLocalLiveServer",
-                Text = "Test Local Server (DEV ONLY)",
                 Left = 12,
                 Top = 78,
-                Width = 200,
-                Enabled = false
+                Width = 400,
+                Text = "Enable Live Broadcast to stewmacrc.com",
+                Checked = AppSettings.LiveBroadcastEnabled
             };
 
             _btnOpenLiveView = new Button
@@ -80,7 +79,7 @@ namespace RCDragManagerProd.UI.Forms
                 _chkLogging,
                 lblPath,
                 _txtPath,
-                _btnStartLocalLiveServer,
+                _chkLiveBroadcast,
                 _btnOpenLiveView,
                 _btnOk,
                 _btnCancel
@@ -88,24 +87,15 @@ namespace RCDragManagerProd.UI.Forms
 
             AcceptButton = _btnOk;
             CancelButton = _btnCancel;
-            _btnStartLocalLiveServer.Click += btnStartLocalLiveServer_Click;
             _btnOpenLiveView.Click += btnOpenLiveView_Click;
 
             _btnOk.Click += (_, __) =>
             {
                 AppSettings.EnableLogging = _chkLogging.Checked;
+                AppSettings.LiveBroadcastEnabled = _chkLiveBroadcast.Checked;
                 if (AppSettings.EnableLogging) Logger.Log("[SETTINGS] Logging enabled.");
                 Close();
             };
-        }
-
-        private void btnStartLocalLiveServer_Click(object sender, EventArgs e)
-        {
-            MessageBox.Show(this,
-                "Local server start is disabled in production builds.",
-                "DEV ONLY",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Information);
         }
 
         private void btnOpenLiveView_Click(object sender, EventArgs e)


### PR DESCRIPTION
Adds Enable Live Broadcast checkbox to SettingsForm. Moves LiveUpdateEnabled control from App.config to AppSettings.json, defaulting to false. Removes dead Start Local Server button.