### PR TITLE
fix: #180 — lane-swap recovered by string-compare in BuildLiveRaceUpdateDto

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
@@ -75,9 +75,7 @@ namespace RCDragManagerProd.Controllers
                 .Select(m =>
                 {
                     GetLaneAdjustedNames(m, out var leftName, out var rightName);
-                    bool swapped = leftName != (m.Driver1?.Name ?? "BYE");
-                    var leftDriver  = swapped ? m.Driver2 : m.Driver1;
-                    var rightDriver = swapped ? m.Driver1 : m.Driver2;
+                    GetLaneAdjustedDrivers(m, out var leftDriver, out var rightDriver);
                     return new LiveMatchDto
                     {
                         RoundLabel = m.RoundLabel,

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.View.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.View.cs
@@ -46,6 +46,26 @@ namespace RCDragManagerProd.Controllers
             }
         }
 
+        internal void GetLaneAdjustedDrivers(EngineMatch m, out Driver leftDriver, out Driver rightDriver)
+        {
+            leftDriver = m.Driver1;
+            rightDriver = m.Driver2;
+
+            if (m.Driver1 == null || m.Driver2 == null) return;
+
+            int a = Math.Min(m.Driver1.Id, m.Driver2.Id);
+            int b = Math.Max(m.Driver1.Id, m.Driver2.Id);
+            string laneKey = m.RoundLabel + "|M" + m.MatchId + "|" + a + "-" + b;
+
+            bool swap = laneFairness.ShouldSwap(laneKey, m.Driver1.Id, m.Driver2.Id);
+
+            if (swap)
+            {
+                leftDriver = m.Driver2;
+                rightDriver = m.Driver1;
+            }
+        }
+
         private string BuildMatchDisplayText(EngineMatch m)
         {
             string l;


### PR DESCRIPTION
Closes #180