### PR TITLE
fix: #190 — REVIEW-11: LiveApiClient.SendAsync serialises all pushes through global SemaphoreSlim

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -167,7 +167,7 @@ namespace RCDragManagerProd.Controllers
             _winners.Clear();
             PushFullRefresh();
             var resetEventName = string.IsNullOrWhiteSpace(_session.EventName) ? "Quick Session" : _session.EventName;
-            _ = _liveApiClient.ResetAsync(_session.EventId.ToString("N"), resetEventName);
+            _ = _liveApiClient.ResetAsync(_session.EventId.ToString("N"), _session.ClassType, resetEventName);
             QueueLiveUpdate("GenerateBracket");
         }
 

--- a/src/RCDragManagerProd/Integration/LiveApiClient.cs
+++ b/src/RCDragManagerProd/Integration/LiveApiClient.cs
@@ -4,7 +4,6 @@ using System.Configuration;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using RCDragManagerProd.Config;
 using RCDragManagerProd.Logging;
@@ -26,19 +25,53 @@ namespace RCDragManagerProd.Integration
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
 
-        private static readonly SemaphoreSlim SendGate = new SemaphoreSlim(1, 1);
+        // Per-key coalescing send channels. Each (eventId, classType) pair gets
+        // its own serial worker so a slow push for one class never blocks another,
+        // and only the latest pending state for a class is ever sent (drop-old /
+        // latest-wins). Resets and updates for the same key are ordered FIFO so a
+        // reset issued right before a bracket push cannot overtake it.
+        private readonly object _channelsLock = new object();
+        private readonly Dictionary<string, SendChannel> _channels =
+            new Dictionary<string, SendChannel>();
 
