### PR TITLE
refactor(console): extract result-entry commands to service (#284)

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceConsoleServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceConsoleServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Controllers;
 using RCDragManagerProd.Domain;
+using RCDragManagerProd.RaceEngines;
 using RCDragManagerProd.Tests.Helpers;
 
 namespace RCDragManagerProd.Tests;
@@ -106,5 +107,85 @@ public class RaceConsoleServiceTests
 
         Assert.AreEqual(BuybackSelectionOutcome.Stored, outcome);
         Assert.IsTrue(controller.IsInLosersBracketPhase, "Two or more buyback drivers enter the Losers Bracket phase");
+    }
+
+    // ── Result entry: winner submission + edit ────────────────────────────────────
+
+    [TestMethod]
+    public void SubmitWinnerFromButton_NormalMatch_MapsClickedSideViaLaneSwap()
+    {
+        var controller = StartedProLadder(out var service);
+        var match = controller.PeekUpcomingMatches(1).First(); // two real drivers, no BYE
+
+        bool swapped = controller.IsLaneSwapped(match.MatchId, match.RoundLabel, match.Driver1.Id, match.Driver2.Id);
+        var submission = service.SubmitWinnerFromButton(match.MatchId, uiFirstOption: true);
+
+        Assert.IsTrue(submission.Accepted);
+        // UI-left click → engine Driver1 normally, engine Driver2 when the lane is swapped.
+        Assert.AreEqual(!swapped, submission.EngineFirstOption);
+    }
+
+    [TestMethod]
+    public void SubmitWinnerFromButton_ByeMatch_ForcesRealDriverToWin()
+    {
+        var controller = new RaceController(TestSessionFactory.ProLadder());
+        var service = new RaceConsoleService(controller);
+        controller.GenerateBracket("Pro Ladder", TestDriverFactory.CreateProLadderByePack());
+
+        var byeMatch = controller.PeekUpcomingMatches(20)
+            .First(m => ByePolicy.IsBye(m.Driver1) ^ ByePolicy.IsBye(m.Driver2));
+        var realDriver = ByePolicy.IsBye(byeMatch.Driver1) ? byeMatch.Driver2 : byeMatch.Driver1;
+
+        // Even clicking the BYE side, the real driver must be the one advanced.
+        var submission = service.SubmitWinnerFromButton(byeMatch.MatchId, uiFirstOption: ByePolicy.IsBye(byeMatch.Driver2) ? false : true);
+
+        Assert.IsTrue(submission.Accepted);
+        Assert.AreEqual(realDriver.Id, controller.GetWinner(byeMatch.MatchId)?.Id);
+    }
+
+    [TestMethod]
+    public void SubmitWinnerFromButton_UnknownMatch_IsRejected()
+    {
+        var controller = StartedProLadder(out var service);
+
+        Assert.IsFalse(service.SubmitWinnerFromButton(999999, uiFirstOption: true).Accepted);
+    }
+
+    [TestMethod]
+    public void ValidateEditable_ReflectsMatchState()
+    {
+        var controller = StartedProLadder(out var service);
+        var match = controller.PeekUpcomingMatches(1).First();
+
+        Assert.AreEqual(EditResultStatus.NoResultYet, service.ValidateEditable(match.MatchId));
+
+        controller.SubmitWinner(match.MatchId, firstOption: true);
+        Assert.AreEqual(EditResultStatus.Editable, service.ValidateEditable(match.MatchId));
+
+        Assert.AreEqual(EditResultStatus.MatchNotFound, service.ValidateEditable(999999));
+    }
+
+    [TestMethod]
+    public void ApplyEditResult_FlipsWinner_ForActiveRoundMatch()
+    {
+        var controller = StartedProLadder(out var service);
+        var match = controller.PeekUpcomingMatches(1).First();
+
+        controller.SubmitWinner(match.MatchId, firstOption: true);
+        var firstWinner = controller.GetWinner(match.MatchId);
+
+        var ok = service.ApplyEditResult(match.MatchId, engineFirstOption: false);
+
+        Assert.IsTrue(ok);
+        Assert.AreNotEqual(firstWinner.Id, controller.GetWinner(match.MatchId).Id,
+            "Editing to the other option must flip the recorded winner");
+    }
+
+    private static RaceController StartedProLadder(out RaceConsoleService service)
+    {
+        var controller = new RaceController(TestSessionFactory.ProLadder());
+        service = new RaceConsoleService(controller);
+        service.ExecutePrimaryAction(TestDriverFactory.CreateProLadderPack(), "Pro Ladder");
+        return controller;
     }
 }

