### PR TITLE
chore: bump version to 1.4.0.0

### DIFF
--- a/src/RCDragManagerProd/Properties/AssemblyInfo.cs
+++ b/src/RCDragManagerProd/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/src/RCDragManagerProd/UI/Forms/Session/LandingPageForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/LandingPageForm.Designer.cs
@@ -91,7 +91,7 @@ namespace RCDragManagerProd.UI.Forms
             // lblVersion
             this.lblVersion.Location = new System.Drawing.Point(20, 570);
             this.lblVersion.Size = new System.Drawing.Size(200, 20);
-            this.lblVersion.Text = "v1.2.0";
+            this.lblVersion.Text = "v1.4.0";
             this.Controls.Add(this.lblVersion);
 
             // logoBox


### PR DESCRIPTION
Release prep for v1.4.0.

Changes:
- AssemblyInfo: 1.3.0.0 -> 1.4.0.0
- LandingPageForm lblVersion: v1.2.0 -> v1.4.0 (was stale - never bumped for v1.3.0; correcting straight to 1.4.0)

Mechanical only. After merge, the v1.4.0 tag will be cut from main and the installer published in a follow-up step.
