### PR TITLE
feat: simplified RR config — card selector + Buyback checkbox

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -125,7 +125,7 @@ namespace RCDragManagerProd.Controllers
                 {
                     Logger.Log("[EngineCall] " + _engine.GetType().Name + " SetRoundsToRun matchId=- round=-");
                     int naturalMax = Math.Max(1, _drivers.Count - 1);
-                    int standardRounds = Math.Min(3, naturalMax);
+                    int standardRounds = Math.Min(_session?.RoundsToRun ?? 3, naturalMax);
                     rrAdapter.SetRoundsToRun(standardRounds);
                     Logger.Log($"[ENGINE][RR] Standard RR ? SetRoundsToRun({standardRounds}) (drivers={_drivers.Count}, naturalMax={naturalMax})");
                 }

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
@@ -9,19 +9,20 @@ namespace RCDragManagerProd.UI.Forms
 
         private Label lblClassName;
         private TextBox txtClassName;
-        private Label lblRaceType;
-        private ComboBox cmbRaceType;
+        private Panel pnlCardProLadder;
+        private Panel pnlCardRandomDraw;
+        private Panel pnlCardRoundRobin;
+        private Panel pnlRrConfig;
+        private Label lblRrRounds;
+        private NumericUpDown nudRoundsToRun;
+        private CheckBox chkBuybackRace;
+        private Label lblBuybackHint;
         private GroupBox grpClassType;
         private RadioButton rbHeadsUp;
         private RadioButton rbBracket;
         private RadioButton rbDialIn;
         private Label lblFixedDialIn;
         private TextBox txtFixedDialIn;
-        private GroupBox grpVariant;
-        private RadioButton rbStandard;
-        private RadioButton rbQmdra;
-        private Label lblRoundsToRun;
-        private NumericUpDown nudRoundsToRun;
         private Button btnAddNewDriver;
         private Label lblDrivers;
         private ListView lvDrivers;
