### PR TITLE
fix: #302 - get dotnet test baseline green

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerResetTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerResetTests.cs
@@ -102,15 +102,25 @@ public class RaceControllerResetTests
     [TestMethod]
     public void ActiveRound_IsNullAfterReset_WhenBracketWasStarted()
     {
-        // GenerateBracket sets _activeRound to the first round label.
-        // After Reset() it must be null (or empty) so that a fresh bracket can set it.
-        var controller = new RaceController(NewSession());
-        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderPack());
+        // _activeRound is the RR pre-reveal active-round gate: GenerateBracket only
+        // assigns it in Round Robin mode (roundOrder[0]); non-RR modes leave it null.
+        // Use a Round Robin session so the precondition is valid, then confirm Reset()
+        // clears it back to null/empty so a fresh bracket can re-assign it.
+        var rrSession = new RaceSession
+        {
+            EventName         = "Reset Field Tests",
+            EventDate         = new DateTime(2026, 3, 29),
+            RaceType          = "Round Robin",
+            ClassType         = "Open",
+            RoundRobinVariant = "Standard"
+        };
+        var controller = new RaceController(rrSession, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(6));
 
-        // Precondition: _activeRound was assigned by GenerateBracket.
+        // Precondition: _activeRound was assigned by GenerateBracket (RR1).
         var activeAfterGenerate = GetField<string>(controller, "_activeRound");
         Assert.IsFalse(string.IsNullOrEmpty(activeAfterGenerate),
-            "Precondition: _activeRound must be non-null/non-empty after GenerateBracket()");
+            "Precondition: _activeRound must be non-null/non-empty after GenerateBracket() in RR mode");
 
         controller.Reset();
 


### PR DESCRIPTION
## Summary

Fixes the one failing test that was blocking a green baseline (issue #302). With this change the suite is **162 passed / 11 skipped / 0 failed** (was 161 / 11 / 1).

## Root cause

`RaceControllerResetTests.ActiveRound_IsNullAfterReset_WhenBracketWasStarted` asserted, as a *precondition*, that `_activeRound` is non-empty after `GenerateBracket()` — using a **Pro Ladder** session.

That premise is stale. `_activeRound` is now the **Round Robin pre-reveal active-round gate**: `GenerateBracket` only assigns it in RR mode (`roundOrder[0]`, `RaceController.RoundFlow.Core.cs:158`); non-RR modes intentionally leave it null (`:164`). So under Pro Ladder the precondition could never hold. This is an outdated test expectation, **not** a production behaviour regression.

## Fix

Rewrote the test to use a Round Robin session, so `GenerateBracket` genuinely sets `_activeRound` to `RR1` and the precondition is valid. The test's real intent — *Reset() must clear `_activeRound` back to null/empty* — is unchanged and still asserted. Only the test file changed; no production code touched.

## Skipped tests (acceptance criterion review)

The 11 skipped tests are all `Assert.Inconclusive` placeholders in `MultiClassFeatureTests.cs`:
- 8 × "Implement after **MultiClassSetupValidator** exists" → covered by #287 (extract race setup/class config workflow)
- 3 × "Implement after **MultiClassGateEvaluator** exists" → covered by #289 (extract MultiClass race coordination)

They are intentionally deferred and already tracked by those extraction issues — no new follow-ups needed.

## Test plan

- [x] Targeted test passes in isolation
- [x] Full suite green: `dotnet test ... -m:1` → 162 passed, 11 skipped, 0 failed
- [ ] CI green on PR

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
