### PR TITLE
fix: #242 — Replace Car/Class/State filter dropdowns with name search box in MultiClassConfigDialog

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
@@ -144,7 +144,7 @@ namespace RCDragManagerProd.UI.Forms
             // Add New Driver button
             btnAddNewDriver = new Button { Text = "Add New Driver", Location = new Point(20, 310), Size = new Size(140, 30) };
 
-            // Filter controls are created dynamically in CreateFilterControls()
+            // Driver search box is created dynamically in CreateSearchControl()
 
             // Driver list
             lblDrivers = new Label { Text = "Drivers (check to include):", Location = new Point(20, 348), AutoSize = true };
@@ -179,7 +179,7 @@ namespace RCDragManagerProd.UI.Forms
             pnlButtonBar.Controls.Add(btnCancel);
 
             // Scrollable content host — holds everything above the button bar.
-            // Filter controls are added to this panel at runtime (CreateFilterControls).
+            // The search box is added to this panel at runtime (CreateSearchControl).
             pnlContent = new Panel
             {
                 Dock = DockStyle.Fill,

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using RCDragManagerProd.Domain;
 using RCDragManagerProd.Logging;
@@ -32,9 +33,7 @@ namespace RCDragManagerProd.UI.Forms
         private readonly HashSet<int> _checkedDriverIds = new HashSet<int>();
         private bool _suppressRosterEvents = false;
 
-        private ComboBox cmbFilterCar;
-        private ComboBox cmbFilterClass;
-        private ComboBox cmbFilterState;
+        private TextBox txtSearch;
 
         private string _selectedRaceType = RaceTypes.RoundRobin;
 
@@ -53,8 +52,8 @@ namespace RCDragManagerProd.UI.Forms
 
             _driverRepo = new DriverRepository(connectionString);
 
-            CreateFilterControls();
-            FillFilterCombos();
+            CreateSearchControl();
+            LoadDrivers();
             PopulateDriverList(existing);
 
             if (existing != null)
@@ -102,96 +101,45 @@ namespace RCDragManagerProd.UI.Forms
             Location = new Point(x, y);
         }
 
-        // ── Filter controls ───────────────────────────────────────────────────
+        // ── Search control ────────────────────────────────────────────────────
 
-        private void CreateFilterControls()
+        private const int EM_SETCUEBANNER = 0x1501;
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, string lParam);
+
+        private void CreateSearchControl()
         {
-            int comboW = 120, labelToBox = 4, groupGap = 12;
-            int y = btnAddNewDriver.Top;
-            int x = btnAddNewDriver.Right + 8;
-
-            int carLblW   = TextRenderer.MeasureText("Car:",   this.Font).Width;
-            int classLblW = TextRenderer.MeasureText("Class:", this.Font).Width;
-            int stateLblW = TextRenderer.MeasureText("State:", this.Font).Width;
-
-            var lblCar = new Label { Text = "Car:", AutoSize = true, Left = x, Top = y + 6 };
-            pnlContent.Controls.Add(lblCar); lblCar.BringToFront();
-            cmbFilterCar = new ComboBox
-            {
-                DropDownStyle = ComboBoxStyle.DropDownList,
-                Left = lblCar.Left + carLblW + labelToBox,
-                Top = y + 2,
-                Width = comboW
-            };
-            pnlContent.Controls.Add(cmbFilterCar); cmbFilterCar.BringToFront();
-
-            int nextX = cmbFilterCar.Left + comboW + groupGap;
-            var lblClass = new Label { Text = "Class:", AutoSize = true, Left = nextX, Top = y + 6 };
-            pnlContent.Controls.Add(lblClass); lblClass.BringToFront();
-            cmbFilterClass = new ComboBox
-            {
-                DropDownStyle = ComboBoxStyle.DropDownList,
-                Left = lblClass.Left + classLblW + labelToBox,
-                Top = y + 2,
-                Width = comboW
-            };
-            pnlContent.Controls.Add(cmbFilterClass); cmbFilterClass.BringToFront();
-
-            nextX = cmbFilterClass.Left + comboW + groupGap;
-            var lblState = new Label { Text = "State:", AutoSize = true, Left = nextX, Top = y + 6 };
-            pnlContent.Controls.Add(lblState); lblState.BringToFront();
-            cmbFilterState = new ComboBox
-            {
-                DropDownStyle = ComboBoxStyle.DropDownList,
-                Left = lblState.Left + stateLblW + labelToBox,
-                Top = y + 2,
-                Width = comboW
-            };
-            pnlContent.Controls.Add(cmbFilterState); cmbFilterState.BringToFront();
-
-            cmbFilterCar.SelectedIndexChanged   += FilterChanged;
-            cmbFilterClass.SelectedIndexChanged += FilterChanged;
-            cmbFilterState.SelectedIndexChanged += FilterChanged;
-
+            // The State column used to be added as a side effect of the (now
+            // removed) filter row. State is kept as a display column, so its
+            // creation is relocated here to survive the filter-row removal.
             if (lvDrivers.Columns.Count == 5)
                 lvDrivers.Columns.Add("State", 70, HorizontalAlignment.Left);
+
+            // A single search box fills the slot vacated by the three combos,
+            // stretching from just right of "Add New Driver" to the list's edge.
+            int left = btnAddNewDriver.Right + 8;
+            txtSearch = new TextBox
+            {
+                Left = left,
+                Top = btnAddNewDriver.Top + 4,
+                Width = lvDrivers.Right - left
+            };
+            pnlContent.Controls.Add(txtSearch); txtSearch.BringToFront();
+
+            // Native cue text shown greyed when the box is empty and unfocused.
+            // wParam = 0 → the cue hides as soon as the box gains focus.
+            SendMessage(txtSearch.Handle, EM_SETCUEBANNER, IntPtr.Zero, "Search drivers...");
+
+            txtSearch.TextChanged += SearchChanged;
         }
 
