### PR TITLE
fix: #294 - full save/resume recovery across all event phases

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerResumeTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerResumeTests.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.RandomMode;
+using RCDragManagerProd.Repositories;
+using RCDragManagerProd.Tests.Helpers;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Button-free regression tests for issue #294 — resume of an interrupted event.
+///
+/// Each test drives a controller to a save point, persists the session through the
+/// REAL repository (SQLite round-trip, exactly as the app does), constructs a fresh
+/// controller from the loaded session, calls <see cref="RaceController.RestoreFromSave"/>,
+/// and asserts the restored observable state (bracket structure, recorded winners,
+/// active round, pending matches, finals-pending flag) matches the pre-save state.
+///
+/// State is compared by (round label + unordered driver-name pair) rather than raw
+/// MatchId, because restored engines regenerate/re-inject and may assign new MatchIds.
+///
+/// The Random-mode tests are the critical ones: Random brackets are NON-deterministic
+/// (RandomBracket shuffles), so a faithful resume MUST re-inject the saved pairings.
+/// If restore regenerated instead, the pairings would reshuffle and the assertions fail.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class RaceControllerResumeTests
+{
+    [TestInitialize]
+    public void ResetStatics() => RandomBracket.ResetByeTracker();
+
+    // ── Save point 1: setup (no bracket generated) ───────────────────────────
+
+    [TestMethod]
+    public void Setup_NoBracketYet_RestoreIsNoOp()
+    {
+        var session = NewSession("Pro Ladder");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+
+        var restored = SaveRestore(session, controller);
+
+        // No engine existed at save time, so no resume snapshot is written and the
+        // fresh controller has no bracket — restore is a clean no-op (must not throw).
+        Assert.IsNull(session.Resume, "No snapshot should be captured before a bracket exists");
+        Assert.IsFalse(restored.HasBracketStarted, "Restore must not fabricate a bracket from an empty snapshot");
+        Assert.AreEqual(0, restored.BuildCurrentBracketRows().Count);
+    }
+
+    // ── Save point 2: post-bracket, no winners (Pro Ladder) ──────────────────
+
+    [TestMethod]
+    public void ProLadder_PostBracket_RestoresStructure()
+    {
+        var session = NewSession("Pro Ladder");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderPack());
+
+        var before = Capture(controller);
+        var restored = SaveRestore(session, controller);
+
+        AssertSameState(before, Capture(restored));
+    }
+
+    // ── Save point 3: mid-round, partial results (Pro Ladder) ────────────────
+
+    [TestMethod]
+    public void ProLadder_MidRound_RestoresPartialResults()
+    {
+        var session = NewSession("Pro Ladder");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderPack());
+
+        // Resolve exactly one of the two semifinal matches.
+        var first = controller.PeekUpcomingMatches(10).First();
+        controller.SubmitWinner(first.MatchId, firstOption: true);
+
+        var before = Capture(controller);
+        Assert.AreEqual(1, before.Results.Count, "Exactly one match should be resolved at this save point");
+
+        var restored = SaveRestore(session, controller);
+        AssertSameState(before, Capture(restored));
+    }
+
+    // ── Save point 4: between rounds (Pro Ladder, finals pending) ────────────
+
+    [TestMethod]
+    public void ProLadder_BetweenRounds_RestoresState()
+    {
+        var session = NewSession("Pro Ladder");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderPack());
+
+        // Resolve the whole semifinal round and advance into the final.
+        foreach (var m in controller.PeekUpcomingMatches(10).ToList())
+            controller.SubmitWinner(m.MatchId, firstOption: true);
+        controller.AdvanceRound();
+
+        var before = Capture(controller);
+        var restored = SaveRestore(session, controller);
+
+        AssertSameState(before, Capture(restored));
+    }
+
+    // ── Save point 5: post-finals (Pro Ladder, champion decided) ─────────────
+
+    [TestMethod]
+    public void ProLadder_PostFinals_RestoresChampion()
+    {
+        var session = NewSession("Pro Ladder");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+
+        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderPack());
+        RunOut(controller);
+
+        var before = Capture(controller);
+        Assert.IsTrue(before.Results.Count > 0, "All matches should be resolved at the post-finals save point");
+        Assert.AreEqual(0, before.Upcoming.Count, "No matches should remain after the final");
+
+        var restored = SaveRestore(session, controller);
+        AssertSameState(before, Capture(restored));
+    }
+
+    // ── Random mode: re-injection must preserve EXACT pairings (critical) ─────
+
+    [TestMethod]
+    public void Random_PostBracket_ReInjectionPreservesExactPairings()
+    {
+        var session = NewSession("Random");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Random", TestDriverFactory.CreateRoundRobinPack(8));
+
+        var before = Capture(controller);
+        Assert.AreEqual(4, before.Upcoming.Count, "Random R1 with 8 drivers must have 4 matches");
+
+        var restored = SaveRestore(session, controller);
+        var after = Capture(restored);
+
+        // The exact R1 pairings must survive the round-trip. Random regeneration would
+        // reshuffle these; equality here is the proof that restore re-injected.
+        AssertSameState(before, after);
+        CollectionAssert.AreEqual(before.Upcoming, after.Upcoming,
+            "Restored Random R1 pairings must be identical to the saved pairings (re-injection, not reshuffle)");
+    }
+
+    [TestMethod]
+    public void Random_BetweenRounds_RestoresState()
+    {
+        var session = NewSession("Random");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Random", TestDriverFactory.CreateRoundRobinPack(8));
+
+        foreach (var m in controller.PeekUpcomingMatches(10).ToList())
+            controller.SubmitWinner(m.MatchId, firstOption: true);
+        controller.AdvanceRound();
+        Assert.AreEqual("R2", controller.GetActiveRoundLabel());
+
+        var before = Capture(controller);
+        var restored = SaveRestore(session, controller);
+
+        AssertSameState(before, Capture(restored));
+    }
+
+    // ── Round Robin mid-event ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void RoundRobin_MidEvent_RestoresState()
+    {
+        var session = NewSession("Round Robin");
+        session.RoundRobinVariant = "Standard";
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(6));
+
+        // Resolve RR1 and advance into RR2.
+        foreach (var m in controller.PeekUpcomingMatches(20).ToList())
+            controller.SubmitWinner(m.MatchId, firstOption: true);
+        controller.AdvanceRound();
+
+        var before = Capture(controller);
+        var restored = SaveRestore(session, controller);
+
+        AssertSameState(before, Capture(restored));
+    }
+
+    // ── Full multi-phase: RR → Buyback/LB and RR → … → Finals ────────────────
+
+    [TestMethod]
+    public void MultiPhase_LosersBracketPhase_RestoresState()
+    {
+        var (session, controller) = RunToLosersBracket();
+
+        var before = Capture(controller);
+        Assert.AreEqual("Losers Bracket", session.RaceType);
+        Assert.IsTrue(before.Upcoming.Count > 0, "LB phase must have pending matches");
+
+        var restored = SaveRestore(session, controller);
+        AssertSameState(before, Capture(restored));
+    }
+
+    [TestMethod]
+    public void MultiPhase_FinalsPhase_RestoresState()
+    {
+        var (session, controller) = RunToLosersBracket();
+
+        // Drive the LB to completion so finals become pending, then start finals.
+        var startFinals = false;
+        controller.CanStartFinalsChanged += v => { if (v) startFinals = true; };
+        int guard = 40;
+        while (!startFinals && guard-- > 0)
+        {
+            var matches = controller.PeekUpcomingMatches(20).ToList();
+            if (matches.Count == 0) controller.AdvanceRound();
+            else foreach (var m in matches) controller.SubmitWinner(m.MatchId, firstOption: true);
+        }
+        Assert.IsTrue(controller.IsFinalsPending, "Finals must be pending after LB completes");
+        controller.StartFinals();
+        Assert.AreEqual("Finals", session.RaceType);
+
+        var before = Capture(controller);
+        var restored = SaveRestore(session, controller);
+
+        AssertSameState(before, Capture(restored));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static (RaceSession, RaceController) RunToLosersBracket()
+    {
+        var session = NewSession("Round Robin");
+        session.RoundRobinVariant = "Standard";
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+
+        var canBuyback = false;
+        controller.CanOfferBuybackChanged += v => { if (v) canBuyback = true; };
+
+        controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(6));
+
+        int guard = 40;
+        while (!canBuyback && guard-- > 0)
+        {
+            var matches = controller.PeekUpcomingMatches(20).ToList();
+            if (matches.Count == 0) controller.AdvanceRound();
+            else foreach (var m in matches) controller.SubmitWinner(m.MatchId, firstOption: true);
+        }
+
+        Assert.IsTrue(canBuyback, "Buyback must be offered after all RR rounds complete");
+        var eligible = controller.GetEligibleBuybackDrivers();
+        controller.GenerateLosersBracket(eligible);
+        return (session, controller);
+    }
+
+    /// <summary>Resolves every match and advances until the bracket can advance no further.</summary>
+    private static void RunOut(RaceController controller)
+    {
+        int guard = 40;
+        while (guard-- > 0)
+        {
+            var matches = controller.PeekUpcomingMatches(20).ToList();
+            if (matches.Count > 0)
+            {
+                foreach (var m in matches) controller.SubmitWinner(m.MatchId, firstOption: true);
+                continue;
+            }
+
+            var before = controller.GetActiveRoundLabel();
+            controller.AdvanceRound();
+            if (string.Equals(controller.GetActiveRoundLabel(), before, StringComparison.OrdinalIgnoreCase))
+                break; // no further round to reveal — bracket is complete
+        }
+    }
+
+    private static RaceSession NewSession(string raceType) => new RaceSession
+    {
+        EventName = "QA Resume " + raceType,
+        EventDate = new DateTime(2026, 6, 8, 9, 0, 0),
+        RaceType = raceType,
+        ClassType = "Heads Up"
+    };
+
+    /// <summary>
+    /// Persists the controller's session through the real repository, loads it back into a
+    /// fresh controller, and runs the restore — the exact path the app takes on resume.
+    /// </summary>
+    private static RaceController SaveRestore(RaceSession session, RaceController controller)
+    {
+        controller.SaveSession();
+
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+
+        var id = repo.SaveSession(session);
+        var loaded = repo.LoadSession(id);
+        Assert.IsNotNull(loaded, "Session must load back from the repository");
+
+        var restored = new RaceController(loaded, new NoOpStandingsDialogService());
+        restored.RestoreFromSave();
+        return restored;
+    }
+
+    private sealed class StateSnapshot
+    {
+        public string ActiveRound = "";
+        public bool FinalsPending;
+        public List<string> Structure = new List<string>();
+        public List<string> Results = new List<string>();
+        public List<string> Upcoming = new List<string>();
+    }
+
+    private static StateSnapshot Capture(RaceController c)
+    {
+        var snap = new StateSnapshot
+        {
+            ActiveRound = c.GetActiveRoundLabel() ?? "",
+            FinalsPending = c.IsFinalsPending
+        };
+
+        foreach (var r in c.BuildCurrentBracketRows().Where(r => !r.IsHeader))
+        {
+            var pair = NormPair(r.Driver1, r.Driver2, r.RoundLabel);
+            snap.Structure.Add(pair);
+            var w = c.GetWinner(r.MatchId);
+            if (w != null) snap.Results.Add(pair + "|" + w.Name);
+        }
+
+        foreach (var m in c.PeekUpcomingMatches(50))
+            snap.Upcoming.Add(NormPair(m.Driver1?.Name, m.Driver2?.Name, m.RoundLabel));
+
+        snap.Structure.Sort(StringComparer.Ordinal);
+        snap.Results.Sort(StringComparer.Ordinal);
+        snap.Upcoming.Sort(StringComparer.Ordinal);
+        return snap;
+    }
+
+    private static string NormPair(string a, string b, string round)
+    {
+        a ??= ""; b ??= "";
+        var swap = string.CompareOrdinal(a, b) > 0;
+        var lo = swap ? b : a;
+        var hi = swap ? a : b;
+        return $"{(round ?? "").Trim().ToUpperInvariant()}|{lo}|{hi}";
+    }
+
+    private static void AssertSameState(StateSnapshot before, StateSnapshot after)
+    {
+        Assert.AreEqual(before.ActiveRound, after.ActiveRound, "Active round label must match after restore");
+        Assert.AreEqual(before.FinalsPending, after.FinalsPending, "Finals-pending flag must match after restore");
+        CollectionAssert.AreEqual(before.Structure, after.Structure,
+            $"Bracket structure must match.\n  before: [{string.Join("; ", before.Structure)}]\n  after:  [{string.Join("; ", after.Structure)}]");
+        CollectionAssert.AreEqual(before.Results, after.Results,
+            $"Recorded results must match.\n  before: [{string.Join("; ", before.Results)}]\n  after:  [{string.Join("; ", after.Results)}]");
+        CollectionAssert.AreEqual(before.Upcoming, after.Upcoming,
+            $"Pending matches must match.\n  before: [{string.Join("; ", before.Upcoming)}]\n  after:  [{string.Join("; ", after.Upcoming)}]");
+    }
+
+    private sealed class TemporarySqliteDb : IDisposable
+    {
+        public TemporarySqliteDb()
+        {
+            DatabasePath = Path.Combine(Path.GetTempPath(), $"rcdragmanager-resume-{Guid.NewGuid():N}.db");
+        }
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try { if (File.Exists(DatabasePath)) File.Delete(DatabasePath); }
+            catch { /* best-effort */ }
+        }
+    }
+}