@@ -40,7 +41,7 @@ namespace RCDragManagerProd.UI.Forms
         private void InitializeComponent()
         {
             this.Text = "Class Configuration";
-            this.ClientSize = new Size(900, 700);
+            this.ClientSize = new Size(900, 770);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;
             this.StartPosition = FormStartPosition.CenterParent;
             this.MaximizeBox = false;
@@ -50,52 +51,72 @@ namespace RCDragManagerProd.UI.Forms
             lblClassName = new Label { Text = "Class Name:", Location = new Point(20, 20), AutoSize = true };
             txtClassName = new TextBox { Location = new Point(110, 17), Width = 220 };
 
-            // Race type
-            lblRaceType = new Label { Text = "Race Type:", Location = new Point(20, 55), AutoSize = true };
-            cmbRaceType = new ComboBox
+            // Race format cards (replace the old Race Type dropdown)
+            pnlCardProLadder  = CreateRaceTypeCard("Pro Ladder",  "Pro Ladder",  "NHRA bracket",  new Point(20, 55));
+            pnlCardRandomDraw = CreateRaceTypeCard("Random Draw", "Random Draw", "Single elim",   new Point(240, 55));
+            pnlCardRoundRobin = CreateRaceTypeCard("Round Robin", "Round Robin", "Points based",  new Point(460, 55));
+
+            // Round Robin config panel (visible only when Round Robin card is selected)
+            pnlRrConfig = new Panel
             {
-                DropDownStyle = ComboBoxStyle.DropDownList,
-                Location = new Point(110, 52),
-                Width = 220
+                Location = new Point(20, 135),
+                Size = new Size(640, 90),
+                BackColor = Color.FromArgb(240, 253, 250),
+                BorderStyle = BorderStyle.FixedSingle,
+                Visible = true
             };
-            cmbRaceType.Items.AddRange(new string[] { "Pro Ladder", "Round Robin", "Random Draw" });
-            cmbRaceType.SelectedIndex = 1;
+            lblRrRounds = new Label
+            {
+                Text = "Rounds:",
+                Location = new Point(15, 16),
+                AutoSize = true,
+                BackColor = Color.Transparent
+            };
+            nudRoundsToRun = new NumericUpDown
+            {
+                Location = new Point(75, 13),
+                Width = 60,
+                Minimum = 1,
+                Maximum = 100,
+                Value = 3
+            };
+            chkBuybackRace = new CheckBox
+            {
+                Text = "Buyback race for 4th finals spot",
+                Location = new Point(15, 41),
+                AutoSize = true,
+                Checked = true,
+                BackColor = Color.Transparent
+            };
+            lblBuybackHint = new Label
+            {
+                Text = "Unchecked → all drivers advance in ranked order",
+                Location = new Point(15, 64),
+                AutoSize = true,
+                ForeColor = Color.Gray,
+                BackColor = Color.Transparent
+            };
+            pnlRrConfig.Controls.AddRange(new Control[] { lblRrRounds, nudRoundsToRun, chkBuybackRace, lblBuybackHint });
 
             // Class type group
-            grpClassType = new GroupBox { Text = "Class Type", Location = new Point(20, 84), Size = new Size(640, 62) };
-            rbHeadsUp = new RadioButton { Text = "Heads Up",     Location = new Point(20, 28), AutoSize = true, Checked = true };
+            grpClassType = new GroupBox { Text = "Class Type", Location = new Point(20, 235), Size = new Size(640, 62) };
+            rbHeadsUp = new RadioButton { Text = "Heads Up",      Location = new Point(20, 28),  AutoSize = true, Checked = true };
             rbBracket = new RadioButton { Text = "Bracket Class", Location = new Point(130, 28), AutoSize = true };
-            rbDialIn  = new RadioButton { Text = "Dial-In",       Location = new Point(265, 28), AutoSize = true };
+            rbDialIn  = new RadioButton { Text = "Dial-In",        Location = new Point(265, 28), AutoSize = true };
             lblFixedDialIn = new Label  { Text = "Fixed Dial-In:", Location = new Point(355, 31), AutoSize = true, Visible = false };
             txtFixedDialIn = new TextBox { Location = new Point(450, 28), Width = 100, Visible = false };
             grpClassType.Controls.AddRange(new Control[] { rbHeadsUp, rbBracket, rbDialIn, lblFixedDialIn, txtFixedDialIn });
 
-            // Round Robin variant group (visible only when Race Type == Round Robin)
-            grpVariant = new GroupBox { Text = "Round Robin Variant", Location = new Point(20, 155), Size = new Size(600, 62), Visible = false };
-            rbStandard = new RadioButton { Text = "Standard", Location = new Point(20, 28), AutoSize = true, Checked = true };
-            rbQmdra    = new RadioButton { Text = "QMDRA",    Location = new Point(120, 28), AutoSize = true };
-            lblRoundsToRun = new Label { Text = "Rounds (N):", Location = new Point(230, 31), AutoSize = true, Visible = false };
-            nudRoundsToRun = new NumericUpDown
-            {
-                Location = new Point(325, 28),
-                Width = 70,
-                Minimum = 1,
-                Maximum = 100,
-                Value = 3,
-                Visible = false
-            };
-            grpVariant.Controls.AddRange(new Control[] { rbStandard, rbQmdra, lblRoundsToRun, nudRoundsToRun });
-
             // Add New Driver button
-            btnAddNewDriver = new Button { Text = "Add New Driver", Location = new Point(20, 228), Size = new Size(140, 30) };
+            btnAddNewDriver = new Button { Text = "Add New Driver", Location = new Point(20, 310), Size = new Size(140, 30) };
 
             // Filter controls are created dynamically in CreateFilterControls()
 
             // Driver list
-            lblDrivers = new Label { Text = "Drivers (check to include):", Location = new Point(20, 263), AutoSize = true };
+            lblDrivers = new Label { Text = "Drivers (check to include):", Location = new Point(20, 348), AutoSize = true };
             lvDrivers = new ListView
             {
-                Location = new Point(20, 283),
+                Location = new Point(20, 368),
                 Size = new Size(860, 280),
                 View = View.Details,
                 FullRowSelect = true,
@@ -108,24 +129,57 @@ namespace RCDragManagerProd.UI.Forms
             lvDrivers.Columns.Add("Override Dial-In", 115);
 
             // Dial-in override editor
-            lblDialInOverride = new Label { Text = "Override Dial-In:", Location = new Point(20, 573), AutoSize = true };
-            txtDialInOverride = new TextBox { Location = new Point(145, 570), Width = 110, Enabled = false };
+            lblDialInOverride = new Label { Text = "Override Dial-In:", Location = new Point(20, 658), AutoSize = true };
+            txtDialInOverride = new TextBox { Location = new Point(145, 655), Width = 110, Enabled = false };
 
             // Buttons
-            btnOk     = new Button { Text = "OK",     Location = new Point(690, 648), Size = new Size(85, 30) };
-            btnCancel = new Button { Text = "Cancel",  Location = new Point(790, 648), Size = new Size(85, 30) };
+            btnOk     = new Button { Text = "OK",     Location = new Point(690, 720), Size = new Size(85, 30) };
+            btnCancel = new Button { Text = "Cancel", Location = new Point(790, 720), Size = new Size(85, 30) };
 
             Controls.AddRange(new Control[]
             {
                 lblClassName, txtClassName,
-                lblRaceType, cmbRaceType,
+                pnlCardProLadder, pnlCardRandomDraw, pnlCardRoundRobin,
+                pnlRrConfig,
                 grpClassType,
-                grpVariant,
                 btnAddNewDriver,
                 lblDrivers, lvDrivers,
                 lblDialInOverride, txtDialInOverride,
                 btnOk, btnCancel
             });
+        }
+
+        private Panel CreateRaceTypeCard(string raceType, string title, string subtitle, Point location)
+        {
+            var card = new Panel
+            {
+                Tag = raceType,
+                Location = location,
+                Size = new Size(200, 70),
+                BackColor = Color.White,
+                Cursor = Cursors.Hand
+            };
+            var titleLabel = new Label
+            {
+                Text = title,
+                Location = new Point(12, 12),
+                AutoSize = true,
+                Font = new Font("Microsoft Sans Serif", 11F, FontStyle.Bold),
+                BackColor = Color.Transparent,
+                Cursor = Cursors.Hand
+            };
+            var subLabel = new Label
+            {
+                Text = subtitle,
+                Location = new Point(12, 38),
+                AutoSize = true,
+                ForeColor = Color.Gray,
+                BackColor = Color.Transparent,
+                Cursor = Cursors.Hand
+            };
+            card.Controls.Add(titleLabel);
+            card.Controls.Add(subLabel);
+            return card;
         }
     }
 }

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
@@ -89,9 +89,10 @@ namespace RCDragManagerProd.UI.Forms
             pnlRrConfig = new Panel
             {
                 Location = new Point(20, 135),
-                Size = new Size(640, 70),
+                Size = new Size(860, 70),
                 BackColor = Color.FromArgb(240, 253, 250),
                 BorderStyle = BorderStyle.FixedSingle,
+                Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
                 Visible = true
             };
             lblRrRounds = new Label
