### PR TITLE
feat: #256 — Reset as setup/recovery action, not active-race control

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -276,7 +276,7 @@ namespace RCDragManagerProd.UI.Forms
             Logger.Log($"[FORM1] GenerateBracket called with race type: {selectedType} and {drivers.Count} drivers");
             _controller.GenerateBracket(selectedType, drivers);
             btnGenerateBracket.Enabled = false;
-            UpdateDriverEntryVisibility();
+            UpdateSetupPhaseUi();
         }
 
         private void btnWinner1_Click(object sender, EventArgs e)
@@ -334,6 +334,22 @@ namespace RCDragManagerProd.UI.Forms
 
         private void btnReset_Click(object sender, EventArgs e)
         {
+            // Before a bracket exists this is a harmless setup reset. Once a bracket is
+            // live it is a destructive recovery action (issue #256): confirm strongly and
+            // save a recovery snapshot first so the race can be reloaded if Reset was a
+            // mistake.
+            if (_controller.HasBracketStarted)
+            {
+                var confirm = MessageBox.Show(
+                    "Reset this active race? This will clear current bracket progress, winners, and round state. This cannot be undone.",
+                    "Reset Active Race", MessageBoxButtons.YesNo, MessageBoxIcon.Warning,
+                    MessageBoxDefaultButton.Button2);
+                if (confirm != DialogResult.Yes)
+                    return;
+
+                SaveRecoverySnapshot();
+            }
+
             _controller.Reset();
 
             lvPairings.Items.Clear();
@@ -343,7 +359,25 @@ namespace RCDragManagerProd.UI.Forms
             btnGenerateBracket.Enabled = true;
             btnNextRound.Enabled = false;
             btnStandings.Enabled = false;
-            UpdateDriverEntryVisibility();
+            UpdateSetupPhaseUi();
+        }
+
+        // Persists a resumable checkpoint before an active-race reset wipes live state,
+        // so a mistaken Reset can be recovered by reloading the saved session (issue #256).
+        private void SaveRecoverySnapshot()
+        {
+            if (currentSession == null) return;   // Quick Session: nothing persisted to recover
+
+            try
+            {
+                _controller.SaveProgress();
+                PersistSession();
+                Logger.Log("[RESET] Recovery snapshot saved before active-race reset.");
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[RESET][ERROR] Recovery snapshot failed: {ex}");
+            }
         }
 
         // Save Progress and Close Race are distinct operator actions (issue #255).

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.UI.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.UI.cs
@@ -44,20 +44,24 @@ namespace RCDragManagerProd.UI.Forms
             btnGenerateBracket.Enabled = canGenerate;
 
             UpdateDialInButtonEnabled();
-            UpdateDriverEntryVisibility();
+            UpdateSetupPhaseUi();
 
             Logger.Log($"[UI] Driver list updated ({drivers.Count}); Generate Bracket {(canGenerate ? "ENABLED" : "disabled")}.");
         }
 
-        // The Add Driver section (name/time inputs + Add/Edit buttons) is a pre-race
-        // setup affordance only. Once a bracket is live it must not be exposed on the
-        // active console (issue #254); it returns after a Reset clears the bracket.
-        private void UpdateDriverEntryVisibility()
+        // Setup-phase affordances that must not act like normal race-day controls once
+        // a bracket is live:
+        //   • the Add Driver section (name/time inputs + Add/Edit) is hidden (issue #254);
+        //   • Reset is a plain "Reset Setup" before racing but becomes the protected
+        //     "Reset Race" recovery action afterwards (issue #256).
+        // All of these return to setup form after a Reset clears the bracket.
+        private void UpdateSetupPhaseUi()
         {
             bool setupPhase = !_controller.HasBracketStarted;
             txtName.Visible = setupPhase;
             txtTime.Visible = setupPhase;
             tlpAddEdit.Visible = setupPhase;
+            btnReset.Text = setupPhase ? "Reset Setup" : "Reset Race";
         }
 
         private void UpdateDialInButtonEnabled()

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
@@ -75,7 +75,7 @@ namespace RCDragManagerProd.UI.Forms
             }
 
             btnNextRound.Enabled = false;
-            UpdateDriverEntryVisibility();
+            UpdateSetupPhaseUi();
 
             _controller.BracketRedrawn += RedrawFullBracket;
             _controller.NextMatchReady += OnNextMatchReady;


### PR DESCRIPTION
## What & why

Closes #256 — Reset should not behave like a normal race-day button once a race
has started. A mis-click during a live race could wipe the operator's bracket
progress with no warning and no way back.

## Changes (all in `Form1`)

- **`Form1.UI.cs`** — the setup-phase helper from #254 is renamed
  `UpdateSetupPhaseUi()` and now also sets the Reset label:
  **"Reset Setup"** before a bracket exists, **"Reset Race"** once it is live.
- **`Form1.cs` / `Form1.Events.cs`** — call sites updated to the renamed helper.
- **`Form1.Events.cs` — `btnReset_Click`:**
  - Pre-bracket: unchanged, a harmless setup reset (no confirmation).
  - Active race (`HasBracketStarted`): strong Yes/No confirmation defaulted to
    **No** — *"Reset this active race? This will clear current bracket progress,
    winners, and round state. This cannot be undone."* — and a recovery snapshot
    (`SaveProgress()` + repository write) saved **before** the wipe.
  - New `SaveRecoverySnapshot()` helper persists a resumable checkpoint so a
    mistaken active-race Reset can be recovered by reloading the saved session.
    Quick Sessions (no `currentSession`) skip the snapshot but still confirm.

## Acceptance criteria

- [x] Rename pre-race Reset to a more specific label (**Reset Setup**).
- [x] Reset is a protected action once the bracket is live (strong confirmation),
      rather than a plain race-day button.
- [x] Active-race recovery reset sits behind explicit warning copy (exact text
      from the issue).
- [x] A recovery snapshot is saved before any active-race reset path runs.

## Design note

The issue described three phases (setup → after-generation-before-first-race →
after-first-race). I collapsed the two post-generation phases into a single
protected path keyed on `HasBracketStarted`: any reset once a bracket exists
gets the strong confirmation **and** the recovery snapshot. That is strictly
safer than confirmation-only for the middle phase and avoids needing a new
"has any result yet" controller signal. Reset remains available for genuine
race-day recovery rather than being hidden.

## Verification

- Production build: clean (only the pre-existing CS0618 warning).
- Full suite: **175 passed / 11 skipped / 0 failed.**

## Notes

WinForms handler behaviour is exercised manually (button-free test policy). The
snapshot reuses the `SaveProgress()` / repository path proven by the #294/#304
resume + save tests.
