### PR TITLE
test: #304 — save/resume/close coverage + Save-vs-Close split

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerSaveCloseTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerSaveCloseTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.RandomMode;
+using RCDragManagerProd.Repositories;
+using RCDragManagerProd.Tests.Helpers;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Button-free coverage for issue #304 — the Save Progress vs Close Race distinction
+/// (issue #255). These prove the two operator actions are NOT interchangeable:
+///
+///   • Save Progress persists a resumable checkpoint and leaves the race OPEN
+///     (IsClosed == false, a resume snapshot is written, and the state restores).
+///   • Close Race marks the event FINISHED (IsClosed == true) without, by itself,
+///     capturing a resumable in-progress checkpoint.
+///
+/// Each test drives a controller to an identical mid-event state, applies the action,
+/// round-trips the session through the REAL SQLite repository, and inspects the loaded
+/// session — exactly the persistence path the app uses.
+///
+/// The remaining #304 acceptance criteria (save at every event stage + full resume of
+/// round/bracket/driver/results/next-action) are covered by RaceControllerResumeTests.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class RaceControllerSaveCloseTests
+{
+    [TestInitialize]
+    public void ResetStatics() => RandomBracket.ResetByeTracker();
+
+    [TestMethod]
+    public void SaveProgress_OnInProgressRace_PersistsResumableCheckpoint()
+    {
+        var (session, controller) = NewMidEventRace();
+
+        controller.SaveProgress();
+        var loaded = Persist(session);
+
+        Assert.IsFalse(loaded.IsClosed, "Save Progress must leave the race open (resumable)");
+        Assert.IsNotNull(loaded.Resume, "Save Progress must capture a resume snapshot");
+
+        var restored = new RaceController(loaded, new NoOpStandingsDialogService());
+        restored.RestoreFromSave();
+        Assert.IsTrue(restored.HasBracketStarted, "Saved in-progress race must restore its bracket");
+        Assert.IsTrue(restored.PeekUpcomingMatches(10).Count > 0,
+            "A mid-event Save Progress must restore with pending matches still to run");
+    }
+
+    [TestMethod]
+    public void CloseRace_MarksEventComplete()
+    {
+        var (session, controller) = NewMidEventRace();
+
+        controller.CloseRace();
+        var loaded = Persist(session);
+
+        Assert.IsTrue(loaded.IsClosed, "Close Race must mark the event finished");
+    }
+
+    [TestMethod]
+    public void SaveProgress_AndCloseRace_AreNotTheSameAction()
+    {
+        var (saveSession, saveController) = NewMidEventRace();
+        var (closeSession, closeController) = NewMidEventRace();
+
+        saveController.SaveProgress();
+        closeController.CloseRace();
+
+        var saved = Persist(saveSession);
+        var closed = Persist(closeSession);
+
+        // The defining difference: Save keeps the race resumable/open; Close ends it.
+        Assert.AreNotEqual(saved.IsClosed, closed.IsClosed,
+            "Save Progress and Close Race must not record the same race state");
+        Assert.IsFalse(saved.IsClosed, "Save Progress leaves the race open");
+        Assert.IsTrue(closed.IsClosed, "Close Race marks the race finished");
+        Assert.IsNotNull(saved.Resume, "Only Save Progress writes a resumable checkpoint");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>Pro Ladder generated and one semifinal resolved — a genuine in-progress event.</summary>
+    private static (RaceSession session, RaceController controller) NewMidEventRace()
+    {
+        var session = NewSession("Pro Ladder");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderPack());
+
+        var first = controller.PeekUpcomingMatches(10).First();
+        controller.SubmitWinner(first.MatchId, firstOption: true);
+        return (session, controller);
+    }
+
+    private static RaceSession NewSession(string raceType) => new RaceSession
+    {
+        EventName = "QA SaveClose " + raceType,
+        EventDate = new DateTime(2026, 6, 8, 9, 0, 0),
+        RaceType = raceType,
+        ClassType = "Heads Up"
+    };
+
+    /// <summary>Round-trips the session through the real repository and returns the loaded copy.</summary>
+    private static RaceSession Persist(RaceSession session)
+    {
+        using var db = new TempDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+
+        var id = repo.SaveSession(session);
+        var loaded = repo.LoadSession(id);
+        Assert.IsNotNull(loaded, "Session must load back from the repository");
+        return loaded;
+    }
+
+    private sealed class TempDb : IDisposable
+    {
+        public TempDb() =>
+            DatabasePath = Path.Combine(Path.GetTempPath(), $"rcdragmanager-saveclose-{Guid.NewGuid():N}.db");
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try { if (File.Exists(DatabasePath)) File.Delete(DatabasePath); }
+            catch { /* best-effort */ }
+        }
+    }
+}

