### PR TITLE
fix(dialogs): standardize Enter/Escape, centering, and action labels (#269/#270/#276)

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Cars/AddCarDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Cars/AddCarDialog.Designer.cs
@@ -31,7 +31,7 @@ namespace RCDragManagerProd.UI.Forms
 
         private void InitializeComponent()
         {
-            this.Text = "Add / Edit Car";
+            this.Text = "Add Car";
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new Size(450, 300);
@@ -55,8 +55,11 @@ namespace RCDragManagerProd.UI.Forms
             lblDialIn = new Label() { Text = "Dial-In:", Location = new Point(20, 100), AutoSize = true };
             txtDialIn = new TextBox() { Location = new Point(140, 100), Width = 100, Enabled = false };
 
-            btnOK = new Button() { Text = "OK", Location = new Point(100, 180), Size = new Size(100, 40) };
+            btnOK = new Button() { Text = "Add Car", Location = new Point(100, 180), Size = new Size(100, 40) };
             btnCancel = new Button() { Text = "Cancel", Location = new Point(240, 180), Size = new Size(100, 40), DialogResult = DialogResult.Cancel };
+
+            this.AcceptButton = btnOK;
+            this.CancelButton = btnCancel;
 
             btnOK.Click += new EventHandler(this.btnOK_Click);
 

--- a/src/RCDragManagerProd/UI/Forms/Cars/AddCarDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Cars/AddCarDialog.cs
@@ -17,6 +17,9 @@ namespace RCDragManagerProd.UI.Forms
         {
             InitializeComponent();
 
+            this.Text = "Edit Car";
+            btnOK.Text = "Save Changes";
+
             txtCarName.Text = carToEdit.CarName;
 
             if (carToEdit.ClassType == "Heads Up")

--- a/src/RCDragManagerProd/UI/Forms/Drivers/AddDriverAndCarDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/AddDriverAndCarDialog.Designer.cs
@@ -45,8 +45,11 @@ namespace RCDragManagerProd.UI.Forms
             lblDialIn = new Label() { Text = "Dial-In:", Location = new Point(20, 140), AutoSize = true };
             txtDialIn = new TextBox() { Location = new Point(140, 140), Width = 100, Enabled = false };
 
-            btnOK = new Button() { Text = "OK", Location = new Point(100, 200), Size = new Size(100, 40) };
+            btnOK = new Button() { Text = "Add Driver", Location = new Point(100, 200), Size = new Size(100, 40) };
             btnCancel = new Button() { Text = "Cancel", Location = new Point(240, 200), Size = new Size(100, 40), DialogResult = DialogResult.Cancel };
+
+            this.AcceptButton = btnOK;
+            this.CancelButton = btnCancel;
 
             // Wire events
             btnOK.Click += new EventHandler(this.btnOK_Click);

--- a/src/RCDragManagerProd/UI/Forms/Drivers/AddEditQualTimeDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/AddEditQualTimeDialog.Designer.cs
@@ -62,6 +62,9 @@ namespace RCDragManagerProd.UI.Forms
             };
             btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             this.Controls.Add(btnCancel);
+
+            this.AcceptButton = btnSave;
+            this.CancelButton = btnCancel;
         }
     }
 }

