### PR TITLE
fix(finals): keep full match-up grid in race order on QMDRA finals

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerQmdraFlowTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerQmdraFlowTests.cs
@@ -138,6 +138,40 @@ public class RaceControllerQmdraFlowTests
         Assert.AreEqual(0, controller.PeekUpcomingMatches(10).Count);
     }
 
+    [TestMethod]
+    public void Qmdra_AfterFinalsTransition_BracketGridKeepsRoundRobinHistory()
+    {
+        // Regression: QMDRA "all advance" used to clear the match-up grid when moving to
+        // Finals (it captured no RR snapshot and swapped engines), leaving only the injected
+        // Finals round. The grid must keep the full match-up list in race order — every
+        // Round Robin round first, then the Finals round.
+        var session = CreateQmdraSession(roundsToRun: 2);
+        var controller = CreateController(session);
+        controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(4));
+
+        ResolveVisibleMatches(controller); // RR1
+        controller.AdvanceRound();         // reveal RR2
+        ResolveVisibleMatches(controller); // RR2 complete -> auto-injects Finals
+
+        Assert.AreEqual("Finals", session.RaceType);
+
+        var headers = controller.BuildCurrentBracketRows()
+            .Where(r => r.IsHeader)
+            .Select(r => r.RoundLabel)
+            .ToList();
+
+        CollectionAssert.Contains(headers, "RR1", "RR1 must remain in the grid after moving to Finals");
+        CollectionAssert.Contains(headers, "RR2", "RR2 must remain in the grid after moving to Finals");
+        Assert.IsTrue(headers.Any(h => string.Equals(h, "SF", StringComparison.OrdinalIgnoreCase)),
+            "The Finals round (SF) must be appended after the Round Robin rounds");
+
+        // Race order: all RR rounds must be listed before the Finals round.
+        int lastRrIndex = headers.FindLastIndex(h => h != null && h.StartsWith("RR", StringComparison.OrdinalIgnoreCase));
+        int sfIndex = headers.FindIndex(h => string.Equals(h, "SF", StringComparison.OrdinalIgnoreCase));
+        Assert.IsTrue(lastRrIndex >= 0 && sfIndex > lastRrIndex,
+            "Round Robin rounds must be listed before the Finals round (race order)");
+    }
+
     private static void ResolveVisibleMatches(RaceController controller)
     {
         foreach (var match in controller.PeekUpcomingMatches(20).ToList())

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Finals.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Finals.cs
@@ -189,15 +189,29 @@ namespace RCDragManagerProd.Controllers
             Logger.Log("[FINALS][QMDRA] Seed order: " +
                 string.Join(", ", rankedDrivers.Select(d => d.Name)));
 
+            // Preserve the completed Round Robin before we swap _engine to the Finals
+            // ladder. The bracket grid renders RR rounds from this snapshot (View Phase A),
+            // so without it the grid would drop the entire RR match-up history and show only
+            // the freshly-injected Finals round. The Standard RR path snapshots at completion
+            // for the same reason; QMDRA "all advance" must do the same.
+            if (_engine != null && (_rrMatchesSnapshot == null || _rrRoundOrderSnapshot == null))
+            {
+                _rrMatchesSnapshot = EngineGetMatches(_engine).ToList();
+                _rrRoundOrderSnapshot = EngineGetRoundOrder(_engine).ToList();
+                Logger.Log($"[FINALS][QMDRA] RR snapshot captured: matches={_rrMatchesSnapshot.Count}, rounds={_rrRoundOrderSnapshot.Count}");
+            }
+
             // Switch session to Finals
             _session.RaceType = RaceTypes.Finals;
             _inLosersPhase = false;
             _finalsPending = false;
             _activeRound = null;   // RR active-round gate cleared on Finals injection
 
-            // Reset state
+            // Reset revealed rounds (the Finals first round is revealed below). The winners
+            // list is NOT cleared: it is append-only and holds the RR results, so the grid
+            // keeps the full race-order history as Finals results are added — matching the
+            // Standard RR → Finals path, which never clears it.
             _revealedRounds.Clear();
-            _winners.Clear();
 
             // Create Pro Ladder engine
             var pro = new ProLadderEngineAdapter();


### PR DESCRIPTION
## The bug (found in smoke testing)
In a **QMDRA** event, the moment the race moved from Round Robin to the Finals, the bracket **match-up grid was cleared** — the operator lost the entire RR match-up list and saw only the new Finals round.

## Root cause
QMDRA "all advance" finishes by calling `InjectFinalsAllAdvance`, which:
- captured **no RR snapshot**, and
- swapped `_engine` to a fresh Pro Ladder finals adapter (and cleared `_winners`).

`BuildCurrentBracketRows` only renders the RR history from `_rrMatchesSnapshot` (View Phase A / Phase C). With no snapshot it fell through to showing just the newly-injected Finals round. The **Standard RR → Finals** path doesn't have this problem because it snapshots the RR engine at completion.

## Fix
Make QMDRA do what Standard already does:
- Snapshot the completed RR engine (`_rrMatchesSnapshot` / `_rrRoundOrderSnapshot`) **before** swapping engines, so the grid keeps the RR rounds and appends the Finals round — the **full list in race order**.
- Stop clearing `_winners` (it's append-only and holds the RR results), so the winners list also keeps the full race-order history as Finals results come in.

No change to the Standard / Pro Ladder paths.

## Test plan
- [x] New regression test `Qmdra_AfterFinalsTransition_BracketGridKeepsRoundRobinHistory` — drives a 2-round QMDRA event through the Finals transition and asserts RR1 and RR2 remain in the grid, before the SF round, in race order. Fails on the old behavior; passes now.
- [x] MSBuild Debug — clean (only the pre-existing CS0618 warning)
- [x] `dotnet test` — **188 passed / 11 skipped / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)