--- a/src/RCDragManagerProd/Controllers/RaceController.SaveClose.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.SaveClose.cs
@@ -1,0 +1,49 @@
+// RaceController.SaveClose.cs
+using RCDragManagerProd.Logging;
+
+namespace RCDragManagerProd.Controllers
+{
+    public partial class RaceController
+    {
+        // Save Progress and Close Race are DISTINCT operator intents (issue #255). They
+        // are deliberately NOT interchangeable, and the split exists so an operator can
+        // always tell whether an interrupted event is safely resumable:
+        //
+        //   • SaveProgress() captures a resumable checkpoint of an in-progress event so it
+        //     can be reopened later — rain delay, power loss, a paused meet. The race stays
+        //     OPEN: IsClosed is cleared and a full resume snapshot is written (see
+        //     SaveSession / CaptureResumeSnapshot, issue #294).
+        //
+        //   • CloseRace() records that the event is FINISHED and the operator is done with
+        //     this console. Per #255 it does not, by itself, imply saving a resumable
+        //     checkpoint — it only marks completion (IsClosed = true).
+
+        /// <summary>
+        /// Persists a resumable checkpoint of the current in-progress event. The race
+        /// remains open and can be restored later via <see cref="RestoreFromSave"/>.
+        /// </summary>
+        public void SaveProgress()
+        {
+            SaveSession();
+            if (_session != null) _session.IsClosed = false;
+            Logger.Log("[SAVE] SaveProgress — resumable checkpoint captured (race remains open).");
+        }
+
+        /// <summary>
+        /// Marks the event finished (operator is done with this console). Unlike
+        /// <see cref="SaveProgress"/> this does not capture a resumable in-progress
+        /// checkpoint; it only records completion.
+        /// </summary>
+        public void CloseRace()
+        {
+            if (_session == null)
+            {
+                Logger.Log("[CLOSE] CloseRace — no active session.");
+                return;
+            }
+
+            _session.IsClosed = true;
+            Logger.Log("[CLOSE] CloseRace — event marked complete (not a resumable checkpoint).");
+        }
+    }
+}

--- a/src/RCDragManagerProd/Domain/RaceSession.cs
+++ b/src/RCDragManagerProd/Domain/RaceSession.cs
@@ -26,6 +26,11 @@ namespace RCDragManagerProd.Domain
         // Null on pre-feature saves or before a bracket is generated.
         public ResumeSnapshot Resume { get; set; }
 
+        // True once the operator has CLOSED the race (event finished / done with the
+        // console). Distinct from a Save Progress checkpoint, which leaves the race open
+        // and resumable. See issue #255 (Save Progress vs Close Race) and #294 (resume).
+        public bool IsClosed { get; set; }
+
         // -----------------------------
         // Round Robin configuration
         // -----------------------------

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Controllers\RaceController.EngineCalls.cs" />
     <Compile Include="Controllers\RaceController.Persistence.cs" />
     <Compile Include="Controllers\RaceController.Resume.cs" />
+    <Compile Include="Controllers\RaceController.SaveClose.cs" />
     <Compile Include="Controllers\RaceController.Results.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Core.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Finals.cs" />


### PR DESCRIPTION
## What & why

Closes #304 — automated coverage for save / resume / close / recovery workflows.

Most of #304's acceptance criteria were already satisfied by the resume suite
merged with #294 (`RaceControllerResumeTests` — 10 button-free tests covering
save at every event stage and full resume of round/bracket/driver/results/
next-action across Round Robin → buyback → Losers Bracket → Finals).

The one criterion not yet covered was **"Close Race does not mean the same
thing as Save Progress."** That distinction is the testable core of #255
(Save Progress vs Close Race), which is still open. Rather than touch `Form1`'s
fused Save-and-Close button (out of scope here, left for #255's UI work), this
PR adds the distinction at the controller/persistence layer so it can be
proven by tests today.

## Changes

- **`RaceSession.IsClosed`** — new persisted flag. `true` once the operator has
  CLOSED the event (done with the console); a Save Progress checkpoint leaves it
  `false` so the race stays resumable. Persists automatically via the existing
  SessionData JSON blob.
- **`RaceController.SaveClose.cs`** (new partial) — `SaveProgress()` captures a
  resumable checkpoint and keeps the race open; `CloseRace()` marks the event
  finished without, by itself, capturing an in-progress checkpoint.
- **`RaceControllerSaveCloseTests.cs`** (new, button-free) — drives a controller
  to an identical mid-event state, applies each action, round-trips through the
  REAL SQLite repository, and asserts the two actions record different race
  state (Save → open + resume snapshot; Close → finished).

## Verification

- Production build: clean (only the pre-existing CS0618 warning).
- Full suite: **175 passed / 11 skipped (pre-existing multi-class gates) / 0 failed.**

## Notes

- Additive only — no existing tests changed, no engines/`RaceSessionRepository`
  modified. `Form1`'s Save-and-Close button is intentionally untouched and
  remains tracked under #255.