--- a/src/RCDragManagerProd/UI/Forms/Drivers/DriverManagerForm.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/DriverManagerForm.Events.cs
@@ -72,7 +72,7 @@ namespace RCDragManagerProd.UI.Forms
         {
             using (var dlg = new AddDriverAndCarDialog())
             {
-                if (dlg.ShowDialog() != DialogResult.OK) return;
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
 
                 var newDriver = new Driver
                 {
@@ -115,7 +115,7 @@ namespace RCDragManagerProd.UI.Forms
 
             using (var dlg = new EditDriverDialog(selectedDriver.Name, selectedDriver.State))
             {
-                if (dlg.ShowDialog() != DialogResult.OK) return;
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
 
                 selectedDriver.Name = dlg.DriverName;
                 selectedDriver.State = dlg.State;
@@ -155,7 +155,7 @@ namespace RCDragManagerProd.UI.Forms
 
             using (var dlg = new AddCarDialog())
             {
-                if (dlg.ShowDialog() != DialogResult.OK) return;
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
 
                 selectedDriver.Cars ??= new List<Car>();
                 selectedDriver.Cars.Add(dlg.NewCar);
@@ -182,7 +182,7 @@ namespace RCDragManagerProd.UI.Forms
 
             using (var dlg = new AddCarDialog(currentCar))
             {
-                if (dlg.ShowDialog() != DialogResult.OK) return;
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
 
                 var displayedCarIds = selectedDriver.Cars.Select(c => c.CarID).ToList();
                 int selectedIndex = displayedCarIds.IndexOf(carId);
@@ -241,7 +241,7 @@ namespace RCDragManagerProd.UI.Forms
             var driver = repository.GetDriverById(selectedDriver.Id);
             using (var dialog = new AddEditQualTimeDialog(driver.Name, driver.QualTime))
             {
-                if (dialog.ShowDialog() != DialogResult.OK) return;
+                if (dialog.ShowDialog(this) != DialogResult.OK) return;
 
                 if (dialog.QualifyingTime.HasValue)
                 {
@@ -267,7 +267,7 @@ namespace RCDragManagerProd.UI.Forms
 
             using (var statsForm = new DriverStatsForm(selectedDriver, Program.ConnectionString))
             {
-                statsForm.ShowDialog();
+                statsForm.ShowDialog(this);
             }
         }
 

--- a/src/RCDragManagerProd/UI/Forms/Drivers/DriverStatsForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/DriverStatsForm.Designer.cs
@@ -82,8 +82,10 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.Name = "DriverStatsForm";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Driver Stats";
+            this.AcceptButton = this.btnClose;
+            this.CancelButton = this.btnClose;
             this.ResumeLayout(false);
         }
     }

--- a/src/RCDragManagerProd/UI/Forms/Drivers/EditDriverDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/EditDriverDialog.Designer.cs
@@ -42,8 +42,11 @@ namespace RCDragManagerProd.UI.Forms
                 "", "NSW", "QLD", "VIC", "WA", "SA", "TAS", "NT", "ACT",
             });
 
-            btnOK = new Button() { Text = "OK", Location = new Point(100, 150), Size = new Size(100, 40) };
+            btnOK = new Button() { Text = "Save Changes", Location = new Point(100, 150), Size = new Size(100, 40) };
             btnCancel = new Button() { Text = "Cancel", Location = new Point(240, 150), Size = new Size(100, 40), DialogResult = DialogResult.Cancel };
+
+            this.AcceptButton = btnOK;
+            this.CancelButton = btnCancel;
 
             btnOK.Click += new EventHandler(this.btnOK_Click);
 

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -181,7 +181,7 @@ namespace RCDragManagerProd.UI.Forms
                 if (driver != null)
                 {
                     var editDialog = new EditDriverDialog(driver.Name, "");
-                    if (editDialog.ShowDialog() == DialogResult.OK)
+                    if (editDialog.ShowDialog(this) == DialogResult.OK)
                     {
                         driver.Name = editDialog.DriverName;
                         UpdateDriverList();
@@ -236,7 +236,7 @@ namespace RCDragManagerProd.UI.Forms
                 if (driver != null)
                 {
                     var qualDialog = new AddEditQualTimeDialog(driver.Name, driver.QualTime);
-                    if (qualDialog.ShowDialog() == DialogResult.OK)
+                    if (qualDialog.ShowDialog(this) == DialogResult.OK)
                     {
                         driver.QualTime = qualDialog.QualifyingTime;
                         UpdateDriverList();
@@ -466,7 +466,7 @@ namespace RCDragManagerProd.UI.Forms
 
                 using (var dlg = new BuybackDriverSelectionForm(eligible))
                 {
-                    var dr = dlg.ShowDialog();
+                    var dr = dlg.ShowDialog(this);
 
                     if (dr != DialogResult.OK)
                     {

--- a/src/RCDragManagerProd/UI/Forms/Results/BuybackDriverSelectionForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Results/BuybackDriverSelectionForm.Designer.cs
@@ -61,6 +61,7 @@
             this.Name = "BuybackDriverSelectionForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Select Buyback Drivers";
+            this.AcceptButton = this.btnConfirm;
             this.ResumeLayout(false);
         }
     }

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.Designer.cs
@@ -204,6 +204,9 @@ namespace RCDragManagerProd.UI.Forms
             pnlButtonBar.Controls.Add(btnOk);
             pnlButtonBar.Controls.Add(btnCancel);
 
+            this.AcceptButton = btnOk;
+            this.CancelButton = btnCancel;
+
             pnlContent.Controls.AddRange(new Control[]
             {
                 lblClassName, txtClassName,

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
@@ -65,6 +65,8 @@ namespace RCDragManagerProd.UI.Forms
             if (existing != null)
                 LoadExistingValues(existing);
 
+            btnOk.Text = existing != null ? "Save Class" : "Add Class";
+
             WireRaceTypeCard(pnlCardProLadder);
             WireRaceTypeCard(pnlCardRandomDraw);
             WireRaceTypeCard(pnlCardRoundRobin);
@@ -364,7 +366,7 @@ namespace RCDragManagerProd.UI.Forms
         {
             using (var addDialog = new AddDriverAndCarDialog())
             {
-                if (addDialog.ShowDialog() != DialogResult.OK) return;
+                if (addDialog.ShowDialog(this) != DialogResult.OK) return;
 
                 var newDriver = new Driver { Name = addDialog.DriverName, Cars = new List<Car>() };
                 _driverRepo.AddDriver(newDriver);

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassSetupForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassSetupForm.cs
@@ -94,7 +94,7 @@ namespace RCDragManagerProd.UI.Forms
         {
             using (var dlg = new MultiClassConfigDialog(_connectionString))
             {
-                if (dlg.ShowDialog() == DialogResult.OK)
+                if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     AddClass(new ClassConfig
                     {
@@ -129,7 +129,7 @@ namespace RCDragManagerProd.UI.Forms
 
             using (var dlg = new MultiClassConfigDialog(_connectionString, existing))
             {
-                if (dlg.ShowDialog() == DialogResult.OK)
+                if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     _classList[idx] = new ClassConfig
                     {


### PR DESCRIPTION
## Summary

Standardizes modal-dialog UX across the driver/car/qual-time/buyback/multi-class
dialogs:

- **#269 Enter/Escape** — every modal now sets `AcceptButton`/`CancelButton` so
  Enter confirms and Escape cancels.
- **#270 Centering + ownership** — dialogs are `CenterParent` and are now shown
  with an explicit owner (`ShowDialog(this)`) so they center over their
  launcher. `DriverStatsForm` was `CenterScreen`; fixed to `CenterParent` and
  given Enter/Escape-to-close.
- **#276 Action labels** — OK buttons now name the action: `Add Driver`,
  `Add Car` / `Save Changes` (mode-aware), `Save Changes` (edit driver),
  `Add Class` / `Save Class` (multi-class config). Qual-time and buyback dialogs
  already had specific labels.

Dialogs touched: AddDriverAndCarDialog, EditDriverDialog, AddCarDialog,
AddEditQualTimeDialog, BuybackDriverSelectionForm, DriverStatsForm,
MultiClassConfigDialog. Launch sites updated to pass owner: DriverManagerForm,
Form1, MultiClassSetupForm, MultiClassConfigDialog.

`AddDriverDialog` and `EditWinnerDialog` were intentionally left untouched —
both are dead code (never instantiated; the live edit-result UI is the inline
picker in `Form1.WinnerButtons.ShowWinnerPicker`).

#271 (button-bar re-layout) is **deferred** — it is a DPI-sensitive layout
refactor that needs a dedicated UI session for visual verification.

Closes #269
Closes #270
Closes #276

## Test plan

- [x] MSBuild Debug — clean (only the pre-existing CS0618 warning)
- [x] Full test suite — 175 passed / 11 skipped / 0 failed (baseline held)
- [ ] Manual: Enter/Escape work in each dialog; dialogs center over launcher;
      OK buttons show action-specific labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