-        public async Task SendAsync(LiveRaceUpdateDto dto)
+        private SendChannel GetChannel(string eventId, string classType)
         {
-            await SendGate.WaitAsync().ConfigureAwait(false);
+            var key = (eventId ?? string.Empty) + "|" + (classType ?? string.Empty);
+            lock (_channelsLock)
+            {
+                if (!_channels.TryGetValue(key, out var channel))
+                {
+                    channel = new SendChannel(this);
+                    _channels[key] = channel;
+                }
+                return channel;
+            }
+        }
+
+        public Task SendAsync(LiveRaceUpdateDto dto)
+        {
+            if (!AppSettings.LiveBroadcastEnabled)
+            {
+                Logger.Log("[LIVE][FAIL] Live updates disabled by config.");
+                return Task.CompletedTask;
+            }
+
+            var payload = dto ?? new LiveRaceUpdateDto();
+            GetChannel(payload.EventId, payload.ClassType).EnqueueUpdate(payload);
+            return Task.CompletedTask;
+        }
+
+        public Task ResetAsync(string eventId, string classType, string eventName)
+        {
+            if (!AppSettings.LiveBroadcastEnabled) return Task.CompletedTask;
+            GetChannel(eventId, classType).EnqueueReset(eventId, eventName);
+            return Task.CompletedTask;
+        }
+
+        private async Task SendCoreAsync(LiveRaceUpdateDto dto)
+        {
             try
             {
-                if (!AppSettings.LiveBroadcastEnabled)
-                {
-                    Logger.Log("[LIVE][FAIL] Live updates disabled by config.");
-                    return;
-                }
-
                 var apiKey = ConfigurationManager.AppSettings["ApiKey"];
                 var isNull = apiKey == null;
                 var isEmpty = apiKey != null && apiKey.Length == 0;
@@ -83,19 +116,12 @@ namespace RCDragManagerProd.Integration
             {
                 Logger.Log("[LIVE][FAIL] " + ex.Message);
             }
-            finally
-            {
-                SendGate.Release();
-            }
         }
 
-        public async Task ResetAsync(string eventId, string eventName)
+        private async Task ResetCoreAsync(string eventId, string eventName)
         {
-            await SendGate.WaitAsync().ConfigureAwait(false);
             try
             {
-                if (!AppSettings.LiveBroadcastEnabled) return;
-
                 var apiKey = ConfigurationManager.AppSettings["ApiKey"];
                 if (string.IsNullOrWhiteSpace(apiKey)) return;
 
@@ -115,10 +141,6 @@ namespace RCDragManagerProd.Integration
             catch (Exception ex)
             {
                 Logger.Log("[LIVE][RESET][FAIL] " + ex.Message);
-            }
-            finally
-            {
-                SendGate.Release();
             }
         }
 
@@ -151,6 +173,91 @@ namespace RCDragManagerProd.Integration
                 Logger.Log("[DIALIN][POLL][ERROR] " + ex.Message);
                 return null;
             }
+        }
+
+        // A serial, coalescing worker for one (eventId, classType) key. Updates
+        // are latest-wins (a queued-but-not-yet-sent update is replaced by a newer
+        // one); resets are kept as ordered barriers and never dropped.
+        private sealed class SendChannel
+        {
+            private readonly LiveApiClient _owner;
+            private readonly object _lock = new object();
+            private readonly LinkedList<LiveOp> _queue = new LinkedList<LiveOp>();
+            private bool _draining;
+
+            public SendChannel(LiveApiClient owner)
+            {
+                _owner = owner;
+            }
+
+            public void EnqueueUpdate(LiveRaceUpdateDto dto)
+            {
+                lock (_lock)
+                {
+                    // Drop-old: if the tail is still a pending update, overwrite it
+                    // rather than queueing another stale send behind it.
+                    var tail = _queue.Last;
+                    if (tail != null && tail.Value is UpdateOp pending)
+                        pending.Dto = dto;
+                    else
+                        _queue.AddLast(new UpdateOp { Dto = dto });
+
+                    EnsureDraining();
+                }
+            }
+
+            public void EnqueueReset(string eventId, string eventName)
+            {
+                lock (_lock)
+                {
+                    _queue.AddLast(new ResetOp { EventId = eventId, EventName = eventName });
+                    EnsureDraining();
+                }
+            }
+
+            // Caller must hold _lock.
+            private void EnsureDraining()
+            {
+                if (_draining) return;
+                _draining = true;
+                _ = Task.Run(DrainAsync);
+            }
+
+            private async Task DrainAsync()
+            {
+                while (true)
+                {
+                    LiveOp op;
+                    lock (_lock)
+                    {
+                        if (_queue.Count == 0)
+                        {
+                            _draining = false;
+                            return;
+                        }
+                        op = _queue.First.Value;
+                        _queue.RemoveFirst();
+                    }
+
+                    if (op is UpdateOp u)
+                        await _owner.SendCoreAsync(u.Dto).ConfigureAwait(false);
+                    else if (op is ResetOp r)
+                        await _owner.ResetCoreAsync(r.EventId, r.EventName).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private abstract class LiveOp { }
+
+        private sealed class UpdateOp : LiveOp
+        {
+            public LiveRaceUpdateDto Dto { get; set; }
+        }
+
+        private sealed class ResetOp : LiveOp
+        {
+            public string EventId { get; set; }
+            public string EventName { get; set; }
         }
     }
 }


### PR DESCRIPTION
Closes #190

## Problem
`LiveApiClient` used a process-static `SemaphoreSlim(1,1)` (`SendGate`) to serialise every live push. Combined with the 3 s `HttpClient.Timeout`, a slow network stalled every subsequent push by up to 3 s each. In multi-class mode (one `RaceController`/`LiveApiClient` per class), the *static* gate serialised across all classes, so a slow push for class A blocked class B. Queued pushes also became stale before they sent — only the latest state is meaningful.

## Fix
Replaced the static gate with **per-key (`eventId|classType`) latest-wins coalescing send channels**:

- **Class A does not block class B** — each class's `LiveApiClient` instance drains its own channel concurrently; there is no longer any shared static lock.
- **Stale states never reach the server** — a queued-but-unsent update is overwritten by a newer one (drop-old / latest-wins).
- **No single-class regression** — within a key the channel drains FIFO, and reset/update ordering is preserved so a reset issued just before a bracket push cannot overtake it. All existing `[LIVE]` log lines are kept verbatim.

`ResetAsync` now takes a `classType` argument so it shares the same channel as the `GenerateBracket` update that immediately follows it (the one existing caller was updated).

## Acceptance criteria
- [x] Pushing class A does not block class B
- [x] Stale states never reach the server when newer ones are available
- [x] No regression on single-class send behaviour

## Verification
- `msbuild RCDragManagerProd.csproj /p:Configuration=Debug` — succeeds (only a pre-existing unrelated `CS0618` warning).
- `dotnet test` — 161 passed, 11 skipped. The single failure (`ActiveRound_IsNullAfterReset_WhenBracketWasStarted`) is **pre-existing on `main`** and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
