### PR TITLE
fix: shift landing page buttons up after Quick Session removal

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Session/LandingPageForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/LandingPageForm.Designer.cs
@@ -52,35 +52,35 @@ namespace RCDragManagerProd.UI.Forms
             this.Controls.Add(this.lblEventTitle);
 
             // btnCreateRaceSession
-            this.btnCreateRaceSession.Location = new System.Drawing.Point(40, 150);
+            this.btnCreateRaceSession.Location = new System.Drawing.Point(40, 100);
             this.btnCreateRaceSession.Size = new System.Drawing.Size(200, 50);
             this.btnCreateRaceSession.Text = "Create Race Session";
             this.btnCreateRaceSession.Click += new System.EventHandler(this.btnCreateRaceSession_Click);
             this.Controls.Add(this.btnCreateRaceSession);
 
             // btnLoadEvent
-            this.btnLoadEvent.Location = new System.Drawing.Point(40, 220);
+            this.btnLoadEvent.Location = new System.Drawing.Point(40, 170);
             this.btnLoadEvent.Size = new System.Drawing.Size(200, 50);
             this.btnLoadEvent.Text = "Load Saved Event";
             this.btnLoadEvent.Click += new System.EventHandler(this.btnLoadEvent_Click);
             this.Controls.Add(this.btnLoadEvent);
 
             // btnDriverLists
-            this.btnDriverLists.Location = new System.Drawing.Point(40, 290);
+            this.btnDriverLists.Location = new System.Drawing.Point(40, 240);
             this.btnDriverLists.Size = new System.Drawing.Size(200, 50);
             this.btnDriverLists.Text = "Driver Lists";
             this.btnDriverLists.Click += new System.EventHandler(this.btnDriverLists_Click);
             this.Controls.Add(this.btnDriverLists);
 
             // btnSettings
-            this.btnSettings.Location = new System.Drawing.Point(40, 360);
+            this.btnSettings.Location = new System.Drawing.Point(40, 310);
             this.btnSettings.Size = new System.Drawing.Size(200, 50);
             this.btnSettings.Text = "Settings";
             this.btnSettings.Click += new System.EventHandler(this.btnSettings_Click);
             this.Controls.Add(this.btnSettings);
 
             // btnExit
-            this.btnExit.Location = new System.Drawing.Point(40, 430);
+            this.btnExit.Location = new System.Drawing.Point(40, 380);
             this.btnExit.Size = new System.Drawing.Size(200, 50);
             this.btnExit.Text = "Exit";
             this.btnExit.Click += new System.EventHandler(this.btnExit_Click);
@@ -89,7 +89,7 @@ namespace RCDragManagerProd.UI.Forms
             // lblVersion
             this.lblVersion.Location = new System.Drawing.Point(20, 570);
             this.lblVersion.Size = new System.Drawing.Size(200, 20);
-            this.lblVersion.Text = "v1.00";
+            this.lblVersion.Text = "v1.2.0";
             this.Controls.Add(this.lblVersion);
 
             // logoBox


### PR DESCRIPTION
## Summary
After ENH-08 (#216) removed the Quick Session button, the remaining 5 landing-page buttons were left with a 50px gap at the top where Quick Session used to sit. This PR shifts them up by exactly one button height (50px) and refreshes the version label.

## Changes (LandingPageForm.Designer.cs only)

| Control | Before | After |
|---|---|---|
| btnCreateRaceSession | Y=150 | Y=100 |
| btnLoadEvent | Y=220 | Y=170 |
| btnDriverLists | Y=290 | Y=240 |
| btnSettings | Y=360 | Y=310 |
| btnExit | Y=430 | Y=380 |
| lblVersion.Text | "v1.00" | "v1.2.0" |

Each button is `200×50` so the shift equals exactly one button height; inter-button spacing (70px) unchanged.

## Test plan
- [ ] Build `RCDragManagerProd` (Debug) — confirmed clean locally
- [ ] Open the app and verify the landing page has no leading gap
- [ ] Verify the version label reads `v1.2.0`
- [ ] Click each button to confirm handlers still wire up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)