### PR TITLE
refactor(console): UI-independent RaceConsoleViewModel + builder (#284)

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceConsoleViewModelTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceConsoleViewModelTests.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Tests.Helpers;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Covers the UI-independent race-console state contract (issue #284): the
+/// <see cref="RaceConsoleViewModel"/> produced by <see cref="RaceConsoleViewModelBuilder"/>.
+/// These prove the builder derives the right state straight from a
+/// <see cref="RaceController"/> with no WinForms involvement, so the same snapshot can
+/// drive the existing console (after rewiring) and a future WPF view.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class RaceConsoleViewModelTests
+{
+    // ── Primary-action resolution (pure decision, no controller needed) ───────────
+
+    [TestMethod]
+    public void PrimaryAction_BeforeAnyPhase_BuildsBracket()
+    {
+        var action = RaceConsoleViewModelBuilder.ResolvePrimaryAction(isFinalsPending: false, isInLosersBracketPhase: false);
+
+        Assert.AreEqual(RaceConsolePrimaryAction.BuildBracket, action);
+        Assert.AreEqual("Build Bracket", RaceConsoleViewModelBuilder.LabelFor(action));
+    }
+
+    [TestMethod]
+    public void PrimaryAction_WhenLosersBracketPending_StartsLosersBracket()
+    {
+        var action = RaceConsoleViewModelBuilder.ResolvePrimaryAction(isFinalsPending: false, isInLosersBracketPhase: true);
+
+        Assert.AreEqual(RaceConsolePrimaryAction.StartLosersBracket, action);
+        Assert.AreEqual("Start Losers Bracket", RaceConsoleViewModelBuilder.LabelFor(action));
+    }
+
+    [TestMethod]
+    public void PrimaryAction_WhenFinalsPending_StartsFinals_EvenIfLosersPhaseFlagSet()
+    {
+        // Finals pending takes precedence — matches the console's Build/Start handler order.
+        var action = RaceConsoleViewModelBuilder.ResolvePrimaryAction(isFinalsPending: true, isInLosersBracketPhase: true);
+
+        Assert.AreEqual(RaceConsolePrimaryAction.StartFinals, action);
+        Assert.AreEqual("Start Finals", RaceConsoleViewModelBuilder.LabelFor(action));
+    }
+
+    // ── Builder against a live controller ─────────────────────────────────────────
+
+    [TestMethod]
+    public void Build_BeforeBracket_ReportsSetupState()
+    {
+        var controller = new RaceController(TestSessionFactory.ProLadder(eventName: "Spring Shootout"));
+
+        var vm = RaceConsoleViewModelBuilder.Build(controller);
+
+        Assert.AreEqual("Event: Spring Shootout", vm.EventTitle);
+        Assert.IsFalse(vm.HasBracketStarted);
+        Assert.AreEqual(string.Empty, vm.ActiveRoundLabel, "Active round must be empty before the bracket starts");
+        Assert.AreEqual(0, vm.PairingRows.Count);
+        Assert.AreEqual("No current match.", vm.CurrentMatchText);
+        Assert.AreEqual(string.Empty, vm.OnDeckText);
+        Assert.AreEqual(string.Empty, vm.InTheHoleText);
+        Assert.AreEqual(RaceConsolePrimaryAction.BuildBracket, vm.PrimaryAction);
+        Assert.AreEqual("Build Bracket", vm.PrimaryActionLabel);
+    }
+
+    [TestMethod]
+    public void Build_AfterProLadderBracket_ReportsActiveState()
+    {
+        var controller = new RaceController(TestSessionFactory.ProLadder());
+        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderPack());
+
+        var vm = RaceConsoleViewModelBuilder.Build(controller);
+
+        Assert.IsTrue(vm.HasBracketStarted);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(vm.ActiveRoundLabel), "Active round label must be set once started");
+        Assert.IsTrue(vm.PairingRows.Count > 0, "A started bracket must expose pairing rows");
+        Assert.IsTrue(vm.PairingRows.Any(r => !r.IsHeader), "Pairing rows must include at least one match row");
+        Assert.AreNotEqual("No current match.", vm.CurrentMatchText, "A started bracket has a current match");
+        StringAssert.Contains(vm.CurrentMatchText, " vs ", "Current match text must read as 'Name vs Name'");
+
+        // Bracket is live, no buyback/finals phase yet → primary action is still Build Bracket.
+        Assert.AreEqual(RaceConsolePrimaryAction.BuildBracket, vm.PrimaryAction);
+    }
+}