--- a/src/RCDragManagerProd/Controllers/RaceController.Persistence.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Persistence.cs
@@ -88,12 +88,92 @@ namespace RCDragManagerProd.Controllers
                     }
                 }
 
+                CaptureResumeSnapshot();
+
                 Logger.Log($"[SAVE] results={list.Count}, rounds={_session.SavedRevealedRounds.Count}, type='{_session.RaceType}'");
             }
             catch (Exception ex)
             {
                 Logger.Log($"[SAVE][ERROR] {ex}");
             }
+        }
+
+        // Captures the live bracket structure + transient phase state so an interrupted
+        // event can be reconstructed on load (see RestoreFromSave). SavedResults already
+        // holds the winners/losers; this adds the STRUCTURE the old save path dropped.
+        private void CaptureResumeSnapshot()
+        {
+            if (_engine == null)
+            {
+                // No bracket generated yet — nothing to resume into. Leave any prior
+                // snapshot untouched (a re-save before generation shouldn't wipe it).
+                return;
+            }
+
+            var snap = new ResumeSnapshot
+            {
+                OriginalRaceType = string.IsNullOrWhiteSpace(_session.OriginalRaceType)
+                    ? _session.RaceType
+                    : _session.OriginalRaceType,
+                CurrentPhase = InferResumePhase(),
+                ActiveRound = _activeRound,
+                InLosersPhase = _inLosersPhase,
+                FinalsPending = _finalsPending,
+                BuybackChampionOverrideId = _buybackChampionOverride?.Id,
+                RrTop3Ids = _rrTop3?.Select(d => d.Id).ToList() ?? new List<int>(),
+                MainMatches = EngineGetMatches(_engine).Select(ToSavedMatch).ToList(),
+                RrSnapshotMatches = _rrMatchesSnapshot?.Select(ToSavedMatch).ToList() ?? new List<SavedMatch>(),
+                RrSnapshotRoundOrder = _rrRoundOrderSnapshot?.ToList() ?? new List<string>()
+            };
+
+            // Persist the LB structure whenever a losers engine exists — including the
+            // in-LB-phase case where _engine IS the losers engine (so restore is unambiguous).
+            if (_losersEngine != null)
+                snap.LosersMatches = EngineGetMatches(_losersEngine).Select(ToSavedMatch).ToList();
+
+            _session.OriginalRaceType = snap.OriginalRaceType;
+            _session.Resume = snap;
+
+            Logger.Log($"[SAVE][RESUME] phase='{snap.CurrentPhase}', original='{snap.OriginalRaceType}', " +
+                       $"main={snap.MainMatches.Count}, losers={snap.LosersMatches.Count}, " +
+                       $"rrTop3={snap.RrTop3Ids.Count}, activeRound='{snap.ActiveRound ?? "-"}', " +
+                       $"inLosers={snap.InLosersPhase}, finalsPending={snap.FinalsPending}");
+        }
+
+        private string InferResumePhase()
+        {
+            var rt = (_session.RaceType ?? string.Empty).Trim();
+            if (string.Equals(rt, RaceTypes.Finals, StringComparison.OrdinalIgnoreCase))
+                return "Finals";
+            if (_inLosersPhase || string.Equals(rt, RaceTypes.LosersBracket, StringComparison.OrdinalIgnoreCase))
+                return "LosersBracket";
+            return "Main";
+        }
+
+        // Instance (not static) so the inline result is read from the retained
+        // _matchResult — which still holds a phase's winners even after its matches
+        // have left the live engine (e.g. RR results during the LB/Finals phases).
+        //
+        // Gate on m.HasResult (the OWNING engine's own verdict) before trusting
+        // _matchResult: match-id spaces overlap across engines (RR 1..9 collide with
+        // the finals Pro-Ladder SF/F ids), so a blind _matchResult.GetWinner(id) lookup
+        // would stamp an unplayed finals match with a stale RR winner — which then
+        // replays on resume and marks the match resolved when it should still be pending.
+        private SavedMatch ToSavedMatch(EngineMatch m)
+        {
+            var w = m.HasResult ? _matchResult.GetWinner(m.MatchId) : null;
+            var l = m.HasResult ? _matchResult.GetLoser(m.MatchId) : null;
+            return new SavedMatch
+            {
+                MatchId = m.MatchId,
+                Driver1Id = m.Driver1?.Id,
+                Driver2Id = m.Driver2?.Id,
+                RoundLabel = m.RoundLabel,
+                FromMatch1 = m.FromMatch1,
+                FromMatch2 = m.FromMatch2,
+                WinnerId = w?.Id,
+                LoserId = l?.Id
+            };
         }
     }
 }

