### PR TITLE
fix(ui): standardize race-day terminology and capitalization (#275)

### DIFF
--- a/src/RCDragManagerProd/UI/Forms/Drivers/DriverManagerForm.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Drivers/DriverManagerForm.Designer.cs
@@ -111,7 +111,7 @@ namespace RCDragManagerProd.UI.Forms
 
             this.btnSetQualTime.Location = new Point(722, 200);
             this.btnSetQualTime.Size = new Size(150, 40);
-            this.btnSetQualTime.Text = "Set Qual Time";
+            this.btnSetQualTime.Text = "Set Qualifying Time";
             this.btnSetQualTime.Click += new System.EventHandler(this.btnSetQualTime_Click);
 
             this.btnDriverStats.Location = new Point(722, 260);
@@ -177,7 +177,7 @@ namespace RCDragManagerProd.UI.Forms
             this.colCarName.Width = 200;
             this.colCarClass.Text = "Class";
             this.colCarClass.Width = 110;
-            this.colCarDialIn.Text = "Dial-in";
+            this.colCarDialIn.Text = "Dial-In";
             this.colCarDialIn.Width = 75;
             this.colCarDialIn.TextAlign = HorizontalAlignment.Right;
 

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Designer.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Designer.cs
@@ -568,8 +568,8 @@ namespace RCDragManagerProd.UI.Forms
             // 
             // colTime
             // 
-            this.colTime.Text = "Qual Time";
-            this.colTime.Width = 65;
+            this.colTime.Text = "Qualifying Time";
+            this.colTime.Width = 110;
             // 
             // colDialIn
             // 
@@ -602,7 +602,7 @@ namespace RCDragManagerProd.UI.Forms
             this.btnSetQualTime.Name = "btnSetQualTime";
             this.btnSetQualTime.Size = new System.Drawing.Size(100, 26);
             this.btnSetQualTime.TabIndex = 11;
-            this.btnSetQualTime.Text = "Set Time";
+            this.btnSetQualTime.Text = "Set Qualifying Time";
             this.btnSetQualTime.Click += new System.EventHandler(this.btnSetQualTime_Click);
             // 
             // btnSetDialIn
@@ -830,7 +830,7 @@ namespace RCDragManagerProd.UI.Forms
             this.MinimumSize = new System.Drawing.Size(900, 600);
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "RC Drag Manager Stable Build";
+            this.Text = "RC Drag Manager";
             this.pnlHeader.ResumeLayout(false);
             this.pnlBottom.ResumeLayout(false);
             this.tlpBottom.ResumeLayout(false);

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -37,7 +37,7 @@ namespace RCDragManagerProd.UI.Forms
             {
                 RaceDialogs.Info(this,
                     "Round-Robin complete.\nClick 'Open Buybacks' to add drivers to the Losers Bracket.",
-                    "Buy-Back Phase Ready");
+                    "Buyback Phase Ready");
             }
         }
 

--- a/src/RCDragManagerProd/UI/Forms/Main/MultiClassRaceForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/MultiClassRaceForm.cs
@@ -243,9 +243,9 @@ namespace RCDragManagerProd.UI.Forms
                 Logger.Log("[MultiClass] All classes completed RR — releasing LB gate");
                 MessageBox.Show(
                     "All classes have completed Round Robin.\n" +
-                    "The Buy-Back phase is now open for all classes.\n\n" +
-                    "Switch to each class tab to run buy-backs.",
-                    "Buy-Back Phase Ready — All Classes",
+                    "The Buyback phase is now open for all classes.\n\n" +
+                    "Switch to each class tab to run buybacks.",
+                    "Buyback Phase Ready — All Classes",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Information);
             }


### PR DESCRIPTION
## Summary

Applies a canonical UI copy glossary to user-facing race-day terminology (#275).
Glossary direction confirmed with the product owner before sweeping:

- **Qualifying time** → full wording. Buttons now read **"Set Qualifying Time"**
  (was "Set Time" in the race console and "Set Qual Time" in Driver Manager).
  Race-console column header → **"Qualifying Time"** (was "Qual Time"; widened
  65→110 px to fit).
- **Dial-in** → canonical **"Dial-In"** (capital I, the app's dominant form).
  Fixes the one stray lowercase "Dial-in" column in Driver Manager. No other
  Dial-In strings changed.
- **Buyback** → one word. Collapses hyphenated "Buy-Back" / "buy-backs" in the
  operator message boxes (Form1 buyback-ready popup, MultiClass all-classes
  popup) to "Buyback" / "buybacks".
- **Main window title** → **"RC Drag Manager"** (dropped the "Stable Build"
  dev suffix).

Internal `Logger.Log` strings (e.g. the `[CTRL] Buy-back drivers stored` marker)
are intentionally left unchanged to preserve documented QA log markers.

Deliberately **not** touched: the class-type radio labels ("Heads Up" / "Dial" /
"Index" / "Bracket Class") — those are class-type names backed by stored domain
values, distinct from the dial-in field. Likewise the distinct feature names
"Create Race Session" / "Load Saved Event" / "New Multi-Class Event" refer to
genuinely different things and are already internally consistent.

Closes #275

## Test plan

- [x] MSBuild Debug — clean (only the pre-existing CS0618 warning)
- [x] Full test suite — 175 passed / 11 skipped / 0 failed (baseline held)
- [ ] Manual: confirm the "Qualifying Time" column fits without clipping and
      the renamed buttons/title/popups read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
