### PR TITLE
test: headless test foundation + testing policy (#290, #292)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ on this codebase:
 | `DATA-LAYER.md` | Touching DB or repositories — schema, serialization, quirks |
 | `RACE-FLOW.md` | Touching race logic — step-by-step event flow, bracket types |
 | `CODEBASE-MAP.md` | Finding files — every source file with one-line description |
+| `TESTING.md` | Writing tests or refactoring UI — standard commands, coverage expectations, headless test helpers |
 | `TECHNICAL-DEBT.md` | Before any refactor — known issues, closed bugs, weaknesses |
 | `CURRENT-SESSION-SETUP-AUDIT.md` | Touching session setup or multi-class work |
 | `MULTI-CLASS-EVENT-SPEC.md` | Working on the multi-class feature — full specification |

--- a/Docs/claude-context/TESTING.md
+++ b/Docs/claude-context/TESTING.md
@@ -1,0 +1,81 @@
+# RC Drag Manager — Testing Policy
+
+This is the testing guardrail for the project (issue #292). Every UI/UX refactor
+should ship with runnable tests so behaviour is verified while coding — not by
+asking the owner to manually click through the app. Manual app testing is the
+**final smoke check**, never the primary verification method.
+
+---
+
+## Standard Commands
+
+The solution targets .NET Framework 4.8 (WinForms). Build with MSBuild or Visual
+Studio — **not** `dotnet build`. Tests run under `dotnet test`.
+
+**Build (Debug):**
+
+```
+MSBuild.exe src/RCDragManagerProd/RCDragManagerProd.sln /t:Build /p:Configuration=Debug
+```
+
+**Run the full test suite:**
+
+```
+dotnet test src/RCDragManagerProd.Tests/RCDragManagerProd.Tests.csproj
+```
+
+The test project uses in-memory / temp SQLite — no external setup required. On
+Windows, run MSBuild from PowerShell (not Git Bash, which mangles `/t:` `/p:`
+switches).
+
+### Baseline
+
+A clean run is **all green** with a small, known set of skipped tests (the
+multi-class `ValidateClassName` / `ValidateCanStart` gates). The only expected
+build noise is the `CS0618` obsolete-API warning at
+`RaceController.EngineCalls.cs` and nullable warnings in the test project. If the
+baseline is not green, fix that **before** starting a refactor (see issue #302).
+
+---
+
+## What Every UI/UX Refactor Should Cover
+
+When extracting or changing a workflow, add or update **service/controller-level**
+tests (no WinForms controls, no dialogs to close) covering:
+
+- **Command state changes** — which actions/buttons are enabled per race phase.
+- **Validation failures** — bad input is rejected with the expected outcome.
+- **Persistence outcomes** — saves write through the repositories; reloads restore.
+- **Resume / load behaviour** — an interrupted event resumes where it left off.
+- **No-window execution** — the test runs head­less under `dotnet test`.
+
+Keep UI smoke testing (visually confirming layout/appearance on the running app)
+**separate** from service-workflow testing.
+
+---
+
+## Test Foundation (headless helpers)
+
+Reusable seams live in `src/RCDragManagerProd.Tests/Helpers/` (issue #290). Prefer
+them over re-deriving inline boilerplate:
+
+| Helper | Use |
+|--------|-----|
+| `TestDriverFactory` | Driver packs (`CreateProLadderPack`, `CreateProLadderByePack`, `CreateRoundRobinPack(n)`). |
+| `TestSessionFactory` | `RaceSession` / `MultiClassEvent` builders (`ProLadder`, `RoundRobin`, `WithDriverEntries`, `MultiClassEvent`). |
+| `NoOpStandingsDialogService` | Suppress the standings dialog in headless runs. |
+| `RecordingStandingsDialogService` | Record `Show(...)` calls to assert the standings seam was (or wasn't) invoked. |
+
+`RaceController` accepts an `IStandingsDialogService` so dialog display can be
+doubled in tests. As more UI workflow is extracted into application services
+(issues #283/#284), introduce matching interfaces/doubles for prompts,
+confirmations, input dialogs, navigation, and repositories, and add them here.
+
+---
+
+## PR Expectations
+
+- Every UI/UX or refactor PR **lists the test command run** and its result in the
+  test plan.
+- New behaviour comes with a failing-then-passing test where practical.
+- Do not change passing tests to make a refactor look clean — add new ones.

--- a/src/RCDragManagerProd.Tests/Helpers/RecordingStandingsDialogService.cs
+++ b/src/RCDragManagerProd.Tests/Helpers/RecordingStandingsDialogService.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using RCDragManagerProd.Controllers;
+
+namespace RCDragManagerProd.Tests.Helpers;
+
+/// <summary>
+/// Test double for <see cref="IStandingsDialogService"/> that records every
+/// <see cref="Show"/> call instead of opening a WinForms dialog. Lets headless tests
+/// assert whether (and with what content) the controller tried to surface standings —
+/// the reusable counterpart to <see cref="NoOpStandingsDialogService"/> for the cases
+/// that need to verify the interaction rather than just suppress it (issue #290).
+/// </summary>
+internal sealed class RecordingStandingsDialogService : IStandingsDialogService
+{
+    public List<(string Title, string Content)> ShowCalls { get; } = new();
+
+    public int ShowCount => ShowCalls.Count;
+
+    public (string Title, string Content)? LastShow =>
+        ShowCalls.Count == 0 ? null : ShowCalls[ShowCalls.Count - 1];
+
+    public void Show(string title, string content)
+    {
+        ShowCalls.Add((title, content));
+    }
+}

--- a/src/RCDragManagerProd.Tests/Helpers/TestSessionFactory.cs
+++ b/src/RCDragManagerProd.Tests/Helpers/TestSessionFactory.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RCDragManagerProd.Domain;
+
+namespace RCDragManagerProd.Tests.Helpers;
+
+/// <summary>
+/// Reusable builders for <see cref="RaceSession"/> and <see cref="MultiClassEvent"/>
+/// so service/controller tests can construct realistic sessions without re-deriving
+/// the same inline boilerplate (issue #290). Pairs with <see cref="TestDriverFactory"/>,
+/// which supplies driver packs. All builders are headless — no WinForms, runnable under
+/// <c>dotnet test</c>.
+/// </summary>
+internal static class TestSessionFactory
+{
+    private static readonly DateTime DefaultDate = new DateTime(2026, 3, 24, 9, 0, 0);
+
+    /// <summary>
+    /// A Pro Ladder (seeded knockout) session. The first arg passed to
+    /// <c>RaceController.GenerateBracket</c> is the engine key "Pro Ladder";
+    /// <see cref="RaceSession.ClassType"/> defaults to "Heads Up" to match the
+    /// existing flow-test sessions.
+    /// </summary>
+    public static RaceSession ProLadder(string classType = "Heads Up", string eventName = "QA Pro Ladder")
+    {
+        return new RaceSession
+        {
+            EventName = eventName,
+            EventDate = DefaultDate,
+            RaceType = "Pro Ladder",
+            ClassType = classType
+        };
+    }
+
+    /// <summary>
+    /// A Round Robin session. <paramref name="variant"/> is "Standard" or "QMDRA";
+    /// <paramref name="roundsToRun"/> is only meaningful for QMDRA.
+    /// </summary>
+    public static RaceSession RoundRobin(
+        string variant = "Standard",
+        int? roundsToRun = null,
+        string classType = "Open",
+        string eventName = "QA Round Robin")
+    {
+        return new RaceSession
+        {
+            EventName = eventName,
+            EventDate = DefaultDate,
+            RaceType = RaceTypes.RoundRobin,
+            ClassType = classType,
+            RoundRobinVariant = variant,
+            RoundsToRun = roundsToRun
+        };
+    }
+
+    /// <summary>
+    /// Populates <see cref="RaceSession.DriverEntries"/> from a driver pack, seeding
+    /// each entry's dial-in from the driver's qualifying time when present. Returns the
+    /// same session for fluent chaining. Needed by tests that exercise the dial-in
+    /// commands, which read/write <c>DriverEntries</c>.
+    /// </summary>
+    public static RaceSession WithDriverEntries(this RaceSession session, IEnumerable<Driver> drivers)
+    {
+        if (session == null) throw new ArgumentNullException(nameof(session));
+        if (drivers == null) throw new ArgumentNullException(nameof(drivers));
+
+        session.DriverEntries = drivers.Select(d => new RaceSessionDriverEntry
+        {
+            DriverID = d.Id,
+            DriverName = d.Name,
+            ClassType = session.ClassType,
+            QualifyingTime = d.QualTime,
+            DialIn = d.QualTime
+        }).ToList();
+
+        return session;
+    }
+
+    /// <summary>
+    /// A multi-class parent event wrapping the supplied class sessions. Each class
+    /// session inherits the event name/date so the parent and children stay consistent.
+    /// </summary>
+    public static MultiClassEvent MultiClassEvent(string eventName, params RaceSession[] classSessions)
+    {
+        var evt = new MultiClassEvent
+        {
+            EventName = eventName,
+            EventDate = DefaultDate,
+            ClassSessions = (classSessions ?? Array.Empty<RaceSession>()).ToList()
+        };
+
+        foreach (var session in evt.ClassSessions)
+        {
+            session.EventName = eventName;
+            session.EventDate = evt.EventDate;
+        }
+
+        return evt;
+    }
+}

--- a/src/RCDragManagerProd.Tests/TestFoundationTests.cs
+++ b/src/RCDragManagerProd.Tests/TestFoundationTests.cs
@@ -1,0 +1,133 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Tests.Helpers;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Exercises the shared headless test foundation (issue #290): the reusable
+/// <see cref="TestSessionFactory"/> builders and the <see cref="RecordingStandingsDialogService"/>
+/// double. These tests both prove the helpers produce valid inputs and add genuine new
+/// coverage of the standings dialog seam that backs the race-console "Standings" button —
+/// previously untested. Everything runs under <c>dotnet test</c> with no WinForms windows.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class TestFoundationTests
+{
+    // ── Session builders produce valid controller inputs ──────────────────────────
+
+    [TestMethod]
+    public void ProLadderBuilder_ProducesSessionThatStartsBracket()
+    {
+        var session = TestSessionFactory.ProLadder();
+        var controller = new RaceController(session);
+
+        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderPack());
+
+        Assert.IsTrue(controller.HasBracketStarted, "Pro Ladder builder must yield a startable session");
+        Assert.AreEqual("Pro Ladder", session.RaceType);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(controller.GetActiveRoundLabel()));
+        Assert.IsTrue(controller.PeekUpcomingMatches(10).Count > 0);
+    }
+
+    [TestMethod]
+    public void RoundRobinBuilder_ProducesQmdraSession_WithExpectedConfig()
+    {
+        var session = TestSessionFactory.RoundRobin(variant: "QMDRA", roundsToRun: 2);
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+
+        controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(4));
+
+        Assert.AreEqual(RaceTypes.RoundRobin, session.RaceType);
+        Assert.AreEqual("QMDRA", session.RoundRobinVariant);
+        Assert.AreEqual(2, session.RoundsToRun);
+        Assert.AreEqual("RR1", controller.GetActiveRoundLabel());
+    }
+
+    [TestMethod]
+    public void WithDriverEntries_SeedsDialInsReadableThroughController()
+    {
+        var pack = TestDriverFactory.CreateProLadderPack();
+        var session = TestSessionFactory.ProLadder().WithDriverEntries(pack);
+        var controller = new RaceController(session);
+
+        Assert.AreEqual(pack.Count, session.DriverEntries.Count);
+        foreach (var driver in pack)
+        {
+            Assert.AreEqual(driver.QualTime, controller.GetDriverDialIn(driver.Id),
+                $"Dial-in for driver {driver.Id} must be seeded from the qualifying time");
+        }
+    }
+
+    [TestMethod]
+    public void MultiClassEventBuilder_WrapsClassSessions_AndPropagatesEventName()
+    {
+        var pro = TestSessionFactory.ProLadder(classType: "Pro");
+        var sportsman = TestSessionFactory.RoundRobin(classType: "Sportsman");
+
+        var evt = TestSessionFactory.MultiClassEvent("Spring Shootout", pro, sportsman);
+
+        Assert.AreEqual("Spring Shootout", evt.EventName);
+        Assert.AreEqual(2, evt.ClassSessions.Count);
+        Assert.IsTrue(evt.ClassSessions.All(s => s.EventName == "Spring Shootout"),
+            "Each class session must inherit the parent event name");
+        Assert.IsTrue(evt.ClassSessions.All(s => s.EventDate == evt.EventDate));
+    }
+
+    // ── Standings dialog seam (backs the "Standings" button) ──────────────────────
+
+    [TestMethod]
+    public void Standings_NotShown_BeforeRoundRobinCompletes()
+    {
+        var recorder = new RecordingStandingsDialogService();
+        var controller = new RaceController(
+            TestSessionFactory.RoundRobin(variant: "Standard"), recorder);
+
+        controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(4));
+
+        Assert.IsFalse(controller.TryShowRoundRobinStandings(),
+            "Standings must report unavailable before any RR round completes");
+        Assert.AreEqual(0, recorder.ShowCount, "No standings dialog should be surfaced yet");
+    }
+
+    [TestMethod]
+    public void Standings_SurfacedOnCompletion_AndReShownOnDemand()
+    {
+        var recorder = new RecordingStandingsDialogService();
+        var controller = new RaceController(
+            TestSessionFactory.RoundRobin(variant: "Standard"), recorder);
+
+        // 6 drivers (not 4): completion then leaves >=2 buyback-eligible drivers, so the
+        // controller takes the buyback path. The standings auto-show fires on RR completion
+        // regardless; this loop stops the instant that happens, before the buyback gate — so
+        // it never reaches the <2-eligible "wildcard" branch, which surfaces a modal
+        // MessageBox that would block a headless test host.
+        controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(6));
+
+        // Resolve every revealed match and advance until RR completion auto-surfaces standings.
+        for (int i = 0; i < 40 && recorder.ShowCount == 0; i++)
+        {
+            var matches = controller.PeekUpcomingMatches(50).ToList();
+            if (matches.Count > 0)
+                foreach (var m in matches)
+                    controller.SubmitWinner(m.MatchId, firstOption: true);
+            else
+                controller.AdvanceRound();
+        }
+
+        Assert.IsTrue(recorder.ShowCount >= 1,
+            "RR completion must surface standings through the dialog service");
+        int afterAutoShow = recorder.ShowCount;
+
+        // The "Standings" button re-shows the cached card on demand.
+        Assert.IsTrue(controller.TryShowRoundRobinStandings(),
+            "Standings must be available on demand once RR is complete");
+        Assert.AreEqual(afterAutoShow + 1, recorder.ShowCount,
+            "On-demand Standings must route exactly one more call through the dialog service");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(recorder.LastShow?.Content),
+            "Standings content must be non-empty");
+    }
+}


### PR DESCRIPTION
## Summary
Adds a reusable headless test foundation and codifies the project's testing guardrail, so service/controller tests stop re-deriving inline boilerplate and every UI/UX refactor ships with runnable verification.

- **`TestSessionFactory`** — `RaceSession`/`MultiClassEvent` builders (`ProLadder`, `RoundRobin`, `WithDriverEntries`, `MultiClassEvent`) that produce valid `RaceController` inputs.
- **`RecordingStandingsDialogService`** — records `Show(...)` calls so headless tests can assert the standings seam was (or wasn't) invoked; the recording counterpart to the existing `NoOpStandingsDialogService`.
- **`TestFoundationTests`** — proves the builders yield startable sessions *and* adds net-new coverage of the standings dialog seam behind the race-console "Standings" button (previously untested).
- **`Docs/claude-context/TESTING.md`** — testing policy: standard build/test commands, the green baseline + known skips/noise, per-refactor coverage expectations, the helper table, and PR expectations. Linked from `CLAUDE.md`'s documentation index.

Everything runs headless under `dotnet test` — no WinForms windows.

## Scope note
`Closes #292` (testing policy + standard commands — fully delivered).
**Advances #290** but does *not* close it: the full test-doubles checklist (prompts, confirmations, input dialogs, navigation, repositories) depends on the UI-extraction interfaces from the #283/#284 architecture epic, which don't exist yet. The two reusable seams that *can* land now (session builders + standings recorder) are included here; #290 stays open for the rest.

## Test plan
- [x] `MSBuild.exe ... /p:Configuration=Debug` — clean build
- [x] `dotnet test RCDragManagerProd.Tests.csproj` — **187 passed / 11 skipped / 0 failed**
- [x] Confirmed no test-host hang (standings-completion test uses a 6-driver RR so it exercises the buyback path and never reaches the modal wildcard branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)