### PR TITLE
fix: #164 — Show lane assignments (Left/Right) on live scoreboard

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
@@ -72,12 +72,18 @@ namespace RCDragManagerProd.Controllers
             }
 
             var matches = allMatches
-                .Select(m => new LiveMatchDto
+                .Select(m =>
                 {
-                    RoundLabel = m.RoundLabel,
-                    Driver1 = m.Driver1?.Name ?? "BYE",
-                    Driver2 = m.Driver2?.Name ?? "BYE",
-                    WinnerName = _matchResult.HasResult(m.MatchId) ? _matchResult.GetWinner(m.MatchId)?.Name : null
+                    GetLaneAdjustedNames(m, out var leftName, out var rightName);
+                    return new LiveMatchDto
+                    {
+                        RoundLabel = m.RoundLabel,
+                        Driver1 = m.Driver1?.Name ?? "BYE",
+                        Driver2 = m.Driver2?.Name ?? "BYE",
+                        LeftDriver = leftName,
+                        RightDriver = rightName,
+                        WinnerName = _matchResult.HasResult(m.MatchId) ? _matchResult.GetWinner(m.MatchId)?.Name : null
+                    };
                 })
                 .ToList();
 

--- a/src/RCDragManagerProd/Integration/LiveRaceUpdateDto.cs
+++ b/src/RCDragManagerProd/Integration/LiveRaceUpdateDto.cs
@@ -20,6 +20,8 @@ namespace RCDragManagerProd.Integration
         public string RoundLabel { get; set; }
         public string Driver1 { get; set; }
         public string Driver2 { get; set; }
+        public string LeftDriver { get; set; }
+        public string RightDriver { get; set; }
         public string WinnerName { get; set; }
     }
 


### PR DESCRIPTION
Closes #164