--- a/src/RCDragManagerProd/Controllers/RaceController.Resume.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Resume.cs
@@ -1,0 +1,368 @@
+// RaceController.Resume.cs
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.RaceEngines;
+using RCDragManagerProd.RandomMode;
+using RCDragManagerProd.Logging;
+
+namespace RCDragManagerProd.Controllers
+{
+    public partial class RaceController
+    {
+        /// <summary>
+        /// Rebuilds live engine/controller state from a saved <see cref="ResumeSnapshot"/>
+        /// so an interrupted event continues exactly where it left off. Call once, right
+        /// after constructing the controller for a loaded session.
+        ///
+        /// Deterministic brackets (Pro Ladder, Round Robin, Finals) are regenerated; the
+        /// non-deterministic ones (Random, Losers Bracket) are re-injected from the saved
+        /// structure so pairings are not re-randomised. Results are then replayed by driver
+        /// pair (not by raw MatchId) so a single path covers both reconstruction styles.
+        /// </summary>
+        public void RestoreFromSave()
+        {
+            if (_session?.Resume == null)
+            {
+                Logger.Log("[RESUME] No resume snapshot — nothing to restore (fresh or pre-feature session).");
+                return;
+            }
+
+            var snap = _session.Resume;
+            if (string.IsNullOrWhiteSpace(snap.OriginalRaceType) ||
+                snap.MainMatches == null || snap.MainMatches.Count == 0)
+            {
+                Logger.Log("[RESUME] Snapshot has no bracket structure — skipping restore.");
+                return;
+            }
+
+            Logger.Log($"[RESUME] Restoring phase='{snap.CurrentPhase}', original='{snap.OriginalRaceType}'.");
+
+            var roster = BuildResumeRoster();
+            _drivers = (_session.Drivers != null && _session.Drivers.Count > 0)
+                ? new List<Driver>(_session.Drivers)
+                : roster.Values.ToList();
+
+            // Snapshots / RR top-3 (consumed later by the Finals seeding + standings views).
+            if (snap.RrTop3Ids != null && snap.RrTop3Ids.Count > 0)
+                _rrTop3 = snap.RrTop3Ids.Where(roster.ContainsKey).Select(id => roster[id]).ToList();
+            if (snap.RrSnapshotMatches != null && snap.RrSnapshotMatches.Count > 0)
+                _rrMatchesSnapshot = snap.RrSnapshotMatches.Select(sm => ToEngineMatch(sm, roster)).ToList();
+            if (snap.RrSnapshotRoundOrder != null && snap.RrSnapshotRoundOrder.Count > 0)
+                _rrRoundOrderSnapshot = new List<string>(snap.RrSnapshotRoundOrder);
+
+            switch (snap.CurrentPhase)
+            {
+                case "Finals":
+                    RestoreFinalsEngine(snap, roster);
+                    break;
+                case "LosersBracket":
+                    RestoreLosersEngine(snap, roster);
+                    break;
+                default:
+                    RestoreMainEngine(snap, roster);
+                    break;
+            }
+
+            if (_engine == null)
+            {
+                Logger.Log("[RESUME][ERROR] Engine reconstruction failed — aborting restore.");
+                return;
+            }
+
+            // Revealed rounds + transient flags.
+            _revealedRounds.Clear();
+            foreach (var r in (_session.SavedRevealedRounds ?? new List<string>()))
+                _revealedRounds.Add(RoundLabels.Normalize(r));
+
+            _activeRound = string.IsNullOrWhiteSpace(snap.ActiveRound) ? null : snap.ActiveRound;
+            _inLosersPhase = snap.InLosersPhase;
+            _finalsPending = snap.FinalsPending;
+            _buybackChampionOverride =
+                (snap.BuybackChampionOverrideId is int bid && roster.ContainsKey(bid)) ? roster[bid] : null;
+
+            Logger.Log($"[RESUME] Reconstructed: engine={_engine.GetType().Name}, losers={_losersEngine?.GetType().Name ?? "null"}, " +
+                       $"revealed=[{string.Join(",", _revealedRounds)}], activeRound='{_activeRound ?? "-"}', " +
+                       $"winners={_winners.Count}, finalsPending={_finalsPending}.");
+
+            // Single refresh so the UI shows the resumed bracket and the correct next action.
+            PushFullRefresh();
+            if (_finalsPending)
+                CanStartFinalsChanged?.Invoke(true);
+        }
+
+        // ── phase reconstructors ─────────────────────────────────────────────
+
+        private void RestoreMainEngine(ResumeSnapshot snap, Dictionary<int, Driver> roster)
+        {
+            _engine = RaceEngineFactory.Create(snap.OriginalRaceType);
+
+            EngineLoadDrivers(_engine, _drivers);
+
+            if (_engine is RandomEngineAdapter rnd)
+            {
+                // Random is non-deterministic — re-inject the exact saved pairings.
+                rnd.InjectMatches(ToRandomMatches(snap.MainMatches, roster));
+                Logger.Log($"[RESUME][MAIN] Re-injected {snap.MainMatches.Count} Random match(es).");
+            }
+            else if (_engine is RoundRobinEngineAdapter rr)
+            {
+                // Round Robin shuffles + random-rotates on generation, so it is just as
+                // non-deterministic as Random — re-inject the saved schedule verbatim.
+                rr.InjectMatches(ToEngineMatches(snap.MainMatches, roster));
+                Logger.Log($"[RESUME][MAIN] Re-injected {snap.MainMatches.Count} Round Robin match(es).");
+            }
+            else
+            {
+                // Pro Ladder regenerates deterministically (seeded by qual time).
+                EngineGenerateBracket(_engine);
+                Logger.Log("[RESUME][MAIN] Regenerated deterministic bracket.");
+            }
+
+            ReplayResults(_engine, snap.MainMatches, roster);
+        }
+
+        private void RestoreLosersEngine(ResumeSnapshot snap, Dictionary<int, Driver> roster)
+        {
+            // In the LB phase the active engine IS the losers engine. Prefer the dedicated
+            // LosersMatches structure, falling back to MainMatches (when _engine == _losersEngine
+            // at save time both held the same LB structure).
+            var lbStructure = (snap.LosersMatches != null && snap.LosersMatches.Count > 0)
+                ? snap.LosersMatches
+                : snap.MainMatches;
+
+            var lbDrivers = (_session.BuybackDrivers != null && _session.BuybackDrivers.Count > 0)
+                ? new List<Driver>(_session.BuybackDrivers)
+                : DistinctDriversFrom(lbStructure, roster);
+
+            var lb = new RandomEngineAdapter();
+            EngineLoadDrivers(lb, lbDrivers, "LB-R1");
+            lb.InjectMatches(ToRandomMatches(lbStructure, roster));
+
+            _losersEngine = lb;
+            _engine = lb;
+
+            ReplayRrHistory(roster);          // RR rows are shown from the snapshot — re-seed their winners.
+            ReplayResults(lb, lbStructure, roster);
+            Logger.Log($"[RESUME][LB] Re-injected {lbStructure.Count} LB match(es); drivers={lbDrivers.Count}.");
+        }
+
+        private void RestoreFinalsEngine(ResumeSnapshot snap, Dictionary<int, Driver> roster)
+        {
+            // The Finals Pro Ladder is deterministic from its finalists. The finalists are
+            // exactly the drivers in the saved finals structure, so regenerate from them and
+            // replay — no need to re-derive the LB champion.
+            var finalists = DistinctDriversFrom(snap.MainMatches, roster);
+            if (finalists.Count < 2)
+            {
+                Logger.Log("[RESUME][FINALS][ERROR] Could not resolve finalists from saved structure.");
+                return;
+            }
+
+            // Reconstruct the losers engine too (if it existed) so post-finals standings/summary
+            // that read the LB champion still resolve.
+            if (snap.LosersMatches != null && snap.LosersMatches.Count > 0)
+            {
+                var lbDrivers = (_session.BuybackDrivers != null && _session.BuybackDrivers.Count > 0)
+                    ? new List<Driver>(_session.BuybackDrivers)
+                    : DistinctDriversFrom(snap.LosersMatches, roster);
+                var lb = new RandomEngineAdapter();
+                EngineLoadDrivers(lb, lbDrivers, "LB-R1");
+                lb.InjectMatches(ToRandomMatches(snap.LosersMatches, roster));
+                _losersEngine = lb;
+                ReplayResults(lb, snap.LosersMatches, roster);
+            }
+
+            var pro = new ProLadderEngineAdapter();
+            EngineLoadDrivers(pro, finalists);
+            EngineGenerateBracket(pro);
+            _engine = pro;
+
+            ReplayRrHistory(roster);          // RR rows are shown from the snapshot — re-seed their winners.
+            ReplayResults(pro, snap.MainMatches, roster);
+            Logger.Log($"[RESUME][FINALS] Regenerated Pro Ladder finals; finalists={finalists.Count}.");
+        }
+
+        // ── replay ───────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Applies saved winners onto a freshly built engine. Matches are located by
+        /// (round label + unordered driver pair) rather than raw MatchId, and applied in
+        /// round order with a re-fetch each step so elimination brackets populate their
+        /// later rounds as earlier winners advance.
+        /// </summary>
+        private void ReplayResults(IRaceEngine engine, List<SavedMatch> structure, Dictionary<int, Driver> roster)
+        {
+            if (engine == null || structure == null) return;
+
+            var ordered = structure
+                .Where(sm => sm.WinnerId is int)
+                .OrderBy(sm => RoundLabels.CompareKey(sm.RoundLabel ?? string.Empty))
+                .ThenBy(sm => sm.MatchId)
+                .ToList();
+
+            foreach (var sm in ordered)
+            {
+                if (!roster.TryGetValue(sm.WinnerId.Value, out var winner) || winner == null)
+                    continue;
+                Driver loser = (sm.LoserId is int lid && roster.TryGetValue(lid, out var l)) ? l : null;
+
+                var live = EngineGetMatches(engine).ToList();
+                var lm = FindLiveMatch(live, sm);
+                if (lm == null)
+                {
+                    Logger.Log($"[RESUME][REPLAY][WARN] No live match for saved M{sm.MatchId} ({sm.RoundLabel}); skipping.");
+                    continue;
+                }
+
+                EngineSetWinner(engine, lm.MatchId, winner, lm.RoundLabel);
+                _matchResult.SetWinner(lm.MatchId, winner, loser);
+                _winners.Add(new ViewModels.WinnerRow
+                {
+                    MatchId = lm.MatchId,
+                    RoundLabel = lm.RoundLabel,
+                    Winner = winner.Name,
+                    Loser = loser?.Name ?? "BYE"
+                });
+            }
+        }
+
+        /// <summary>
+        /// Replays the Round Robin history into <see cref="_matchResult"/> during the LB/Finals
+        /// phases. Those RR matches are no longer in any live engine (the engine was swapped to
+        /// LB then Finals), but the bracket view renders them from <see cref="_rrMatchesSnapshot"/>
+        /// and reads their winners from <see cref="_matchResult"/> by the original RR match id —
+        /// so the results must be re-seeded directly, with no engine round-trip.
+        /// </summary>
+        private void ReplayRrHistory(Dictionary<int, Driver> roster)
+        {
+            var rr = _session.Resume?.RrSnapshotMatches;
+            if (rr == null) return;
+
+            foreach (var sm in rr.Where(m => m.WinnerId is int))
+            {
+                if (!roster.TryGetValue(sm.WinnerId.Value, out var winner) || winner == null)
+                    continue;
+                Driver loser = (sm.LoserId is int lid && roster.TryGetValue(lid, out var l)) ? l : null;
+
+                _matchResult.SetWinner(sm.MatchId, winner, loser);
+                _winners.Add(new ViewModels.WinnerRow
+                {
+                    MatchId = sm.MatchId,
+                    RoundLabel = sm.RoundLabel,
+                    Winner = winner.Name,
+                    Loser = loser?.Name ?? "BYE"
+                });
+            }
+        }
+
+        private static EngineMatch FindLiveMatch(List<EngineMatch> live, SavedMatch sm)
+        {
+            var round = RoundLabels.Normalize(sm.RoundLabel ?? string.Empty);
+            return live.FirstOrDefault(m =>
+                string.Equals(RoundLabels.Normalize(m.RoundLabel ?? string.Empty), round, StringComparison.OrdinalIgnoreCase) &&
+                SamePair(m.Driver1?.Id, m.Driver2?.Id, sm.Driver1Id, sm.Driver2Id));
+        }
+
+        private static bool SamePair(int? aId1, int? aId2, int? bId1, int? bId2)
+        {
+            return (aId1 == bId1 && aId2 == bId2) || (aId1 == bId2 && aId2 == bId1);
+        }
+
+        // ── helpers ──────────────────────────────────────────────────────────
+
+        private Dictionary<int, Driver> BuildResumeRoster()
+        {
+            var map = new Dictionary<int, Driver>();
+
+            void Add(Driver d)
+            {
+                if (d == null || d.Id == 0) return;
+                if (!map.ContainsKey(d.Id)) map[d.Id] = d;
+            }
+
+            if (_session.Drivers != null)
+                foreach (var d in _session.Drivers) Add(d);
+            if (_session.BuybackDrivers != null)
+                foreach (var d in _session.BuybackDrivers) Add(d);
+            if (_session.TopDriversSnapshot != null)
+                foreach (var d in _session.TopDriversSnapshot) Add(d);
+
+            // Fallback: reconstruct any driver only present in the entry list.
+            if (_session.DriverEntries != null)
+            {
+                foreach (var e in _session.DriverEntries)
+                {
+                    if (e == null || e.DriverID == 0 || map.ContainsKey(e.DriverID)) continue;
+                    map[e.DriverID] = new Driver
+                    {
+                        Id = e.DriverID,
+                        Name = e.DriverName,
+                        QualTime = e.QualifyingTime
+                    };
+                }
+            }
+
+            return map;
+        }
+
+        private static List<Driver> DistinctDriversFrom(List<SavedMatch> structure, Dictionary<int, Driver> roster)
+        {
+            var seen = new HashSet<int>();
+            var list = new List<Driver>();
+            foreach (var sm in structure.OrderBy(s => RoundLabels.CompareKey(s.RoundLabel ?? string.Empty)).ThenBy(s => s.MatchId))
+            {
+                foreach (var id in new[] { sm.Driver1Id, sm.Driver2Id })
+                {
+                    if (id is int v && v != 0 && seen.Add(v) && roster.TryGetValue(v, out var d))
+                        list.Add(d);
+                }
+            }
+            return list;
+        }
+
+        private List<RandomMatch> ToRandomMatches(List<SavedMatch> structure, Dictionary<int, Driver> roster)
+        {
+            return structure
+                .OrderBy(sm => RoundLabels.CompareKey(sm.RoundLabel ?? string.Empty))
+                .ThenBy(sm => sm.MatchId)
+                .Select(sm => new RandomMatch
+                {
+                    MatchId = sm.MatchId,
+                    Seed1 = ResolveDriver(sm.Driver1Id, roster),
+                    Seed2 = ResolveDriver(sm.Driver2Id, roster),
+                    RoundLabel = sm.RoundLabel,
+                    FromMatch1 = sm.FromMatch1,
+                    FromMatch2 = sm.FromMatch2
+                })
+                .ToList();
+        }
+
+        private static EngineMatch ToEngineMatch(SavedMatch sm, Dictionary<int, Driver> roster) => new EngineMatch
+        {
+            MatchId = sm.MatchId,
+            Driver1 = ResolveDriver(sm.Driver1Id, roster),
+            Driver2 = ResolveDriver(sm.Driver2Id, roster),
+            RoundLabel = sm.RoundLabel,
+            FromMatch1 = sm.FromMatch1,
+            FromMatch2 = sm.FromMatch2
+        };
+
+        private static List<EngineMatch> ToEngineMatches(List<SavedMatch> structure, Dictionary<int, Driver> roster)
+        {
+            return (structure ?? new List<SavedMatch>())
+                .OrderBy(sm => RoundLabels.CompareKey(sm.RoundLabel ?? string.Empty))
+                .ThenBy(sm => sm.MatchId)
+                .Select(sm => ToEngineMatch(sm, roster))
+                .ToList();
+        }
+
+        private static Driver ResolveDriver(int? id, Dictionary<int, Driver> roster)
+        {
+            if (id is int v && v != 0 && roster.TryGetValue(v, out var d)) return d;
+            return null;
+        }
+    }
+}

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -48,6 +48,11 @@ namespace RCDragManagerProd.Controllers
             }
             _session.RaceType = rt;
 