@@ -128,7 +129,7 @@ namespace RCDragManagerProd.UI.Forms
             pnlRrConfig.Controls.AddRange(new Control[] { lblRrRounds, nudRoundsToRun, chkBuybackRace, lblBuybackHint });
 
             // Class type group
-            grpClassType = new GroupBox { Text = "Class Type", Location = new Point(20, 235), Size = new Size(640, 62) };
+            grpClassType = new GroupBox { Text = "Class Type", Location = new Point(20, 235), Size = new Size(860, 62) };
             rbHeadsUp = new RadioButton { Text = "Heads Up",      Location = new Point(20, 28),  AutoSize = true, Checked = true };
             rbBracket = new RadioButton { Text = "Bracket Class", Location = new Point(130, 28), AutoSize = true };
             rbDialIn  = new RadioButton { Text = "Dial-In",        Location = new Point(265, 28), AutoSize = true };

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
@@ -9,6 +9,7 @@ namespace RCDragManagerProd.UI.Forms
 
         private Label lblClassName;
         private TextBox txtClassName;
+        private TableLayoutPanel pnlCardRow;
         private Panel pnlCardProLadder;
         private Panel pnlCardRandomDraw;
         private Panel pnlCardRoundRobin;
@@ -52,15 +53,43 @@ namespace RCDragManagerProd.UI.Forms
             txtClassName = new TextBox { Location = new Point(110, 17), Width = 220 };
 
             // Race format cards (replace the old Race Type dropdown)
