### PR TITLE
fix: #222 — ENH-09c class type selector + dial-in override gating

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
@@ -175,10 +175,15 @@ namespace RCDragManagerProd.UI.Forms
             if (existing != null)
             {
                 _checkedDriverIds.Clear();
+                // Only treat saved DialIn values as per-driver overrides when the existing
+                // class was Dial-In. For Heads Up the DialIn is null; for Bracket Class it
+                // is the FixedDialIn applied to every driver — neither is a true override.
+                bool wasDialInClass = string.Equals(
+                    existing.ClassType, "Dial-In", StringComparison.OrdinalIgnoreCase);
                 foreach (var entry in existing.DriverEntries ?? new List<RaceSessionDriverEntry>())
                 {
                     _checkedDriverIds.Add(entry.DriverID);
-                    if (entry.DialIn.HasValue)
+                    if (wasDialInClass && entry.DialIn.HasValue)
                         _dialInOverrides[entry.DriverID] = entry.DialIn;
                 }
             }


### PR DESCRIPTION
Closes #222

## Summary
ENH-09c (class type selector, FixedDialIn show/hide, per-class config storage, FixedDialIn passthrough to RaceSession) was substantively delivered as part of PR #224 (which closed parent ENH-09 / #217). This PR addresses the one remaining correctness gap related to the same area.

## What changed
`MultiClassConfigDialog.PopulateDriverList` now only treats per-driver `DialIn` values from saved entries as overrides when the existing class was Dial-In. For Heads Up the values are null and for Bracket Class they all equal the FixedDialIn — neither is a true per-driver override.

## Why
Previously, opening an existing Bracket class for edit would silently load every driver's FixedDialIn-derived `DialIn` into `_dialInOverrides`. The Override column showed these as if they were overrides, and switching the class type to Dial-In would carry stale values forward instead of falling back to each driver's car default.

## Test plan
- [x] Build with msbuild — passes
- [x] Test suite — pre-existing flaky failures only (`ActiveRound_IsNullAfterReset_WhenBracketWasStarted` fails on plain main as well)
- [x] Verified UI flow mentally: edit Bracket → switch to Dial-In → drivers fall back to car defaults instead of inheriting stale FixedDialIn