--- a/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using RCDragManagerProd.Controllers;
 using RCDragManagerProd.Domain;
+using RCDragManagerProd.RaceEngines;
 
 namespace RCDragManagerProd.AppServices
 {
@@ -92,6 +93,103 @@ namespace RCDragManagerProd.AppServices
             _controller.SetBuybackDrivers(selected);
             return BuybackSelectionOutcome.Stored;
         }
+
+        /// <summary>
+        /// Submits the winner of a match from a winner-button click. Maps the UI side that was
+        /// clicked to the engine's winner option, honoring BYEs (the real driver is forced to
+        /// win) and lane swap (a swapped pairing flips left/right). Returns whether the submit
+        /// was accepted (rejected only when both sides are BYE/unresolved). This is the mapping
+        /// that used to live inline in the console's winner-button handler; the form keeps the
+        /// stats bookkeeping that runs after a result is recorded.
+        /// </summary>
+        /// <param name="matchId">Engine match id.</param>
+        /// <param name="uiFirstOption">True when the left winner button was clicked.</param>
+        public WinnerSubmission SubmitWinnerFromButton(int matchId, bool uiFirstOption)
+        {
+            var match = _controller.GetMatch(matchId);
+            if (match == null)
+                return WinnerSubmission.Rejected;
+
+            bool d1IsBye = ByePolicy.IsBye(match.Driver1);
+            bool d2IsBye = ByePolicy.IsBye(match.Driver2);
+
+            bool engineFirstOption;
+            if (d1IsBye && !d2IsBye)
+                engineFirstOption = false;            // engine Driver2 (the real driver) wins
+            else if (d2IsBye && !d1IsBye)
+                engineFirstOption = true;             // engine Driver1 (the real driver) wins
+            else if (d1IsBye && d2IsBye)
+                return WinnerSubmission.Rejected;      // nothing real to advance
+            else
+            {
+                bool swapped = _controller.IsLaneSwapped(match.MatchId, match.RoundLabel, match.Driver1.Id, match.Driver2.Id);
+                engineFirstOption = swapped ? !uiFirstOption : uiFirstOption;
+            }
+
+            _controller.SubmitWinner(matchId, engineFirstOption);
+            return WinnerSubmission.Accept(engineFirstOption);
+        }
+
+        /// <summary>
+        /// Whether a match's result can be edited: it must exist, already have a result, and be
+        /// in the active round. Backs the validation the console's "Edit Match Result" handler
+        /// did before opening the winner picker.
+        /// </summary>
+        public EditResultStatus ValidateEditable(int matchId)
+        {
+            var match = _controller.GetMatch(matchId);
+            if (match == null) return EditResultStatus.MatchNotFound;
+            if (!match.HasResult) return EditResultStatus.NoResultYet;
+            if (!_controller.IsMatchInActiveRound(matchId)) return EditResultStatus.NotInActiveRound;
+            return EditResultStatus.Editable;
+        }
+
+        /// <summary>
+        /// Applies an edited winner for an active-round match (engine option as chosen in the
+        /// picker) and refreshes the on-deck match. Returns false if the controller rejects it.
+        /// </summary>
+        public bool ApplyEditResult(int matchId, bool engineFirstOption)
+        {
+            var ok = _controller.EditWinnerInActiveRound(matchId, engineFirstOption);
+            if (ok) _controller.PushNextMatch();
+            return ok;
+        }
+    }
+
+    /// <summary>Result of <see cref="RaceConsoleService.SubmitWinnerFromButton"/>.</summary>
+    public readonly struct WinnerSubmission
+    {
+        private WinnerSubmission(bool accepted, bool engineFirstOption)
+        {
+            Accepted = accepted;
+            EngineFirstOption = engineFirstOption;
+        }
+
+        /// <summary>False only when the match could not be resolved (both sides BYE / not found).</summary>
+        public bool Accepted { get; }
+
+        /// <summary>The engine winner option that was submitted (meaningful when accepted).</summary>
+        public bool EngineFirstOption { get; }
+
+        public static readonly WinnerSubmission Rejected = new WinnerSubmission(false, false);
+
+        public static WinnerSubmission Accept(bool engineFirstOption) => new WinnerSubmission(true, engineFirstOption);
+    }
+
+    /// <summary>Result of <see cref="RaceConsoleService.ValidateEditable"/>.</summary>
+    public enum EditResultStatus
+    {
+        /// <summary>No match with that id.</summary>
+        MatchNotFound,
+
+        /// <summary>The match has not run yet — nothing to edit.</summary>
+        NoResultYet,
+
+        /// <summary>Only active-round results can be changed.</summary>
+        NotInActiveRound,
+
+        /// <summary>The result can be edited.</summary>
+        Editable
     }
 
     /// <summary>Result of <see cref="RaceConsoleService.ApplyBuybackSelection"/>.</summary>

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -522,28 +522,25 @@ namespace RCDragManagerProd.UI.Forms
                     return;
                 }
 