-            pnlCardProLadder  = CreateRaceTypeCard("Pro Ladder",  "Pro Ladder",  "NHRA bracket",  new Point(20, 55));
-            pnlCardRandomDraw = CreateRaceTypeCard("Random Draw", "Random Draw", "Single elim",   new Point(240, 55));
-            pnlCardRoundRobin = CreateRaceTypeCard("Round Robin", "Round Robin", "Points based",  new Point(460, 55));
+            // Cards live inside a TableLayoutPanel so they share the full width
+            // of the driver ListView below in three equal columns and stretch
+            // together if the form is ever resized.
+            pnlCardRow = new TableLayoutPanel
+            {
+                Location = new Point(20, 55),
+                Size = new Size(860, 70),
+                ColumnCount = 3,
+                RowCount = 1,
+                Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
+            };
+            pnlCardRow.ColumnStyles.Clear();
+            pnlCardRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
+            pnlCardRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.34F));
+            pnlCardRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
+            pnlCardRow.RowStyles.Clear();
+            pnlCardRow.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+
+            pnlCardProLadder  = CreateRaceTypeCard("Pro Ladder",  "Pro Ladder",  "NHRA bracket",  Point.Empty);
+            pnlCardRandomDraw = CreateRaceTypeCard("Random Draw", "Random Draw", "Single elim",   Point.Empty);
+            pnlCardRoundRobin = CreateRaceTypeCard("Round Robin", "Round Robin", "Points based",  Point.Empty);
+
+            pnlCardProLadder.Dock  = DockStyle.Fill;
+            pnlCardRandomDraw.Dock = DockStyle.Fill;
+            pnlCardRoundRobin.Dock = DockStyle.Fill;
+
+            pnlCardRow.Controls.Add(pnlCardProLadder,  0, 0);
+            pnlCardRow.Controls.Add(pnlCardRandomDraw, 1, 0);
+            pnlCardRow.Controls.Add(pnlCardRoundRobin, 2, 0);
 
             // Round Robin config panel (visible only when Round Robin card is selected)