+            // Capture the starting mode exactly once — RaceType mutates during the event,
+            // but resume needs the original to regenerate the initial bracket.
+            if (string.IsNullOrWhiteSpace(_session.OriginalRaceType))
+                _session.OriginalRaceType = rt;
+
             Logger.Log($"[CTRL][DEBUG] GenerateBracket inputs ? raceTypeArg='{raceType}', rt='{rt}', session.RaceType='{_session.RaceType}', RRVariant='{_session.RoundRobinVariant}', N={_session.RoundsToRun}");
 
 

--- a/src/RCDragManagerProd/Domain/RaceSession.cs
+++ b/src/RCDragManagerProd/Domain/RaceSession.cs
@@ -17,6 +17,15 @@ namespace RCDragManagerProd.Domain
         public string ClassType { get; set; }
         public double? FixedDialIn { get; set; }
 
+        // The mode the event STARTED in. Unlike RaceType (which mutates to
+        // "Losers Bracket"/"Finals" during the event) this is set once and never
+        // changes, so resume can regenerate the original bracket.
+        public string OriginalRaceType { get; set; }
+
+        // Bracket-structure + phase snapshot for resuming an interrupted event.
+        // Null on pre-feature saves or before a bracket is generated.
+        public ResumeSnapshot Resume { get; set; }
+
         // -----------------------------
         // Round Robin configuration
         // -----------------------------