--- a/src/RCDragManagerProd/AppServices/RaceConsoleViewModel.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleViewModel.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using RCDragManagerProd.ViewModels;
+
+namespace RCDragManagerProd.AppServices
+{
+    /// <summary>
+    /// The primary "what does the Build/Start button do right now" decision for the
+    /// race console. Resolved from the controller's phase, it replaces the three-way
+    /// branch currently inline in <c>btnGenerateBracket_Click</c>.
+    /// </summary>
+    public enum RaceConsolePrimaryAction
+    {
+        /// <summary>Initial state — build the bracket from the entered drivers.</summary>
+        BuildBracket,
+
+        /// <summary>Round Robin done and buybacks stored — start the Losers Bracket.</summary>
+        StartLosersBracket,
+
+        /// <summary>Losers Bracket done — start the Finals.</summary>
+        StartFinals
+    }
+
+    /// <summary>
+    /// Immutable snapshot of the race-console screen state, derived from
+    /// <see cref="RCDragManagerProd.Controllers.RaceController"/> by
+    /// <see cref="RaceConsoleViewModelBuilder"/>. This is the UI-independent contract
+    /// the race console renders from (issue #284): no WinForms types in or out, so the
+    /// same state can back a future WPF view and can be asserted in headless tests.
+    /// </summary>
+    /// <remarks>
+    /// This type is the data contract only. It performs no rendering and holds no
+    /// engine-internal types — pairing rows are the existing UI-neutral
+    /// <see cref="PairingRow"/> view models.
+    /// </remarks>
+    public sealed class RaceConsoleViewModel
+    {
+        public RaceConsoleViewModel(
+            string eventTitle,
+            bool hasBracketStarted,
+            bool isInLosersBracketPhase,
+            bool isFinalsPending,
+            bool dialInLocked,
+            string activeRoundLabel,
+            IReadOnlyList<PairingRow> pairingRows,
+            string currentMatchText,
+            string onDeckText,
+            string inTheHoleText,
+            RaceConsolePrimaryAction primaryAction,
+            string primaryActionLabel)
+        {
+            EventTitle = eventTitle;
+            HasBracketStarted = hasBracketStarted;
+            IsInLosersBracketPhase = isInLosersBracketPhase;
+            IsFinalsPending = isFinalsPending;
+            DialInLocked = dialInLocked;
+            ActiveRoundLabel = activeRoundLabel;
+            PairingRows = pairingRows ?? new List<PairingRow>();
+            CurrentMatchText = currentMatchText;
+            OnDeckText = onDeckText;
+            InTheHoleText = inTheHoleText;
+            PrimaryAction = primaryAction;
+            PrimaryActionLabel = primaryActionLabel;
+        }
+
+        /// <summary>Header title, e.g. "Event: Spring Shootout" or "Quick Session".</summary>
+        public string EventTitle { get; }
+
+        /// <summary>True once a bracket has been generated for this session.</summary>
+        public bool HasBracketStarted { get; }
+
+        /// <summary>True when buybacks are stored and the Losers Bracket is pending.</summary>
+        public bool IsInLosersBracketPhase { get; }
+
+        /// <summary>True when the Losers Bracket is complete and the Finals are pending.</summary>
+        public bool IsFinalsPending { get; }
+
+        /// <summary>True while the active round's dial-ins are locked.</summary>
+        public bool DialInLocked { get; }
+
+        /// <summary>Active round label (e.g. "RR1", "SF"); empty before the bracket starts.</summary>
+        public string ActiveRoundLabel { get; }
+
+        /// <summary>The full revealed bracket as UI-neutral rows (headers + matches).</summary>
+        public IReadOnlyList<PairingRow> PairingRows { get; }
+
+        /// <summary>Current match as "Name vs Name", or "No current match." when none.</summary>
+        public string CurrentMatchText { get; }
+
+        /// <summary>On-deck match as "Name vs Name"; empty when there isn't one.</summary>
+        public string OnDeckText { get; }
+
+        /// <summary>In-the-hole match as "Name vs Name"; empty when there isn't one.</summary>
+        public string InTheHoleText { get; }
+
+        /// <summary>What the primary Build/Start button does in the current phase.</summary>
+        public RaceConsolePrimaryAction PrimaryAction { get; }
+
+        /// <summary>Caption for the primary button matching <see cref="PrimaryAction"/>.</summary>
+        public string PrimaryActionLabel { get; }
+    }
+}