+            // Single horizontal row: [Rounds: <nud>]   [☑ Buyback race for 4th finals spot]
+            // Hint text below, left-aligned under the checkbox.
             pnlRrConfig = new Panel
             {
                 Location = new Point(20, 135),
-                Size = new Size(640, 90),
+                Size = new Size(640, 70),
                 BackColor = Color.FromArgb(240, 253, 250),
                 BorderStyle = BorderStyle.FixedSingle,
                 Visible = true
@@ -68,13 +97,13 @@ namespace RCDragManagerProd.UI.Forms
             lblRrRounds = new Label
             {
                 Text = "Rounds:",
-                Location = new Point(15, 16),
+                Location = new Point(15, 20),
                 AutoSize = true,
                 BackColor = Color.Transparent
             };
             nudRoundsToRun = new NumericUpDown
             {
-                Location = new Point(75, 13),
+                Location = new Point(75, 17),
                 Width = 60,
                 Minimum = 1,
                 Maximum = 100,
@@ -83,7 +112,7 @@ namespace RCDragManagerProd.UI.Forms
             chkBuybackRace = new CheckBox
             {
                 Text = "Buyback race for 4th finals spot",
-                Location = new Point(15, 41),
+                Location = new Point(165, 19),
                 AutoSize = true,
                 Checked = true,
                 BackColor = Color.Transparent
@@ -91,7 +120,7 @@ namespace RCDragManagerProd.UI.Forms
             lblBuybackHint = new Label
             {
                 Text = "Unchecked → all drivers advance in ranked order",
-                Location = new Point(15, 64),
+                Location = new Point(165, 45),
                 AutoSize = true,
                 ForeColor = Color.Gray,
                 BackColor = Color.Transparent
@@ -139,7 +168,7 @@ namespace RCDragManagerProd.UI.Forms
             Controls.AddRange(new Control[]
             {
                 lblClassName, txtClassName,
-                pnlCardProLadder, pnlCardRandomDraw, pnlCardRoundRobin,
+                pnlCardRow,
                 pnlRrConfig,
                 grpClassType,
                 btnAddNewDriver,

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
@@ -36,6 +36,8 @@ namespace RCDragManagerProd.UI.Forms
         private ComboBox cmbFilterClass;
         private ComboBox cmbFilterState;
 
+        private string _selectedRaceType = RaceTypes.RoundRobin;
+
         public string ClassName { get; private set; }
         public string RaceType { get; private set; }
         public string ClassType { get; private set; }
@@ -58,12 +60,12 @@ namespace RCDragManagerProd.UI.Forms
             if (existing != null)
                 LoadExistingValues(existing);
 
-            cmbRaceType.SelectedIndexChanged += CmbRaceType_SelectedIndexChanged;
+            WireRaceTypeCard(pnlCardProLadder);
+            WireRaceTypeCard(pnlCardRandomDraw);
+            WireRaceTypeCard(pnlCardRoundRobin);
             rbBracket.CheckedChanged += RbClassType_CheckedChanged;
             rbHeadsUp.CheckedChanged += RbClassType_CheckedChanged;
             rbDialIn.CheckedChanged  += RbClassType_CheckedChanged;
-            rbStandard.CheckedChanged += RbVariant_CheckedChanged;
-            rbQmdra.CheckedChanged    += RbVariant_CheckedChanged;
             lvDrivers.SelectedIndexChanged += LvDrivers_SelectedIndexChanged;
             lvDrivers.ItemChecked += LvDrivers_ItemChecked;
             txtDialInOverride.Leave += TxtDialInOverride_Leave;
@@ -71,7 +73,7 @@ namespace RCDragManagerProd.UI.Forms
             btnCancel.Click += BtnCancel_Click;
             btnAddNewDriver.Click += BtnAddNewDriver_Click;
 
-            UpdateRaceTypeUi();
+            SelectRaceTypeCard(_selectedRaceType);
             UpdateClassTypeUi();
         }
 
@@ -246,8 +248,7 @@ namespace RCDragManagerProd.UI.Forms
             // Race type
             if (!string.IsNullOrEmpty(existing.RaceType))
             {
-                int idx = cmbRaceType.Items.IndexOf(existing.RaceType);
-                if (idx >= 0) cmbRaceType.SelectedIndex = idx;
+                SelectRaceTypeCard(existing.RaceType);
             }
 
             // Class type (Heads Up / Bracket Class / Dial-In)
@@ -266,17 +267,10 @@ namespace RCDragManagerProd.UI.Forms
                 rbHeadsUp.Checked = true;
             }
 
-            // Round Robin variant
-            if (string.Equals(existing.Variant, "QMDRA", StringComparison.OrdinalIgnoreCase))
-            {
-                rbQmdra.Checked = true;
-                if (existing.RoundsToRun.HasValue)
-                    nudRoundsToRun.Value = existing.RoundsToRun.Value;
-            }
-            else
-            {
-                rbStandard.Checked = true;
-            }
+            // Round Robin variant: Standard → buyback checked, QMDRA → buyback unchecked
+            chkBuybackRace.Checked = !string.Equals(existing.Variant, "QMDRA", StringComparison.OrdinalIgnoreCase);
+            if (existing.RoundsToRun.HasValue)
+                nudRoundsToRun.Value = existing.RoundsToRun.Value;
         }
 
         // ── ItemChecked — persistent source of truth ──────────────────────────
@@ -318,26 +312,50 @@ namespace RCDragManagerProd.UI.Forms
             PopulateDriverList(null);
         }
 
-        // ── Race type selection ───────────────────────────────────────────────
+        // ── Race type selection (card-based) ──────────────────────────────────
 
-        private void CmbRaceType_SelectedIndexChanged(object sender, EventArgs e)
+        private void WireRaceTypeCard(Panel card)
         {
-            UpdateRaceTypeUi();
+            string raceType = (string)card.Tag;
+            EventHandler clickHandler = (s, e) => SelectRaceTypeCard(raceType);
+            card.Click += clickHandler;
+            foreach (Control child in card.Controls)
+                child.Click += clickHandler;
+            card.Paint += RaceCard_Paint;
         }
 
-        private void UpdateRaceTypeUi()
+        private void SelectRaceTypeCard(string raceType)
         {
-            bool isRR = string.Equals(
-                cmbRaceType.SelectedItem?.ToString(),
-                RaceTypes.RoundRobin,
-                StringComparison.OrdinalIgnoreCase);
+            _selectedRaceType = raceType;
 
-            grpVariant.Visible = isRR;
+            bool isRR = string.Equals(raceType, RaceTypes.RoundRobin, StringComparison.OrdinalIgnoreCase);
+            pnlRrConfig.Visible = isRR;
 
-            if (!isRR)
+            UpdateCardBackground(pnlCardProLadder);
+            UpdateCardBackground(pnlCardRandomDraw);
+            UpdateCardBackground(pnlCardRoundRobin);
+
+            pnlCardProLadder.Invalidate();
+            pnlCardRandomDraw.Invalidate();
+            pnlCardRoundRobin.Invalidate();
+        }
+
+        private void UpdateCardBackground(Panel card)
+        {
+            bool isSelected = string.Equals((string)card.Tag, _selectedRaceType, StringComparison.OrdinalIgnoreCase);
+            card.BackColor = isSelected ? Color.FromArgb(209, 250, 229) : Color.White;
+        }
+
+        private void RaceCard_Paint(object sender, PaintEventArgs e)
+        {
+            var p = (Panel)sender;
+            bool isSelected = string.Equals((string)p.Tag, _selectedRaceType, StringComparison.OrdinalIgnoreCase);
+            var color = isSelected ? Color.FromArgb(16, 185, 129) : Color.FromArgb(220, 220, 220);
+            int width = isSelected ? 2 : 1;
+            using (var pen = new Pen(color, width))
             {
-                rbStandard.Checked = true;
-                nudRoundsToRun.Value = 3;
+                var rect = new Rectangle(0, 0, p.Width - 1, p.Height - 1);
+                e.Graphics.DrawRectangle(pen, rect);
             }
         }
 
@@ -353,20 +371,6 @@ namespace RCDragManagerProd.UI.Forms
             bool isBracket = rbBracket.Checked;
             lblFixedDialIn.Visible = isBracket;
             txtFixedDialIn.Visible = isBracket;
-        }
-
-        // ── Variant radio buttons ─────────────────────────────────────────────
-
-        private void RbVariant_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateRoundsVisibility();
-        }
-
-        private void UpdateRoundsVisibility()
-        {
-            bool isQmdra = rbQmdra.Checked;
-            lblRoundsToRun.Visible = isQmdra;
-            nudRoundsToRun.Visible = isQmdra;
         }
 
         // ── Dial-in override editing ──────────────────────────────────────────
