### PR TITLE
feat: #255 — split Save Progress and Close Race actions

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Designer.cs
@@ -56,7 +56,8 @@ namespace RCDragManagerProd.UI.Forms
         private Button btnStandings;
         private Button btnGenerateLosersBracket;
         private Button btnShowQRCode;
-        private Button btnSaveAndClose;
+        private Button btnSaveProgress;
+        private Button btnCloseRace;
 
         // Bottom bar
         private TableLayoutPanel tlpBottom;
@@ -110,7 +111,8 @@ namespace RCDragManagerProd.UI.Forms
             this.btnStandings = new System.Windows.Forms.Button();
             this.btnGenerateLosersBracket = new System.Windows.Forms.Button();
             this.btnShowQRCode = new System.Windows.Forms.Button();
-            this.btnSaveAndClose = new System.Windows.Forms.Button();
+            this.btnSaveProgress = new System.Windows.Forms.Button();
+            this.btnCloseRace = new System.Windows.Forms.Button();
             this.pnlLeft = new System.Windows.Forms.Panel();
             this.lvDrivers = new System.Windows.Forms.ListView();
             this.colName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -427,18 +429,20 @@ namespace RCDragManagerProd.UI.Forms
             this.tlpRail.Controls.Add(this.btnStandings, 0, 2);
             this.tlpRail.Controls.Add(this.btnGenerateLosersBracket, 0, 3);
             this.tlpRail.Controls.Add(this.btnShowQRCode, 0, 4);
-            this.tlpRail.Controls.Add(this.btnSaveAndClose, 0, 6);
+            this.tlpRail.Controls.Add(this.btnSaveProgress, 0, 6);
+            this.tlpRail.Controls.Add(this.btnCloseRace, 0, 7);
             this.tlpRail.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpRail.Location = new System.Drawing.Point(0, 20);
             this.tlpRail.Margin = new System.Windows.Forms.Padding(0);
             this.tlpRail.Name = "tlpRail";
-            this.tlpRail.RowCount = 7;
+            this.tlpRail.RowCount = 8;
             this.tlpRail.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
             this.tlpRail.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
             this.tlpRail.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
             this.tlpRail.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
             this.tlpRail.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
             this.tlpRail.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpRail.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
             this.tlpRail.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
             this.tlpRail.Size = new System.Drawing.Size(116, 321);
             this.tlpRail.TabIndex = 0;
@@ -499,17 +503,28 @@ namespace RCDragManagerProd.UI.Forms
             this.btnShowQRCode.TabIndex = 24;
             this.btnShowQRCode.Text = "Show QR Code";
             this.btnShowQRCode.Click += new System.EventHandler(this.btnShowQRCode_Click);
-            // 
-            // btnSaveAndClose
-            // 
-            this.btnSaveAndClose.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.btnSaveAndClose.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnSaveAndClose.Location = new System.Drawing.Point(3, 274);
-            this.btnSaveAndClose.Name = "btnSaveAndClose";
-            this.btnSaveAndClose.Size = new System.Drawing.Size(110, 44);
-            this.btnSaveAndClose.TabIndex = 22;
-            this.btnSaveAndClose.Text = "Save and Close";
-            this.btnSaveAndClose.Click += new System.EventHandler(this.btnSaveAndClose_Click);
+            //
+            // btnSaveProgress
+            //
+            this.btnSaveProgress.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.btnSaveProgress.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnSaveProgress.Location = new System.Drawing.Point(3, 274);
+            this.btnSaveProgress.Name = "btnSaveProgress";
+            this.btnSaveProgress.Size = new System.Drawing.Size(110, 44);
+            this.btnSaveProgress.TabIndex = 22;
+            this.btnSaveProgress.Text = "Save Progress";
+            this.btnSaveProgress.Click += new System.EventHandler(this.btnSaveProgress_Click);
+            //
+            // btnCloseRace
+            //
+            this.btnCloseRace.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.btnCloseRace.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnCloseRace.Location = new System.Drawing.Point(3, 324);
+            this.btnCloseRace.Name = "btnCloseRace";
+            this.btnCloseRace.Size = new System.Drawing.Size(110, 44);
+            this.btnCloseRace.TabIndex = 25;
+            this.btnCloseRace.Text = "Close Race";
+            this.btnCloseRace.Click += new System.EventHandler(this.btnCloseRace_Click);
             // 
             // pnlLeft
             // 

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -324,7 +324,28 @@ namespace RCDragManagerProd.UI.Forms
             btnStandings.Enabled = false;
         }
 
