### PR TITLE
refactor(console): extract advance/standings/buyback commands to service (#284)

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceConsoleServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceConsoleServiceTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
 using RCDragManagerProd.Tests.Helpers;
 
 namespace RCDragManagerProd.Tests;
@@ -42,4 +44,67 @@ public class RaceConsoleServiceTests
         Assert.IsTrue(controller.PeekUpcomingMatches(10).Count > 0);
     }
 
+    [TestMethod]
+    public void AdvanceRound_LocksDialIns_AndRevealsNextRound()
+    {
+        var controller = new RaceController(TestSessionFactory.ProLadder());
+        var service = new RaceConsoleService(controller);
+        service.ExecutePrimaryAction(TestDriverFactory.CreateProLadderPack(), "Pro Ladder");
+
+        Assert.AreEqual("SF", controller.GetActiveRoundLabel(), "Pro Ladder opens on the SF round");
+        foreach (var m in controller.PeekUpcomingMatches(10).ToList())
+            controller.SubmitWinner(m.MatchId, firstOption: true);
+
+        service.AdvanceRound();
+
+        Assert.AreEqual("F", controller.GetActiveRoundLabel(), "Advancing must reveal the Final round");
+        Assert.IsTrue(controller.DialInLocked, "Advancing locks the dial-ins for the committed round");
+    }
+
+    [TestMethod]
+    public void TryShowStandings_BeforeRoundRobinComplete_ReportsUnavailable()
+    {
+        var controller = new RaceController(
+            TestSessionFactory.RoundRobin(variant: "Standard"), new NoOpStandingsDialogService());
+        var service = new RaceConsoleService(controller);
+        controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(4));
+
+        Assert.IsFalse(service.TryShowStandings(),
+            "Standings must report unavailable before any RR round completes");
+    }
+
+    [TestMethod]
+    public void ApplyBuybackSelection_NoDrivers_IsRejected()
+    {
+        var service = new RaceConsoleService(new RaceController(TestSessionFactory.RoundRobin()));
+
+        Assert.AreEqual(BuybackSelectionOutcome.Invalid, service.ApplyBuybackSelection(new List<Driver>()));
+        Assert.AreEqual(BuybackSelectionOutcome.Invalid, service.ApplyBuybackSelection(null));
+    }
+
+    [TestMethod]
+    public void ApplyBuybackSelection_SingleDriver_PromotesStraightToFinals()
+    {
+        var controller = new RaceController(TestSessionFactory.RoundRobin());
+        var service = new RaceConsoleService(controller);
+        var one = TestDriverFactory.CreateRoundRobinPack(1);
+
+        var outcome = service.ApplyBuybackSelection(one);
+
+        Assert.AreEqual(BuybackSelectionOutcome.SingleToFinals, outcome);
+        Assert.IsTrue(controller.IsFinalsPending, "A single buyback skips the LB and raises the Finals gate");
+    }
+
+    [TestMethod]
+    public void ApplyBuybackSelection_TwoOrMore_StoredForLosersBracket()
+    {
+        var controller = new RaceController(TestSessionFactory.RoundRobin());
+        var service = new RaceConsoleService(controller);
+        var two = TestDriverFactory.CreateRoundRobinPack(2);
+
+        var outcome = service.ApplyBuybackSelection(two);
+
+        Assert.AreEqual(BuybackSelectionOutcome.Stored, outcome);
+        Assert.IsTrue(controller.IsInLosersBracketPhase, "Two or more buyback drivers enter the Losers Bracket phase");
+    }
 }

--- a/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
@@ -51,5 +51,59 @@ namespace RCDragManagerProd.AppServices
 
             return action;
         }