@@ -420,7 +424,7 @@ namespace RCDragManagerProd.UI.Forms
             }
 
             ClassName = className;
-            RaceType  = cmbRaceType.SelectedItem?.ToString() ?? "Pro Ladder";
+            RaceType  = _selectedRaceType ?? RaceTypes.RoundRobin;
             ClassType = rbHeadsUp.Checked ? "Heads Up" :
                         rbBracket.Checked ? "Bracket Class" : "Dial-In";
 
@@ -430,22 +434,25 @@ namespace RCDragManagerProd.UI.Forms
                 FixedDialIn = null;
 
             bool isRR = string.Equals(RaceType, RaceTypes.RoundRobin, StringComparison.OrdinalIgnoreCase);
-            Variant = isRR ? (rbQmdra.Checked ? "QMDRA" : "Standard") : null;
 
-            if (isRR && rbQmdra.Checked)
+            if (isRR)
             {
+                // Buyback checked → Standard variant; unchecked → QMDRA (all advance)
+                Variant = chkBuybackRace.Checked ? "Standard" : "QMDRA";
+
                 int n = (int)nudRoundsToRun.Value;
                 if (n <= 0)
                 {
-                    MessageBox.Show("Rounds To Run (N) is required for QMDRA and must be >= 1.",
+                    MessageBox.Show("Rounds must be at least 1.",
                         "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    Logger.Log("[MULTICLASS][CFG][RR] BLOCKED OK → QMDRA missing/invalid N.");
+                    Logger.Log("[MULTICLASS][CFG][RR] BLOCKED OK → invalid Rounds.");
                     return;
                 }
                 RoundsToRun = n;
             }
             else
             {
+                Variant = null;
                 RoundsToRun = null;
             }
 


### PR DESCRIPTION
## Summary
Replaces the Race Type dropdown + Round Robin Variant radio group in `MultiClassConfigDialog` with a more discoverable card-based selector. When Round Robin is chosen, a teal-tinted panel appears with a Rounds spinner and a "Buyback race for 4th finals spot" checkbox. The Buyback checkbox is the new façade for Standard-vs-QMDRA selection (Standard = with-buyback, QMDRA = all-advance).

Also includes a one-line controller fix so Standard RR honours the user-chosen Rounds value instead of always auto-computing `min(3, n-1)`.

## Visual
- 3 card-style buttons in a row above the Class Type section
- Selected card: 2px green-teal border + light-teal background
- Unselected: 1px gray border, white background
- RR config panel: visible only when Round Robin is selected; hidden for Pro Ladder / Random Draw

## Output mapping (unchanged for downstream code)
| Selection | Variant | RoundsToRun |
|---|---|---|
| Round Robin + Buyback ✅ | `"Standard"` | N |
| Round Robin + Buyback ☐ | `"QMDRA"` | N |
| Pro Ladder | `null` | `null` |
| Random Draw | `null` | `null` |

`RaceType` output strings remain `"Round Robin"`, `"Pro Ladder"`, `"Random Draw"`.

## Controller fix
`RaceController.RoundFlow.Core.cs` Standard branch (line 128):
```diff
- int standardRounds = Math.Min(3, naturalMax);
+ int standardRounds = Math.Min(_session?.RoundsToRun ?? 3, naturalMax);
```
Behaviour preserved when `RoundsToRun` is null (defaults to 3).

## Files changed
- `UI/Forms/Session/MultiClassConfigDialog.Designer.cs` — full rewrite of UI layout
- `UI/Forms/Session/MultiClassConfigDialog.cs` — card wiring, paint, output mapping, LoadExistingValues
- `Controllers/RaceController.RoundFlow.Core.cs` — one-line Standard rounds fix

## Test plan
- [ ] Build `RCDragManagerProd` (Debug) — confirmed clean locally
- [ ] Open Multi-Class setup → Add class → cards render, Round Robin pre-selected
- [ ] Click Pro Ladder / Random Draw — RR panel hides
- [ ] Click Round Robin — RR panel shows, Buyback checked, Rounds=3
- [ ] Save with Buyback unchecked → confirm session writes `Variant="QMDRA"`
- [ ] Save with Buyback checked → confirm session writes `Variant="Standard"`
- [ ] Edit existing class → cards & buyback state restored correctly
- [ ] Run Standard RR with N=2 → only 2 rounds generated (was 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)