--- a/src/RCDragManagerProd/Domain/ResumeSnapshot.cs
+++ b/src/RCDragManagerProd/Domain/ResumeSnapshot.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+namespace RCDragManagerProd.Domain
+{
+    /// <summary>
+    /// Persisted bracket structure for one match, captured so a saved event can be
+    /// resumed WITHOUT regenerating non-deterministic brackets (Random / Losers Bracket).
+    /// Driver ids only — resolved back to <see cref="Driver"/> from the session roster on load.
+    /// Plain POCO so System.Text.Json round-trips it without custom converters.
+    /// </summary>
+    public sealed class SavedMatch
+    {
+        public int MatchId { get; set; }
+        public int? Driver1Id { get; set; }   // null = empty slot / BYE
+        public int? Driver2Id { get; set; }
+        public string RoundLabel { get; set; }
+        public int? FromMatch1 { get; set; }
+        public int? FromMatch2 { get; set; }
+
+        // Result carried inline with the structure so each persisted bracket is
+        // self-contained. This is essential once a phase's matches leave the live
+        // engine (RR after the LB/Finals swap) and once match-id spaces overlap
+        // across engines (RR vs Finals Pro Ladder) — a single global result map
+        // keyed by match id would lose or alias those results. null = unplayed.
+        public int? WinnerId { get; set; }
+        public int? LoserId { get; set; }
+    }
+
+    /// <summary>
+    /// Everything needed to reconstruct live engine state for an interrupted event.
+    /// Results themselves live in <see cref="RaceSession.SavedResults"/>; this snapshot
+    /// captures the bracket STRUCTURE (which the existing save path did not persist) plus
+    /// the transient controller state that drives phase transitions.
+    /// Null on sessions saved before this feature, or before a bracket was generated.
+    /// </summary>
+    public sealed class ResumeSnapshot
+    {
+        // The mode the event STARTED in (RaceType mutates to "Losers Bracket"/"Finals"
+        // mid-event, so it cannot be used to regenerate the initial bracket).
+        public string OriginalRaceType { get; set; }
+
+        // "Main" (single-engine: RR/Random/Pro Ladder), "LosersBracket", or "Finals".
+        public string CurrentPhase { get; set; }
+
+        public List<SavedMatch> MainMatches { get; set; } = new List<SavedMatch>();
+        public List<SavedMatch> LosersMatches { get; set; } = new List<SavedMatch>();
+
+        // RR completion snapshot — required to seed the Finals once the LB resolves.
+        public List<int> RrTop3Ids { get; set; } = new List<int>();
+        public List<SavedMatch> RrSnapshotMatches { get; set; } = new List<SavedMatch>();
+        public List<string> RrSnapshotRoundOrder { get; set; } = new List<string>();
+
+        // Transient controller flags.
+        public int? BuybackChampionOverrideId { get; set; }
+        public bool FinalsPending { get; set; }
+        public bool InLosersPhase { get; set; }
+        public string ActiveRound { get; set; }
+    }
+}

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Controllers\RaceController.Logging.cs" />
     <Compile Include="Controllers\RaceController.EngineCalls.cs" />
     <Compile Include="Controllers\RaceController.Persistence.cs" />