-        private void FillFilterCombos()
+        private void LoadDrivers()
         {
             _allDrivers = _driverRepo.GetAllDrivers() ?? new List<Driver>();
-
-            var carNames = _allDrivers
-                .SelectMany(d => d.Cars ?? new List<Car>())
-                .Select(c => c.CarName)
-                .Where(s => !string.IsNullOrWhiteSpace(s))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(s => s)
-                .ToList();
-
-            cmbFilterCar.Items.Clear();
-            cmbFilterCar.Items.Add("(All)");
-            foreach (var n in carNames) cmbFilterCar.Items.Add(n);
-            cmbFilterCar.SelectedIndex = 0;
-
-            cmbFilterClass.Items.Clear();
-            cmbFilterClass.Items.AddRange(new object[] { "(All)", "Heads Up", "Bracket", "Dial In" });
-            cmbFilterClass.SelectedIndex = 0;
-
-            var states = _allDrivers
-                .Select(d => d.State)
-                .Where(s => !string.IsNullOrWhiteSpace(s))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(s => s)
-                .ToList();
-
-            cmbFilterState.Items.Clear();
-            cmbFilterState.Items.Add("(All)");
-            foreach (var s in states) cmbFilterState.Items.Add(s);
-            cmbFilterState.SelectedIndex = 0;
         }
 
-        private void FilterChanged(object sender, EventArgs e)
+        private void SearchChanged(object sender, EventArgs e)
         {
             PopulateDriverList(null);
         }
@@ -216,9 +164,7 @@ namespace RCDragManagerProd.UI.Forms
                 }
             }
 
-            string carFilter   = cmbFilterCar?.SelectedItem?.ToString()   ?? "(All)";
-            string classFilter = cmbFilterClass?.SelectedItem?.ToString() ?? "(All)";
-            string stateFilter = cmbFilterState?.SelectedItem?.ToString() ?? "(All)";
+            string search = txtSearch?.Text?.Trim() ?? "";
 
             _suppressRosterEvents = true;
             lvDrivers.BeginUpdate();
@@ -227,20 +173,13 @@ namespace RCDragManagerProd.UI.Forms
                 lvDrivers.Items.Clear();
                 foreach (var driver in _allDrivers)
                 {
-                    if (stateFilter != "(All)" &&
-                        !string.Equals(driver.State ?? "", stateFilter, StringComparison.OrdinalIgnoreCase))
+                    // Case-insensitive "contains" match on driver name only.
+                    // Empty search box shows every driver.
+                    if (!string.IsNullOrEmpty(search) &&
+                        (driver.Name ?? "").IndexOf(search, StringComparison.OrdinalIgnoreCase) < 0)
                         continue;
 
                     var car = driver.Cars?.FirstOrDefault();
-
-                    if (classFilter != "(All)" &&
-                        !string.Equals(car?.ClassType ?? "", classFilter, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    if (carFilter != "(All)" &&
-                        !string.Equals(car?.CarName ?? "", carFilter, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
                     double? defaultDialIn = car?.DefaultDialIn;
 
                     var item = new ListViewItem(driver.Name);
@@ -333,7 +272,7 @@ namespace RCDragManagerProd.UI.Forms
                 _driverRepo.AddCar(insertedDriver.Id, newCar);
             }
 
-            FillFilterCombos();
+            LoadDrivers();
             PopulateDriverList(null);
         }
 


### PR DESCRIPTION
Closes #242

## What changed
Replaces the three filter combo boxes (Car, Class, State) in the Class Configuration dialog driver picker with a single name search box.

- Removed `cmbFilterCar` / `cmbFilterClass` / `cmbFilterState` and their labels.
- Added a single `txtSearch` TextBox filling the slot vacated by the combos (from just right of **Add New Driver** out to the list edge). **Add New Driver** stays exactly where it was.
- Native cue text "Search drivers..." via `EM_SETCUEBANNER` (shown greyed when empty/unfocused).
- `TextChanged` filters `lvDrivers` by **driver name only**, case-insensitive "contains". Empty box shows all drivers.
- Relocated the runtime **State column** add into `CreateSearchControl` so it survives the filter-row removal.
- Split `FillFilterCombos` into `LoadDrivers` (preserves the `_allDrivers` roster load) and dropped the combo-population code; updated both callers.

## Selection preservation
Checked state is still driven by the `_checkedDriverIds` HashSet, so a driver who is checked then filtered out of view is still included in the OK result. No change to that behaviour.

## Verification
- Build: `MSBuild RCDragManagerProd.csproj /p:Configuration=Debug` — **passed** (only a pre-existing unrelated CS0618 warning).
- Tests: 161 passed / 1 failed / 11 skipped. The single failure (`ActiveRound_IsNullAfterReset_WhenBracketWasStarted`) also fails on `main` — pre-existing and unrelated to this UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
