### PR TITLE
fix: #182 — pass eventId to dial-in poll endpoint

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.DialIn.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.DialIn.cs
@@ -71,7 +71,7 @@ namespace RCDragManagerProd.Controllers
         {
             try
             {
-                var updates = await _liveApiClient.GetDialInUpdatesAsync().ConfigureAwait(false);
+                var updates = await _liveApiClient.GetDialInUpdatesAsync(_session?.EventId.ToString() ?? string.Empty).ConfigureAwait(false);
                 if (updates == null || updates.Count == 0) return;
 
                 bool changed = false;

--- a/src/RCDragManagerProd/Integration/LiveApiClient.cs
+++ b/src/RCDragManagerProd/Integration/LiveApiClient.cs
@@ -87,14 +87,15 @@ namespace RCDragManagerProd.Integration
             }
         }
 
-        public async Task<Dictionary<string, double?>> GetDialInUpdatesAsync()
+        public async Task<Dictionary<string, double?>> GetDialInUpdatesAsync(string eventId)
         {
             try
             {
                 var apiKey = ConfigurationManager.AppSettings["ApiKey"];
                 if (string.IsNullOrWhiteSpace(apiKey)) return null;
 
-                using (var req = new HttpRequestMessage(HttpMethod.Get, DialInPollUrl))
+                var url = DialInPollUrl + "?eventId=" + Uri.EscapeDataString(eventId ?? string.Empty);
+                using (var req = new HttpRequestMessage(HttpMethod.Get, url))
                 {
                     req.Headers.Add("X-API-KEY", apiKey);
                     using (var resp = await Http.SendAsync(req).ConfigureAwait(false))


### PR DESCRIPTION
Closes #182