### PR TITLE
feat: #254 — hide Add Driver section on active race console

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -91,6 +91,16 @@ namespace RCDragManagerProd.UI.Forms
 
         private void btnAddDriver_Click(object sender, EventArgs e)
         {
+            // Late entries are a setup-only action. Once a bracket is live the active
+            // race must not gain or lose drivers (issue #254).
+            if (_controller.HasBracketStarted)
+            {
+                MessageBox.Show(
+                    "This race has already started. New drivers can be added to the driver list, but not to the active race.",
+                    "Race In Progress", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
             try
             {
                 string name = (txtName.Text ?? "").Trim();
@@ -156,6 +166,16 @@ namespace RCDragManagerProd.UI.Forms
 
         private void btnEditDriver_Click(object sender, EventArgs e)
         {
+            // Driver identity is fixed once the bracket is live — editing it on the
+            // active console can desync from saved/bracket/report state (issue #254).
+            if (_controller.HasBracketStarted)
+            {
+                MessageBox.Show(
+                    "This race has already started. New drivers can be added to the driver list, but not to the active race.",
+                    "Race In Progress", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
             if (lvDrivers.SelectedItems.Count > 0)
             {
                 string selectedName = lvDrivers.SelectedItems[0].Text;
@@ -256,6 +276,7 @@ namespace RCDragManagerProd.UI.Forms
             Logger.Log($"[FORM1] GenerateBracket called with race type: {selectedType} and {drivers.Count} drivers");
             _controller.GenerateBracket(selectedType, drivers);
             btnGenerateBracket.Enabled = false;
+            UpdateDriverEntryVisibility();
         }
 
         private void btnWinner1_Click(object sender, EventArgs e)
@@ -322,6 +343,7 @@ namespace RCDragManagerProd.UI.Forms
             btnGenerateBracket.Enabled = true;
             btnNextRound.Enabled = false;
             btnStandings.Enabled = false;
+            UpdateDriverEntryVisibility();
         }
 
         // Save Progress and Close Race are distinct operator actions (issue #255).

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.UI.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.UI.cs
@@ -44,8 +44,20 @@ namespace RCDragManagerProd.UI.Forms
             btnGenerateBracket.Enabled = canGenerate;
 
             UpdateDialInButtonEnabled();
+            UpdateDriverEntryVisibility();
 
             Logger.Log($"[UI] Driver list updated ({drivers.Count}); Generate Bracket {(canGenerate ? "ENABLED" : "disabled")}.");
+        }
+
+        // The Add Driver section (name/time inputs + Add/Edit buttons) is a pre-race
+        // setup affordance only. Once a bracket is live it must not be exposed on the
+        // active console (issue #254); it returns after a Reset clears the bracket.
+        private void UpdateDriverEntryVisibility()
+        {
+            bool setupPhase = !_controller.HasBracketStarted;
+            txtName.Visible = setupPhase;
+            txtTime.Visible = setupPhase;
+            tlpAddEdit.Visible = setupPhase;
         }
 
         private void UpdateDialInButtonEnabled()

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
@@ -75,6 +75,7 @@ namespace RCDragManagerProd.UI.Forms
             }
 
             btnNextRound.Enabled = false;
+            UpdateDriverEntryVisibility();
 
             _controller.BracketRedrawn += RedrawFullBracket;
             _controller.NextMatchReady += OnNextMatchReady;


### PR DESCRIPTION
## What & why

Closes #254 — keep the Add Driver section off the active race console.

Once a race has started, adding or renaming drivers from the console can desync
from saved driver/car data, bracket state, reports, and the live scoreboard.
Late entries belong to setup or the driver manager, not the live bracket.

## Changes (all in `Form1`, runtime visibility — no designer churn)

- **`Form1.UI.cs`** — new `UpdateDriverEntryVisibility()` hides the driver
  name/time inputs (`txtName`, `txtTime`) and the Add/Edit buttons
  (`tlpAddEdit`) whenever `_controller.HasBracketStarted`. Called from
  `UpdateDriverList()`.
- **`Form1.cs`** — call it from the constructor so a resumed in-progress race
  opens with the section already hidden.
- **`Form1.Events.cs`** —
  - call `UpdateDriverEntryVisibility()` after `GenerateBracket` (hide) and
    after `Reset` (restore — the section is a setup affordance again).
  - `btnAddDriver_Click` / `btnEditDriver_Click` guard on `HasBracketStarted`
    and show the operator message **"This race has already started. New drivers
    can be added to the driver list, but not to the active race."** as a safety
    net behind the hidden controls.

Before a bracket exists (Quick Session, pre-generate setup) the section stays
fully usable.

## Acceptance criteria

- [x] Hide the Add Driver section on the active race console.
- [x] Disable the race-console edit path that mutates active driver identity.
- [x] Late-driver workflow kept outside the active racing surface (setup only;
      blocked after first race starts).
- [x] Clear operator message when an add is attempted after racing has started.

## Verification

- Production build: clean (only the pre-existing CS0618 warning).
- Full suite: **175 passed / 11 skipped / 0 failed.**
- Set Dial-In / Set Qual Time controls untouched — the mid-race dial-in
  override flow (#306) is unaffected (those handlers use dialogs, not the
  hidden `txtTime`).

## Notes

WinForms handler behaviour is exercised manually (button-free test policy); no
new automated tests. The change is additive and confined to `Form1`.