+
+        /// <summary>
+        /// Advances to the next round. Locks the dial-ins first (a round is now committed)
+        /// then advances — the lock/advance pairing the console's "Generate Next Round" button
+        /// used to do inline. The form still refreshes its dial-in button state afterward.
+        /// </summary>
+        public void AdvanceRound()
+        {
+            _controller.LockDialIn();
+            _controller.AdvanceRound();
+        }
+
+        /// <summary>
+        /// Shows the Round Robin standings if available; returns false when they are not ready
+        /// yet (so the form can explain that). Backs the "Standings" button.
+        /// </summary>
+        public bool TryShowStandings() => _controller.TryShowRoundRobinStandings();
+
+        /// <summary>Drivers currently eligible for a buyback into the Losers Bracket.</summary>
+        public IReadOnlyList<Driver> GetEligibleBuybacks() => _controller.GetEligibleBuybackDrivers();
+
+        /// <summary>
+        /// Applies the operator's buyback selection and reports what happened: a single pick
+        /// skips the Losers Bracket and goes straight to a Finals slot; two or more are stored
+        /// for a Losers Bracket; an empty selection is rejected. This is the dispatch that used
+        /// to live inline in the buyback button handler (the selection dialog stays in the form).
+        /// </summary>
+        public BuybackSelectionOutcome ApplyBuybackSelection(List<Driver> selected)
+        {
+            if (selected == null || selected.Count == 0)
+                return BuybackSelectionOutcome.Invalid;
+
+            if (selected.Count == 1)
+            {
+                _controller.GenerateLosersBracket(selected);
+                return BuybackSelectionOutcome.SingleToFinals;
+            }
+
+            _controller.SetBuybackDrivers(selected);
+            return BuybackSelectionOutcome.Stored;
+        }
+    }
+
+    /// <summary>Result of <see cref="RaceConsoleService.ApplyBuybackSelection"/>.</summary>
+    public enum BuybackSelectionOutcome
+    {
+        /// <summary>No driver was selected — nothing applied.</summary>
+        Invalid,
+
+        /// <summary>One driver selected — Losers Bracket skipped, Finals slot promoted.</summary>
+        SingleToFinals,
+
+        /// <summary>Two or more selected — stored for the Losers Bracket.</summary>
+        Stored
     }
 }

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -313,9 +313,8 @@ namespace RCDragManagerProd.UI.Forms
             {
                 btnNextRound.Enabled = false;
                 Logger.Log("[FORM1] Generate Next Round clicked");
-                _controller.LockDialIn();
+                _raceConsole.AdvanceRound();   // locks dial-ins, then advances (issue #284)
                 UpdateDialInButtonEnabled();
-                _controller.AdvanceRound();
             }
             catch (Exception ex)
             {
@@ -456,7 +455,7 @@ namespace RCDragManagerProd.UI.Forms
 
             try
             {
-                var eligible = _controller.GetEligibleBuybackDrivers();
+                var eligible = _raceConsole.GetEligibleBuybacks();
 
                 if (eligible == null || eligible.Count < 2)
                 {
@@ -465,7 +464,7 @@ namespace RCDragManagerProd.UI.Forms
                     return;
                 }
 
-                using (var dlg = new BuybackDriverSelectionForm(eligible))
+                using (var dlg = new BuybackDriverSelectionForm(eligible.ToList()))
                 {
                     var dr = dlg.ShowDialog(this);
 
@@ -476,35 +475,32 @@ namespace RCDragManagerProd.UI.Forms
                     }
 
                     var selectedDrivers = dlg.SelectedDrivers;
+                    Logger.Log($"📥 [LB] Buybacks selected: {selectedDrivers?.Count ?? 0} drivers → {(selectedDrivers == null ? "" : string.Join(", ", selectedDrivers.Select(d => d.Name)))}");
 
-                    if (selectedDrivers == null || selectedDrivers.Count == 0)
+                    // The single-vs-multi decision now lives in RaceConsoleService (issue #284);
+                    // the form just maps the outcome back to button state.
+                    switch (_raceConsole.ApplyBuybackSelection(selectedDrivers))
                     {
-                        RaceDialogs.Warn(this, "At least one driver must be selected.", "Invalid Selection");
-                        Logger.Log("⚠️ [LB] Invalid buyback selection — no drivers selected.");
-                        return;
-                    }
+                        case BuybackSelectionOutcome.Invalid:
+                            RaceDialogs.Warn(this, "At least one driver must be selected.", "Invalid Selection");
+                            Logger.Log("⚠️ [LB] Invalid buyback selection — no drivers selected.");
+                            return;
 
-                    Logger.Log($"📥 [LB] Buybacks selected: {selectedDrivers.Count} drivers → {string.Join(", ", selectedDrivers.Select(d => d.Name))}");
+                        case BuybackSelectionOutcome.SingleToFinals:
+                            // GenerateLosersBracket fired CanStartFinalsChanged(true), which enables
+                            // btnGenerateBracket via OnCanStartFinalsChanged.
+                            Logger.Log("[UI] Single buyback driver — LB skipped, Finals gate raised.");
+                            break;
 
-                    if (selectedDrivers.Count == 1)
-                    {
-                        // Single buyback: skip LB entirely, promote direct to Finals.
-                        // GenerateLosersBracket sets _buybackChampionOverride + fires CanStartFinalsChanged(true),
-                        // which enables btnGenerateBracket via OnCanStartFinalsChanged.
-                        _controller.GenerateLosersBracket(selectedDrivers);
-                        Logger.Log("[UI] Single buyback driver — LB skipped, Finals gate raised.");
-                    }
-                    else
-                    {
-                        _controller.SetBuybackDrivers(selectedDrivers);
+                        case BuybackSelectionOutcome.Stored:
+                            btnGenerateBracket.Enabled = true;
+                            btnGenerateBracket.Text = "Start Losers Bracket";
 
-                        btnGenerateBracket.Enabled = true;
-                        btnGenerateBracket.Text = "Start Losers Bracket";
+                            btnGenerateLosersBracket.Enabled = true;
+                            btnGenerateLosersBracket.Text = "Edit Buybacks";
 
-                        btnGenerateLosersBracket.Enabled = true;
-                        btnGenerateLosersBracket.Text = "Edit Buybacks";
-
-                        Logger.Log("[UI] Buybacks stored. 'Start Losers Bracket' enabled; 'Open Buybacks' stays enabled for edits until LB is generated.");
+                            Logger.Log("[UI] Buybacks stored. 'Start Losers Bracket' enabled; 'Open Buybacks' stays enabled for edits until LB is generated.");
+                            break;
                     }
                 }
             }