+    <Compile Include="Controllers\RaceController.Resume.cs" />
     <Compile Include="Controllers\RaceController.Results.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Core.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Finals.cs" />
@@ -293,6 +294,7 @@
     <Compile Include="RaceEngines\RandomEngineAdapter.cs" />
     <Compile Include="RaceEngines\RoundRobinEngineAdapter.cs" />
     <Compile Include="Domain\RaceSession.cs" />
+    <Compile Include="Domain\ResumeSnapshot.cs" />
     <Compile Include="Repositories\RaceSessionRepository.cs" />
     <Compile Include="UI\Forms\Common\SettingsForm.cs">
       <SubType>Form</SubType>

--- a/src/RCDragManagerProd/RaceEngines/RoundRobinEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/RoundRobinEngineAdapter.cs
@@ -47,6 +47,16 @@ namespace RCDragManagerProd.RaceEngines
             Logger.Log("[RR-ADAPTER] Engine reset.");
         }
 
+        // Resume path: re-inject a previously-saved schedule instead of regenerating
+        // (RR generation shuffles, so it cannot reproduce the saved pairings).
+        public void InjectMatches(IReadOnlyList<EngineMatch> matches)
+        {
+            Logger.Log($"[ENGINE-API] {GetType().Name}.InjectMatches(count={matches?.Count ?? 0})");
+            _engine.InjectMatches(
+                (matches ?? new List<EngineMatch>())
+                    .Select(m => (m.MatchId, m.Driver1, m.Driver2, m.RoundLabel)));
+        }
+
         public IReadOnlyList<EngineMatch> GetMatches()
         {
             Logger.Log($"[ENGINE-API] {GetType().Name}.GetMatches()");

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
@@ -192,6 +192,28 @@ namespace RCDragManagerProd.RoundRobinMode
                           .ToList();
         }
 