--- a/src/RCDragManagerProd/AppServices/RaceConsoleViewModelBuilder.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleViewModelBuilder.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.RaceEngines;
+using RCDragManagerProd.ViewModels;
+
+namespace RCDragManagerProd.AppServices
+{
+    /// <summary>
+    /// Builds a <see cref="RaceConsoleViewModel"/> snapshot from a
+    /// <see cref="RaceController"/> (issue #284). All console-state derivation lives here
+    /// rather than in the form: the title composition, the current/on-deck/in-the-hole
+    /// decomposition, and the primary Build/Start action decision. The builder reads only
+    /// the controller's public/internal API and references no WinForms types, so its
+    /// output can be asserted headlessly and reused by a future WPF view.
+    /// </summary>
+    public static class RaceConsoleViewModelBuilder
+    {
+        private const string BuildBracketLabel = "Build Bracket";
+        private const string StartLosersBracketLabel = "Start Losers Bracket";
+        private const string StartFinalsLabel = "Start Finals";
+        private const string NoCurrentMatch = "No current match.";
+
+        public static RaceConsoleViewModel Build(RaceController controller)
+        {
+            if (controller == null) throw new ArgumentNullException(nameof(controller));
+
+            bool hasBracketStarted = controller.HasBracketStarted;
+
+            // GetActiveRoundLabel() throws before a bracket exists (EnsureReady), so it is
+            // only safe to query once the bracket has started.
+            string activeRoundLabel = hasBracketStarted
+                ? (controller.GetActiveRoundLabel() ?? string.Empty)
+                : string.Empty;
+
+            var pairingRows = hasBracketStarted
+                ? controller.BuildCurrentBracketRows()
+                : (IReadOnlyList<PairingRow>)Array.Empty<PairingRow>();
+
+            ResolveUpcoming(controller, out string current, out string onDeck, out string inTheHole);
+
+            var primaryAction = ResolvePrimaryAction(controller.IsFinalsPending, controller.IsInLosersBracketPhase);
+
+            return new RaceConsoleViewModel(
+                eventTitle: BuildEventTitle(controller),
+                hasBracketStarted: hasBracketStarted,
+                isInLosersBracketPhase: controller.IsInLosersBracketPhase,
+                isFinalsPending: controller.IsFinalsPending,
+                dialInLocked: controller.DialInLocked,
+                activeRoundLabel: activeRoundLabel,
+                pairingRows: pairingRows,
+                currentMatchText: current,
+                onDeckText: onDeck,
+                inTheHoleText: inTheHole,
+                primaryAction: primaryAction,
+                primaryActionLabel: LabelFor(primaryAction));
+        }
+
+        /// <summary>
+        /// The primary button's meaning by phase — the same precedence the console's
+        /// Build/Start handler uses: Finals pending wins, then Losers Bracket pending,
+        /// otherwise build the initial bracket.
+        /// </summary>
+        public static RaceConsolePrimaryAction ResolvePrimaryAction(bool isFinalsPending, bool isInLosersBracketPhase)
+        {
+            if (isFinalsPending) return RaceConsolePrimaryAction.StartFinals;
+            if (isInLosersBracketPhase) return RaceConsolePrimaryAction.StartLosersBracket;
+            return RaceConsolePrimaryAction.BuildBracket;
+        }
+
+        public static string LabelFor(RaceConsolePrimaryAction action)
+        {
+            switch (action)
+            {
+                case RaceConsolePrimaryAction.StartFinals: return StartFinalsLabel;
+                case RaceConsolePrimaryAction.StartLosersBracket: return StartLosersBracketLabel;
+                default: return BuildBracketLabel;
+            }
+        }
+
+        private static string BuildEventTitle(RaceController controller)
+        {
+            var session = controller.Session;
+            return session != null ? $"Event: {session.EventName}" : "Quick Session";
+        }
+
+        // Mirrors RaceController.BuildNextUpLabelText: the next up to three unresolved
+        // matches in the active round are the current / on-deck / in-the-hole pairs, shown
+        // with lane-adjusted names so the text matches the bracket and winner buttons.
+        private static void ResolveUpcoming(RaceController controller, out string current, out string onDeck, out string inTheHole)
+        {
+            var list = controller.PeekUpcomingMatches(3).ToList();
+
+            current = list.Count > 0 ? PairText(controller, list[0]) : NoCurrentMatch;
+            onDeck = list.Count > 1 ? PairText(controller, list[1]) : string.Empty;
+            inTheHole = list.Count > 2 ? PairText(controller, list[2]) : string.Empty;
+        }
+
+        private static string PairText(RaceController controller, EngineMatch match)
+        {
+            controller.GetLaneAdjustedNames(match, out string left, out string right);
+            return $"{left} vs {right}";
+        }
+    }
+}

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -110,6 +110,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppServices\RaceConsoleViewModel.cs" />
+    <Compile Include="AppServices\RaceConsoleViewModelBuilder.cs" />
     <Compile Include="Controllers\IStandingsDialogService.cs" />
     <Compile Include="Controllers\LaneFairnessManager.cs" />
     <Compile Include="Controllers\RaceController.DialIn.cs" />


