### PR TITLE
refactor(console): route primary Build/Start through RaceConsoleService (#284)

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceConsoleServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceConsoleServiceTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Tests.Helpers;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Covers <see cref="RaceConsoleService"/> (issue #284) — the UI-independent command +
+/// state seam the race console calls instead of branching in its button handler. These
+/// prove the primary Build/Start dispatch picks and runs the right action per phase, all
+/// headless under <c>dotnet test</c>.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class RaceConsoleServiceTests
+{
+    [TestMethod]
+    public void GetState_DelegatesToBuilder_AndReportsEventTitle()
+    {
+        var service = new RaceConsoleService(
+            new RaceController(TestSessionFactory.ProLadder(eventName: "Spring Shootout")));
+
+        var state = service.GetState();
+
+        Assert.AreEqual("Event: Spring Shootout", state.EventTitle);
+        Assert.IsFalse(state.HasBracketStarted);
+        Assert.AreEqual(RaceConsolePrimaryAction.BuildBracket, state.PrimaryAction);
+    }
+
+    [TestMethod]
+    public void ExecutePrimaryAction_BeforeBracket_BuildsBracket()
+    {
+        var controller = new RaceController(TestSessionFactory.ProLadder());
+        var service = new RaceConsoleService(controller);
+
+        var action = service.ExecutePrimaryAction(TestDriverFactory.CreateProLadderPack(), "Pro Ladder");
+
+        Assert.AreEqual(RaceConsolePrimaryAction.BuildBracket, action);
+        Assert.IsTrue(controller.HasBracketStarted, "Building the bracket must start the session");
+        Assert.IsTrue(controller.PeekUpcomingMatches(10).Count > 0);
+    }
+
+}

--- a/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
+
+namespace RCDragManagerProd.AppServices
+{
+    /// <summary>
+    /// UI-independent command + state seam for the race console (issue #284). The console
+    /// form calls these commands and renders the returned <see cref="RaceConsoleViewModel"/>
+    /// instead of owning the workflow decisions itself. Holds no WinForms types, so the same
+    /// service can drive a future WPF view and the command logic can be asserted headlessly.
+    /// </summary>
+    public sealed class RaceConsoleService
+    {
+        private readonly RaceController _controller;
+
+        public RaceConsoleService(RaceController controller)
+        {
+            _controller = controller ?? throw new ArgumentNullException(nameof(controller));
+        }
+
+        /// <summary>Current console state snapshot.</summary>
+        public RaceConsoleViewModel GetState() => RaceConsoleViewModelBuilder.Build(_controller);
+
+        /// <summary>
+        /// Runs the phase-appropriate primary Build/Start action and reports which one ran.
+        /// This is the decision that used to live inline in the console's Build/Start button
+        /// handler: Finals pending → start Finals; Losers Bracket pending → start it;
+        /// otherwise build the initial bracket from <paramref name="drivers"/>.
+        /// </summary>
+        /// <param name="drivers">Roster used only when building the initial bracket.</param>
+        /// <param name="raceType">Engine key used only when building the initial bracket.</param>
+        public RaceConsolePrimaryAction ExecutePrimaryAction(List<Driver> drivers, string raceType)
+        {
+            var action = RaceConsoleViewModelBuilder.ResolvePrimaryAction(
+                _controller.IsFinalsPending, _controller.IsInLosersBracketPhase);
+
+            switch (action)
+            {
+                case RaceConsolePrimaryAction.StartFinals:
+                    _controller.StartFinals();
+                    break;
+                case RaceConsolePrimaryAction.StartLosersBracket:
+                    _controller.StartLosersBracket();
+                    break;
+                default:
+                    _controller.GenerateBracket(raceType, drivers);
+                    break;
+            }
+
+            return action;
+        }
+    }
+}

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -110,6 +110,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppServices\RaceConsoleService.cs" />
     <Compile Include="AppServices\RaceConsoleViewModel.cs" />
     <Compile Include="AppServices\RaceConsoleViewModelBuilder.cs" />
     <Compile Include="Controllers\IStandingsDialogService.cs" />

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -1,4 +1,5 @@
-﻿using RCDragManagerProd.Controllers;
+﻿using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Controllers;
 using RCDragManagerProd.Domain;
 using RCDragManagerProd.Logging;
 using RCDragManagerProd.RaceEngines;
@@ -251,28 +252,28 @@ namespace RCDragManagerProd.UI.Forms
 
         private void btnGenerateBracket_Click(object sender, EventArgs e)
         {
-            if (_controller.IsFinalsPending)
-            {
-                Logger.Log("[FORM1] Generate Bracket pressed — starting Finals…");
-                _controller.StartFinals();
-                btnGenerateBracket.Enabled = false;
-                return;
-            }
-
-            if (_controller.IsInLosersBracketPhase)
-            {
-                Logger.Log("[FORM1] Starting Losers Bracket from stored buybacks...");
-                _controller.StartLosersBracket();
-                btnGenerateBracket.Enabled = false;
-                btnGenerateLosersBracket.Enabled = false;
-                return;
-            }
-
+            // The phase decision (start Finals / start Losers Bracket / build initial bracket)
+            // now lives in RaceConsoleService; the form only dispatches and updates button
+            // state from the action that ran (issue #284).
             var selectedType = _controller.Session?.RaceType ?? currentSession.RaceType;
-            Logger.Log($"[FORM1] GenerateBracket called with race type: {selectedType} and {drivers.Count} drivers");
-            _controller.GenerateBracket(selectedType, drivers);
+            var action = _raceConsole.ExecutePrimaryAction(drivers, selectedType);
+
             btnGenerateBracket.Enabled = false;
-            UpdateSetupPhaseUi();
+
+            switch (action)
+            {
+                case RaceConsolePrimaryAction.StartFinals:
+                    Logger.Log("[FORM1] Build/Start pressed — Finals started.");
+                    break;
+                case RaceConsolePrimaryAction.StartLosersBracket:
+                    Logger.Log("[FORM1] Build/Start pressed — Losers Bracket started from stored buybacks.");
+                    btnGenerateLosersBracket.Enabled = false;
+                    break;
+                default:
+                    Logger.Log($"[FORM1] Build/Start pressed — bracket built (race type: {selectedType}, {drivers.Count} drivers).");
+                    UpdateSetupPhaseUi();
+                    break;
+            }
         }
 
         private void btnWinner1_Click(object sender, EventArgs e)

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
@@ -1,4 +1,5 @@
-﻿using RCDragManagerProd.Controllers;
+﻿using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Controllers;
 using RCDragManagerProd.RaceEngines;
 using RCDragManagerProd.ViewModels;
 using System;
@@ -18,6 +19,7 @@ namespace RCDragManagerProd.UI.Forms
         private RaceSession currentSession;
         private RaceSessionRepository sessionRepository = new RaceSessionRepository(Program.ConnectionString);
         private readonly RaceController _controller;
+        private readonly RaceConsoleService _raceConsole;
         private bool _finalsPopupShown;
         private WinnerButtonContext _currentWinnerButtonContext;
 
@@ -39,6 +41,7 @@ namespace RCDragManagerProd.UI.Forms
         public Form1(RaceController controller)
         {
             _controller = controller ?? throw new ArgumentNullException(nameof(controller));
+            _raceConsole = new RaceConsoleService(_controller);
             InitializeComponent();
 
             btnEditResult.Click += btnEditResult_Click;
@@ -61,9 +64,9 @@ namespace RCDragManagerProd.UI.Forms
 
             currentSession = _controller.Session;
 
-            lblEventTitle.Text = currentSession != null
-                ? $"Event: {currentSession.EventName}"
-                : "Quick Session";
+            // Title comes from the console view model so the "Event: …" / "Quick Session"
+            // composition lives in one UI-independent place (issue #284).
+            lblEventTitle.Text = _raceConsole.GetState().EventTitle;
 
             if (currentSession?.DriverEntries != null && currentSession.DriverEntries.Count > 0)
             {


### PR DESCRIPTION
## Summary
Second slice of the race-console extraction (#284, under #283) — the **first slice that removes workflow logic from `Form1`**, not just adds a contract.

- **`RaceConsoleService`** (`RCDragManagerProd.AppServices`) — the UI-independent command + state seam #284 asks for. `GetState()` returns the `RaceConsoleViewModel`; `ExecutePrimaryAction(drivers, raceType)` resolves and runs the phase-appropriate primary action (`Finals > LosersBracket > BuildBracket`) and reports which ran. No WinForms references.
- **`Form1`** — `btnGenerateBracket_Click` no longer branches on controller phase; it delegates the decision to the service and only updates button state from the returned action. The event title now renders from `GetState().EventTitle`, so the `"Event: …"` / `"Quick Session"` composition lives in one place.

## Behavior is unchanged
Same three controller calls, same per-phase button-state side effects (`btnGenerateBracket` disabled in all cases; `btnGenerateLosersBracket` disabled on the LB branch; `UpdateSetupPhaseUi()` on the build branch), same title text. Only the *decision* moved out of the form.

Advances **#284** (winner / advance / reset / buyback / save-close extraction still to come).

## Test plan
- [x] MSBuild Debug — clean (only the pre-existing CS0618 warning)
- [x] `dotnet test` — **195 passed / 11 skipped / 0 failed** (2 new `RaceConsoleServiceTests`; phase resolution covered by existing `RaceConsoleViewModelTests`)

## Manual smoke check (please verify before merge — this touches live `Form1` wiring)
The Build/Start button is the one piece of live behavior that changed paths. Please confirm each still works exactly as before:
1. **Build Bracket** — set up an event, press the button → bracket builds, button disables, setup UI updates. (Pro Ladder, Standard RR, and QMDRA.)
2. **Start Losers Bracket** — Standard RR with enough buyback entries → open buybacks, select ≥2, press the button → Losers Bracket starts and both the Build and Open-Buybacks buttons disable.
3. **Start Finals** — after the Losers Bracket completes → press the button → Finals start.
4. **Event title** — the header still reads `Event: <name>` (or `Quick Session` for a quick session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)