+                // Editability rules (exists / has a result / in the active round) now live in
+                // RaceConsoleService (issue #284); the form maps each status to its message.
+                switch (_raceConsole.ValidateEditable(matchId))
+                {
+                    case EditResultStatus.MatchNotFound:
+                        RaceDialogs.Warn(this, "Match not found.", "Edit Match Result");
+                        Logger.Log($"[UI][EDIT] GetMatch({matchId}) returned null.");
+                        return;
+                    case EditResultStatus.NoResultYet:
+                        RaceDialogs.Info(this, "That match has not run yet.", "Edit Match Result");
+                        Logger.Log($"[UI][EDIT] Reject — M{matchId} has no result yet.");
+                        return;
+                    case EditResultStatus.NotInActiveRound:
+                        RaceDialogs.Info(this, "You can only change results for the ACTIVE round.", "Edit Match Result");
+                        Logger.Log($"[UI][EDIT] Reject — M{matchId} not in active round.");
+                        return;
+                }
+
                 var match = _controller.GetMatch(matchId);
-                if (match == null)
-                {
-                    RaceDialogs.Warn(this, "Match not found.", "Edit Match Result");
-                    Logger.Log($"[UI][EDIT] GetMatch({matchId}) returned null.");
-                    return;
-                }
-
-                if (!match.HasResult)
-                {
-                    RaceDialogs.Info(this, "That match has not run yet.", "Edit Match Result");
-                    Logger.Log($"[UI][EDIT] Reject — M{matchId} has no result yet.");
-                    return;
-                }
-
-                if (!_controller.IsMatchInActiveRound(matchId))
-                {
-                    RaceDialogs.Info(this, "You can only change results for the ACTIVE round.", "Edit Match Result");
-                    Logger.Log($"[UI][EDIT] Reject — M{matchId} not in active round.");
-                    return;
-                }
-
                 int choice = ShowWinnerPicker(match);
                 if (choice == 0)
                 {
@@ -555,7 +552,7 @@ namespace RCDragManagerProd.UI.Forms
                 var d1 = match.Driver1?.Name ?? "BYE";
                 var d2 = match.Driver2?.Name ?? "BYE";
 
-                var ok = _controller.EditWinnerInActiveRound(matchId, setFirst);
+                var ok = _raceConsole.ApplyEditResult(matchId, setFirst);
                 Logger.Log($"[UI][EDIT] Set winner {(setFirst ? d1 : d2)} for M{matchId} → {(ok ? "OK" : "REJECTED")}");
 
                 if (!ok)
@@ -564,8 +561,6 @@ namespace RCDragManagerProd.UI.Forms
                         "Edit Match Result");
                     return;
                 }