### PR DESCRIPTION
## Summary
First slice of the race-console extraction epic (#284, under #283). Introduces the **UI-framework-free state contract** the race console renders from — the keystone the rest of the epic and the #299 WPF spike build on.

- **`RaceConsoleViewModel`** (`RCDragManagerProd.AppServices`) — immutable snapshot: event title, phase flags (bracket started / losers-pending / finals-pending / dial-in locked), active round label, pairing rows, current/on-deck/in-the-hole text, and the primary Build/Start action + caption.
- **`RaceConsoleViewModelBuilder`** — pure builder deriving the snapshot from `RaceController`'s public API. Guards `GetActiveRoundLabel` behind `HasBracketStarted` (it throws pre-bracket), reuses `GetLaneAdjustedNames` for faithful next-up text, and `ResolvePrimaryAction` mirrors the console's `Finals > LosersBracket > BuildBracket` precedence.

## Scope / safety
- **Additive only** — no form is rewired in this PR, so **WinForms behavior is unchanged** (the form rewire that *removes* this logic from `Form1` is the next slice, which gets a manual smoke test).
- **No UI framework references** in either new type (satisfies the epic's acceptance criterion).
- New namespace is `AppServices`, not `Application` — the latter collides with `System.Windows.Forms.Application` (`Application.Run`/`Exit`).

Advances **#284** (does not close it — command extraction + Form1 rewire remain).

## Test plan
- [x] MSBuild Debug — clean (only the pre-existing CS0618 obsolete-API warning)
- [x] `dotnet test` — **192 passed / 11 skipped / 0 failed** (5 new `RaceConsoleViewModelTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)