+        /// <summary>
+        /// Replaces the generated schedule with an explicit one. Required for resume:
+        /// <see cref="GenerateMatches"/> shuffles and random-rotates the roster, so it
+        /// cannot reproduce a previously-saved schedule — the saved pairings must be
+        /// re-injected verbatim instead.
+        /// </summary>
+        public void InjectMatches(IEnumerable<(int MatchId, Driver D1, Driver D2, string RoundLabel)> injected)
+        {
+            matches.Clear();
+            results = new MatchResult();
+
+            int maxId = 0;
+            foreach (var m in injected ?? Enumerable.Empty<(int, Driver, Driver, string)>())
+            {
+                matches.Add((m.D1, m.D2, m.RoundLabel, m.MatchId));
+                if (m.MatchId > maxId) maxId = m.MatchId;
+            }
+
+            matchIdCounter = maxId + 1;
+            Log($"[RR] InjectMatches: loaded {matches.Count} match(es); next id={matchIdCounter}.");
+        }
+
         public bool TryGetMatch(int matchId, out Driver driver1, out Driver driver2, out string roundLabel)
         {
             var match = matches.FirstOrDefault(m => m.MatchId == matchId);

--- a/src/RCDragManagerProd/UI/Forms/Main/MultiClassRaceForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/MultiClassRaceForm.cs
@@ -58,6 +58,27 @@ namespace RCDragManagerProd.UI.Forms
             BuildTabs();
         }
 