-        private void btnSaveAndClose_Click(object sender, EventArgs e)
+        // Save Progress and Close Race are distinct operator actions (issue #255).
+        // Save Progress persists a resumable checkpoint and KEEPS the console open;
+        // Close Race finalises the event and leaves the console. They share the
+        // persistence path below so both write through the same repositories.
+
+        private void btnSaveProgress_Click(object sender, EventArgs e)
+        {
+            if (currentSession == null)
+            {
+                MessageBox.Show("Quick Session has no saved file to update.", "Nothing to Save",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            _controller.SaveProgress();   // captures a resumable checkpoint, keeps race open
+            PersistSession();
+
+            MessageBox.Show("Race progress saved. You can resume this race later.", "Progress Saved",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        private void btnCloseRace_Click(object sender, EventArgs e)
         {
             if (currentSession == null)
             {
@@ -333,7 +354,28 @@ namespace RCDragManagerProd.UI.Forms
                 return;
             }
 
-            _controller.SaveSession();
+            var confirm = MessageBox.Show(
+                "Close this race? Make sure progress has been saved if you need to resume it later.",
+                "Close Race", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+            if (confirm != DialogResult.Yes)
+                return;
+
+            _controller.SaveSession();   // capture final state into the session
+            _controller.CloseRace();     // mark the event finished
+            PersistSession();
+            _controller.RecomputeEventsWon(drivers, Program.ConnectionString);
+
+            if (IsHostedMode)
+                HostedSaveAndCloseCompleted?.Invoke(this, EventArgs.Empty);
+            else
+                Close();
+        }
+
+        // Writes the current race session (and the parent multi-class event, when
+        // hosted) through the repositories. Callers capture controller state into the
+        // session first; this performs the single repository write per operator action.
+        private void PersistSession()
+        {
             sessionRepository.SaveSession(currentSession);
 
             if (_multiClassEventRepo != null && _multiClassEvent != null)
@@ -348,14 +390,6 @@ namespace RCDragManagerProd.UI.Forms
                     Logger.Log($"[SAVE][ERROR] Multi-class event save failed: {ex}");
                 }
             }
-
-            _controller.RecomputeEventsWon(drivers, Program.ConnectionString);
-
-            MessageBox.Show("Race session saved successfully.", "Saved", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            if (IsHostedMode)
-                HostedSaveAndCloseCompleted?.Invoke(this, EventArgs.Empty);
-            else
-                Close();
         }
 
         // Designer stubs

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
@@ -30,8 +30,8 @@ namespace RCDragManagerProd.UI.Forms
         public event EventHandler HostedSaveAndCloseCompleted;
 
         /// <summary>
-        /// Set by MultiClassRaceForm so that btnSaveAndClose also persists the
-        /// parent multi-class event record. Null in standalone (non-hosted) mode.
+        /// Set by MultiClassRaceForm so that Save Progress / Close Race also persist
+        /// the parent multi-class event record. Null in standalone (non-hosted) mode.
         /// </summary>
         internal MultiClassEvent _multiClassEvent;
         internal MultiClassEventRepository _multiClassEventRepo;


### PR DESCRIPTION
## What & why

Closes #255 — split the fused **Save and Close** race-console button into two
distinct operator actions, because they mean different things to a Race
Director:

- **Save Progress** — persist the current race/session/event so it can be
  resumed later (rain delay, power loss, a paused meet). The race stays open.
- **Close Race** — the event is complete and the operator is done with this
  console.

The backend split (`RaceController.SaveProgress()` / `CloseRace()` +
`RaceSession.IsClosed`) landed with #304; this PR adds the UI half.

## Changes (all in `Form1`)

- **`Form1.Designer.cs`** — the rail's single `btnSaveAndClose` becomes two
  buttons: `btnSaveProgress` ("Save Progress") and `btnCloseRace`
  ("Close Race"). The rail `TableLayoutPanel` gains one row; the flexible
  spacer still pins both to the bottom.
- **`Form1.Events.cs`** —
  - `btnSaveProgress_Click`: `_controller.SaveProgress()` (captures a resumable
    checkpoint, leaves the race open) → `PersistSession()` → success message
    **"Race progress saved. You can resume this race later."** Does NOT close.
  - `btnCloseRace_Click`: confirmation **"Close this race? Make sure progress
    has been saved if you need to resume it later."** → capture final state →
    `_controller.CloseRace()` (marks finished) → `PersistSession()` →
    `RecomputeEventsWon` → close (or fire the hosted completion event).
  - New `PersistSession()` helper centralises the repository writes so each
    action persists **exactly once** (session + parent multi-class event when
    hosted).
- **`Form1.cs`** — comment refresh for the renamed buttons.

## Acceptance criteria

- [x] Replace `Save and Close` with separate `Save Progress` / `Close Race`.
- [x] `Save Progress` persists the active race/session/event exactly once via the
      correct data path.
- [x] `Close Race` does not silently imply a resumable save — it prompts the
      operator first.
- [x] Distinct confirmation/success messages for each action (per the issue).
- [x] Resume-of-in-progress-saved-race test coverage — already provided by the
      `RaceControllerResumeTests` (#294) and `RaceControllerSaveCloseTests`
      (#304) suites; the controller-level Save-vs-Close distinction they assert
      is exactly what these buttons now invoke.

## Verification

- Production build: clean (only the pre-existing CS0618 warning).
- Full suite: **175 passed / 11 skipped (pre-existing multi-class gates) / 0 failed.**
- Hosted multi-class flow preserved: Close Race still fires
  `HostedSaveAndCloseCompleted`, which `MultiClassRaceForm` uses to close.

## Notes

Form behaviour is exercised manually — WinForms handlers aren't unit-tested
(button-free policy). The operator-facing logic they call (`SaveProgress`
keeps the race resumable; `CloseRace` marks it finished) is covered by the
merged #304 tests.
