### PR TITLE
fix: #240 — make app DPI-aware to fix form sizing on 14" laptops at 150% scaling

### DIFF
--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -53,6 +53,7 @@
   <PropertyGroup>
     <ApplicationIcon>Assets\retro trans icon.ico</ApplicationIcon>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="QRCoder">
@@ -358,6 +359,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="app.manifest" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\rcdrag_logo 2.ico">

--- a/src/RCDragManagerProd/UI/Forms/Cars/AddCarDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Cars/AddCarDialog.Designer.cs
@@ -32,6 +32,8 @@ namespace RCDragManagerProd.UI.Forms
         private void InitializeComponent()
         {
             this.Text = "Add / Edit Car";
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(450, 300);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;

--- a/src/RCDragManagerProd/UI/Forms/Cars/SelectCarDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Cars/SelectCarDialog.Designer.cs
@@ -44,6 +44,8 @@
             this.Controls.Add(this.btnCancel);
 
             // SelectCarDialog
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(350, 300);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;

--- a/src/RCDragManagerProd/UI/Forms/Common/ScrollableTextDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Common/ScrollableTextDialog.cs
@@ -29,6 +29,8 @@ namespace RCDragManagerProd.UI.Forms
             MinimizeBox = false;
             MaximizeBox = true;
             ShowInTaskbar = false;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(820, 640);
 
             _rtb = new RichTextBox

--- a/src/RCDragManagerProd/UI/Forms/Common/SettingsForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Common/SettingsForm.cs
@@ -24,6 +24,8 @@ namespace RCDragManagerProd.UI.Forms
             FormBorderStyle = FormBorderStyle.FixedDialog;
             MaximizeBox = false;
             MinimizeBox = false;
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             Width = 460;
             Height = 250;
 

--- a/src/RCDragManagerProd/UI/Forms/Drivers/AddDriverAndCarDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/AddDriverAndCarDialog.Designer.cs
@@ -23,6 +23,8 @@ namespace RCDragManagerProd.UI.Forms
         private void InitializeComponent()
         {
             this.Text = "Add Driver and Car";
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(450, 280);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;

--- a/src/RCDragManagerProd/UI/Forms/Drivers/AddDriverDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/AddDriverDialog.Designer.cs
@@ -16,6 +16,8 @@ namespace RCDragManagerProd.UI.Forms
         private void InitializeComponent()
         {
             this.Text = "Add Driver";
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(400, 200);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;

--- a/src/RCDragManagerProd/UI/Forms/Drivers/AddEditQualTimeDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/AddEditQualTimeDialog.Designer.cs
@@ -13,6 +13,8 @@ namespace RCDragManagerProd.UI.Forms
 
         private void InitializeComponent()
         {
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(400, 200);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;
             this.StartPosition = FormStartPosition.CenterParent;

--- a/src/RCDragManagerProd/UI/Forms/Drivers/DriverManagerForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/DriverManagerForm.Designer.cs
@@ -218,6 +218,8 @@ namespace RCDragManagerProd.UI.Forms
             this.Controls.Add(this.btnDriverStats);
             this.Controls.Add(this.pnlContent);
 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(900, 600);
             this.FormBorderStyle = FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;

--- a/src/RCDragManagerProd/UI/Forms/Drivers/DriverStatsForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/DriverStatsForm.Designer.cs
@@ -72,6 +72,8 @@
             // 
             // DriverStatsForm
             // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(900, 600);
             this.Controls.Add(this.lblHeader);
             this.Controls.Add(this.lblSummary);

--- a/src/RCDragManagerProd/UI/Forms/Drivers/EditDriverDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/EditDriverDialog.Designer.cs
@@ -24,6 +24,8 @@ namespace RCDragManagerProd.UI.Forms
         private void InitializeComponent()
         {
             this.Text = "Edit Driver";
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(450, 250);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Designer.cs
@@ -803,7 +803,8 @@ namespace RCDragManagerProd.UI.Forms
             // 
             // Form1
             // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(884, 561);
             this.Controls.Add(this.tlpMain);
             this.Controls.Add(this.pnlLeft);

--- a/src/RCDragManagerProd/UI/Forms/Main/MultiClassRaceForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/MultiClassRaceForm.Designer.cs
@@ -45,8 +45,8 @@ namespace RCDragManagerProd.UI.Forms
             // 
             // MultiClassRaceForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(1200, 790);
             this.Controls.Add(this.tabControl);
             this.Controls.Add(this.lblStatus);

--- a/src/RCDragManagerProd/UI/Forms/Main/QRCodeDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/QRCodeDialog.cs
@@ -28,7 +28,8 @@ namespace RCDragManagerProd.UI.Forms
             this.MinimizeBox = false;
             this.StartPosition = FormStartPosition.CenterParent;
             this.BackColor = Color.White;
-            this.AutoScaleMode = AutoScaleMode.None;
+            this.AutoScaleDimensions = new SizeF(96F, 96F);
+            this.AutoScaleMode = AutoScaleMode.Dpi;
 
             _lblInstruction = new Label();
             _lblInstruction.Text = "Scan to open the live scoreboard\n" + LiveScoreboardUrl;

--- a/src/RCDragManagerProd/UI/Forms/Results/BuybackDriverSelectionForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Results/BuybackDriverSelectionForm.Designer.cs
@@ -49,6 +49,8 @@
             // 
             // BuybackDriverSelectionForm
             // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(284, 260);
             this.Controls.Add(this.btnNoBuyback);
             this.Controls.Add(this.checkedListBoxDrivers);

--- a/src/RCDragManagerProd/UI/Forms/Results/EditWinnerDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Results/EditWinnerDialog.Designer.cs
@@ -54,6 +54,8 @@
             // 
             // EditWinnerDialog
             // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(300, 110);
             this.Controls.Add(this.cmbWinner);
             this.Controls.Add(this.btnOK);

--- a/src/RCDragManagerProd/UI/Forms/Session/LandingPageForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/LandingPageForm.Designer.cs
@@ -37,6 +37,8 @@ namespace RCDragManagerProd.UI.Forms
             this.SuspendLayout();
 
             // Form
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(900, 600);
             this.FormBorderStyle = FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;

--- a/src/RCDragManagerProd/UI/Forms/Session/LoadSessionForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/LoadSessionForm.Designer.cs
@@ -120,6 +120,8 @@ namespace RCDragManagerProd.UI.Forms
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
 
             // LoadSessionForm
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(900, 560);
             this.Controls.Add(this.tabControl);
             this.Controls.Add(this.btnLoad);

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
@@ -42,6 +42,8 @@ namespace RCDragManagerProd.UI.Forms
         private void InitializeComponent()
         {
             this.Text = "Class Configuration";
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(900, 770);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;
             this.StartPosition = FormStartPosition.CenterParent;

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassSetupForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassSetupForm.Designer.cs
@@ -31,6 +31,8 @@ namespace RCDragManagerProd.UI.Forms
         private void InitializeComponent()
         {
             this.Text = "New Multi-Class Event";
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(900, 600);
             this.FormBorderStyle = FormBorderStyle.FixedSingle;
             this.StartPosition = FormStartPosition.CenterScreen;

--- a/src/RCDragManagerProd/app.manifest
+++ b/src/RCDragManagerProd/app.manifest
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="RCDragManagerProd.app" />
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+    </application>
+  </compatibility>
+
+  <!--
+    DPI awareness. The app is single-operator / single-machine and does not
+    handle runtime DpiChanged events, so System DPI awareness (scale once at
+    startup to the primary monitor) is the safe choice over PerMonitorV2.
+    This stops Windows from bitmap-stretching the forms 1.5x at 150% scaling,
+    which is the root cause of the clipped OK/Cancel buttons (issue #240).
+  -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
Closes #240

## Summary
The app declared no DPI awareness, so Windows bitmap-stretched every form 1.5× at the default **150% scaling** on a 14" 1920×1080 laptop. That stretch is the root cause of `MultiClassConfigDialog`'s OK/Cancel buttons clipping off-screen (the reported symptom), and it makes every form blurry.

## Changes
- **`app.manifest`** declaring **System DPI awareness** (`dpiAware=true` / `dpiAwareness=system`), referenced from the `.csproj`.
  - System (not PerMonitorV2) is the safe choice per the issue's fallback guidance: this is a single-operator / single-machine app that does not handle runtime `DpiChanged` events, so per-monitor awareness would risk broken layouts when a window moves between monitors of different DPI. System scales once at startup — robust for this app.
- **Consistent `AutoScaleMode` across all 19 forms**: `AutoScaleMode.Dpi` with `AutoScaleDimensions = (96, 96)`.
  - Before: only `MultiClassRaceForm` scaled (`Font`); `Form1`/`QRCodeDialog` were `None`; the other 16 were unset (effectively `None`) — the inconsistency flagged in `UI-SIZING-AUDIT.md` §2.
  - `Dpi`/`(96,96)` is **font-independent**: at 96 DPI the scale factor is exactly `1.0` (provably **no layout change at 100%**), and forms re-lay-out cleanly at higher DPI instead of being bitmap-stretched.

## Acceptance criteria
- [x] App declares itself DPI-aware (System DPI awareness via manifest).
- [x] `AutoScaleMode` consistent across every form (`Dpi`, `(96,96)`).
- [x] No regression at 100% scaling — scale factor is exactly 1.0, layout unchanged.
- [ ] *Manual verification on a physical 14" laptop at 150% is recommended (cannot be automated here).*

Per the issue and `UI-SIZING-AUDIT.md`, residual clipping of the tall `MultiClassConfigDialog` at 150% is explicitly the scope of the dependent **BUG-14 / #241**.

## Testing
- `msbuild RCDragManagerProd.csproj /p:Configuration=Debug` — **passes** (only a pre-existing unrelated `CS0618` obsolete-API warning).
- `dotnet test` — the only failures are pre-existing flaky `RandomBracket` tests (random shuffling + static state under parallel execution); they fail on clean `main` too (with a different failing set run-to-run) and are unrelated to these UI/manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