-
-                _controller.PushNextMatch();
             }
             catch (Exception ex)
             {

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.WinnerButtons.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.WinnerButtons.cs
@@ -74,51 +74,14 @@ namespace RCDragManagerProd.UI.Forms
             string round;
             round = match.RoundLabel ?? "Unknown";
 
-            // ---- Source of truth: ENGINE drivers ----
-            bool d1IsBye;
-            bool d2IsBye;
-
-            d1IsBye = ByePolicy.IsBye(match.Driver1);
-            d2IsBye = ByePolicy.IsBye(match.Driver2);
-
-            Logger.Log("[UI][WINNER] Engine snapshot: M" + matchId + " (" + round + ") " +
-                       "D1=" + (match.Driver1 != null ? match.Driver1.Name : "NULL") + " bye=" + d1IsBye + " | " +
-                       "D2=" + (match.Driver2 != null ? match.Driver2.Name : "NULL") + " bye=" + d2IsBye);
-
-            bool engineFirstOption;
-
-            // ---- BYE matches: force the real engine driver to win (ignores swap + button clicked) ----
-            if (d1IsBye && !d2IsBye)
+            // BYE-forcing + lane-swap → engine winner option, and the submit itself, now live
+            // in RaceConsoleService (issue #284). The form keeps the post-result stats below.
+            var submission = _raceConsole.SubmitWinnerFromButton(matchId, firstOption);
+            if (!submission.Accepted)
             {
-                engineFirstOption = false; // Engine Driver2 must win
-                Logger.Log("[UI][WINNER] Mapping: Engine D1 is BYE => force Engine option=2 (engineFirstOption=false)");
-            }
-            else if (d2IsBye && !d1IsBye)
-            {
-                engineFirstOption = true; // Engine Driver1 must win
-                Logger.Log("[UI][WINNER] Mapping: Engine D2 is BYE => force Engine option=1 (engineFirstOption=true)");
-            }
-            else if (d1IsBye && d2IsBye)
-            {
-                Logger.Log("[UI][WINNER][ERROR] Both engine sides are BYE/NULL for M" + matchId + " (" + round + "). Cannot submit winner.");
+                Logger.Log("[UI][WINNER] Submit not accepted (both sides BYE/unresolved) for M" + matchId + " (" + round + ").");
                 return;
             }
-            else
-            {
-                // ---- Normal match: use lane swap mapping ----
-                bool swapped;
-                swapped = _controller.IsLaneSwapped(match.MatchId, match.RoundLabel, match.Driver1.Id, match.Driver2.Id);
-
-                // firstOption == UI-left button. If swapped, UI-left corresponds to engine Driver2.
-                engineFirstOption = swapped ? !firstOption : firstOption;
-
-                Logger.Log("[UI][WINNER] Mapping: Normal match swapped=" + swapped +
-                           " UI-firstOption(left)=" + firstOption +
-                           " => engineFirstOption=" + engineFirstOption);
-            }
-
-            Logger.Log("[UI][WINNER] Calling SubmitWinner(M" + matchId + ", engineFirstOption=" + engineFirstOption + ")...");
-            _controller.SubmitWinner(matchId, engineFirstOption);
 
             var winner = _controller.GetWinner(matchId);
             var loser = _controller.GetLoser(matchId);


### PR DESCRIPTION
## Summary
Continues the race-console extraction (#284, under #283) — moves the **result-entry** logic out of `Form1` into `RaceConsoleService`.

- **`SubmitWinnerFromButton(matchId, uiFirstOption)`** — maps the clicked winner button to the engine's winner option: **BYE-forcing** (the real driver always wins) and **lane-swap** (a swapped pairing flips left/right), then submits. Returns a `WinnerSubmission` (`Accepted` is false only when both sides are BYE/unresolved). This is the error-prone mapping that used to sit inline in the winner-button handler.
- **`ValidateEditable(matchId)`** — `MatchNotFound` / `NoResultYet` / `NotInActiveRound` / `Editable`, the guard the Edit Match Result handler ran before opening the picker.
- **`ApplyEditResult(matchId, engineFirstOption)`** — edits the active-round winner and refreshes the on-deck match.

`Form1.HandleWinnerClick` keeps the post-result **stats bookkeeping**; `btnEditResult_Click` keeps the **winner-picker dialog** and message mapping.

## Behavior unchanged
Same engine calls, same dialogs, same stats. Only the mapping/validation decisions moved into the service.

Advances **#284** (reset + save/close still owned by the form — they need a repository seam, a later batch).

## Test plan
- [x] MSBuild Debug — clean (only the pre-existing CS0618 warning)
- [x] `dotnet test` — **205 passed / 11 skipped / 0 failed** (5 new `RaceConsoleServiceTests`)

## Manual smoke check (please verify before merge — this touches the live winner-selection path, which is race-critical)
1. **Pick a winner** — click each side's winner button in a normal match; the driver you clicked is recorded as the winner (try a round where lane swap is visible — the displayed left/right still maps to the correct driver).
2. **BYE match** — in a bracket with a BYE, the real driver advances (the BYE side button stays disabled, as before).
3. **Edit Match Result** — select a finished active-round match → picker opens → choosing the other driver flips the result; selecting a non-active-round or not-yet-run match shows the same messages as before.
4. **Stats** — a normal (non-BYE) result still updates driver win/loss; a Final still bumps the event win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)