@@ -703,8 +699,8 @@ namespace RCDragManagerProd.UI.Forms
             {
                 Logger.Log("[UI][CLICK] Standings clicked.");
 
-                var shown = _controller.TryShowRoundRobinStandings();
-                Logger.Log("[UI][STANDINGS] TryShowRoundRobinStandings() -> " + (shown ? "SHOWN" : "NOT AVAILABLE"));
+                var shown = _raceConsole.TryShowStandings();
+                Logger.Log("[UI][STANDINGS] TryShowStandings() -> " + (shown ? "SHOWN" : "NOT AVAILABLE"));
 
                 if (!shown)
                 {


### PR DESCRIPTION
## Summary
Continues the race-console extraction (#284, under #283) — a **batch** of three more in-race command decisions moved out of `Form1` into `RaceConsoleService` (per the "more per branch" preference).

- **`AdvanceRound()`** — locks dial-ins, then advances (the lock/advance pairing the "Generate Next Round" button did inline).
- **`TryShowStandings()`** — wraps the RR standings availability check.
- **`GetEligibleBuybacks()` + `ApplyBuybackSelection()`** — the buyback dispatch: empty → rejected, single pick → promoted straight to a Finals slot, two or more → stored for the Losers Bracket, returned as a `BuybackSelectionOutcome` the form maps to button state. The selection dialog stays in the form.

`Form1` now delegates `btnNextRound_Click`, `btnStandings_Click`, and `btnGenerateLosersBracket_Click` to the service.

## Behavior unchanged
Same controller calls, same dialogs, same button-state side effects. Only the decisions moved out of the form.

Advances **#284** (winner-click + reset + save/close still owned by the form — next batches).

## Test plan
- [x] MSBuild Debug — clean (only the pre-existing CS0618 warning)
- [x] `dotnet test` — **200 passed / 11 skipped / 0 failed** (5 new `RaceConsoleServiceTests`)

## Manual smoke check (please verify before merge — touches live `Form1` wiring)
1. **Generate Next Round** — advance a live race; the next round reveals and the dial-in button greys out (locked) exactly as before.
2. **Standings** — before RR completes → "not ready" message; after RR completes → standings show.
3. **Open Buybacks** (Standard RR after RR completes):
   - select **2+** drivers → "Start Losers Bracket" enables, "Open Buybacks" becomes "Edit Buybacks";
   - select **exactly 1** → Losers Bracket skipped, "Start Finals" becomes available;
   - **cancel** the dialog → nothing changes;
   - (fewer than 2 eligible → "Not enough eligible drivers" message, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)