+        private bool _resumeApplied;
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+
+            // Replay any saved bracket state once the tabs (and their Form1 event
+            // subscriptions) exist, so an interrupted event resumes where it left off.
+            // No-ops for fresh events (no resume snapshot).
+            if (_resumeApplied) return;
+            _resumeApplied = true;
+
+            foreach (var controller in _controllers)
+            {
+                try { controller.RestoreFromSave(); }
+                catch (Exception ex) { Logger.Log($"[RESUME][ERROR] {ex}"); }
+            }
+
+            UpdateAllTabStates();
+        }
+
         private void SubscribeToController(RaceController controller, int classIndex)
         {
             controller.CanOfferBuybackChanged += (enabled) =>


### PR DESCRIPTION
Closes #294

## Summary
Full save / resume / recovery for interrupted events — restores live state across **every** phase: Round Robin → buyback → Losers Bracket → Finals (engine swaps, buyback reconstruction, dynamic match ids).

- **Persist structure, not just results.** `SaveSession` now captures a `ResumeSnapshot` holding each engine's generated bracket (main + losers), the RR top-3 snapshot, the original race type, and transient phase flags. Per-`SavedMatch` winners are carried **inline** so each persisted structure is self-contained.
- **Phase-aware reconstruction.** `RestoreFromSave` rebuilds the right engine for the saved phase. Non-deterministic brackets (Round Robin, Random, Losers Bracket) are **re-injected verbatim** — their generation shuffles, so regenerating would change the pairings. Pro Ladder regenerates deterministically. Results are replayed by `(round + driver pair)` so one path covers both styles.
- **Cross-engine id-collision fix.** Match-id spaces overlap across engines (RR `1..9` collide with the finals Pro-Ladder SF/F ids). `ToSavedMatch` now gates the inline winner on the **owning engine's** `HasResult`, so an unplayed finals match can't inherit a completed RR winner from the shared `MatchResult` and surface as already-resolved on resume.
- **Load-path wiring.** `MultiClassRaceForm` replays saved state in `OnShown`, after tabs/subscriptions exist; no-ops for fresh events.

## Test plan
- [x] New `RaceControllerResumeTests` — button-free, saves → round-trips through the **real** SQLite repository → restores into a fresh controller → asserts identical bracket structure, recorded results, and pending matches.
- [x] Covers five save points across all phases & bracket types: setup (no bracket), Pro Ladder (post-bracket / mid-round / between-rounds / post-finals), Random (re-injection preserves exact pairings), Round Robin mid-event, and multi-phase Losers Bracket + Finals.
- [x] Full suite green: 172 passed, 11 skipped (pre-existing), 0 failed.
- [x] Production solution builds clean via MSBuild (.NET Framework 4.8).
