### PR TITLE
fix: #223 — ENH-09d: Add QMDRA and RoundsToRun config to MultiClassConfigDialog

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using RCDragManagerProd.Domain;
+using RCDragManagerProd.Logging;
 using RCDragManagerProd.Repositories;
 
 namespace RCDragManagerProd.UI.Forms
@@ -429,8 +430,29 @@ namespace RCDragManagerProd.UI.Forms
                 FixedDialIn = null;
 
             bool isRR = string.Equals(RaceType, RaceTypes.RoundRobin, StringComparison.OrdinalIgnoreCase);
-            Variant     = isRR ? (rbQmdra.Checked ? "QMDRA" : "Standard") : null;
-            RoundsToRun = isRR && rbQmdra.Checked ? (int?)Convert.ToInt32(nudRoundsToRun.Value) : null;
+            Variant = isRR ? (rbQmdra.Checked ? "QMDRA" : "Standard") : null;
+
+            if (isRR && rbQmdra.Checked)
+            {
+                int n = (int)nudRoundsToRun.Value;
+                if (n <= 0)
+                {
+                    MessageBox.Show("Rounds To Run (N) is required for QMDRA and must be >= 1.",
+                        "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    Logger.Log("[MULTICLASS][CFG][RR] BLOCKED OK → QMDRA missing/invalid N.");
+                    return;
+                }
+                RoundsToRun = n;
+            }
+            else
+            {
+                RoundsToRun = null;
+            }
+
+            if (isRR)
+            {
+                Logger.Log($"[MULTICLASS][CFG][RR] '{className}' → Variant='{Variant}', RoundsToRun={(RoundsToRun.HasValue ? RoundsToRun.Value.ToString() : "null")}");
+            }
 
             BuiltDriverEntries = new List<RaceSessionDriverEntry>();
             foreach (var driverId in _checkedDriverIds)

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassSetupForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassSetupForm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
 using RCDragManagerProd.Domain;
+using RCDragManagerProd.Logging;
 using RCDragManagerProd.Repositories;
 
 namespace RCDragManagerProd.UI.Forms
@@ -189,6 +190,11 @@ namespace RCDragManagerProd.UI.Forms
                     DriverEntries      = cc.DriverEntries
                 };
                 MultiClassEventResult.ClassSessions.Add(session);
+
+                if (isRR)
+                {
+                    Logger.Log($"[MULTICLASS][START][RR] Class '{cc.ClassName}' → Variant='{session.RoundRobinVariant}', RoundsToRun={(session.RoundsToRun.HasValue ? session.RoundsToRun.Value.ToString() : "null")}");
+                }
             }
 
             DialogResult = DialogResult.OK;


### PR DESCRIPTION
Closes #223

The QMDRA and RoundsToRun controls in MultiClassConfigDialog were already wired up by ENH-09a (issue #217). This PR completes the SessionSetupForm parity work called out in ENH-09d:

- MultiClassConfigDialog.BtnOk_Click now validates that RoundsToRun >= 1 when QMDRA is selected, mirroring SessionSetupForm.BtnStartRace_Click validation.
- Adds Logger.Log statements to MultiClassConfigDialog and MultiClassSetupForm so multi-class RR config decisions are traceable in the same way the single-class flow already is.

No changes to UI gating (already correct) or to the per-class RaceSession build (already passes RoundRobinVariant + RoundsToRun through to the hosted Form1).