### PR TITLE
refactor(console): extract save/close via IRaceSessionStore seam (#284)

### DIFF
--- a/src/RCDragManagerProd.Tests/Helpers/RecordingSessionStore.cs
+++ b/src/RCDragManagerProd.Tests/Helpers/RecordingSessionStore.cs
@@ -1,0 +1,15 @@
+using RCDragManagerProd.AppServices;
+
+namespace RCDragManagerProd.Tests.Helpers;
+
+/// <summary>
+/// Test double for <see cref="IRaceSessionStore"/> that counts persistence calls instead
+/// of writing to repositories. Lets headless tests assert that save/close orchestration in
+/// <see cref="RaceConsoleService"/> persisted through the store (issue #284).
+/// </summary>
+internal sealed class RecordingSessionStore : IRaceSessionStore
+{
+    public int PersistCount { get; private set; }
+
+    public void Persist() => PersistCount++;
+}

--- a/src/RCDragManagerProd.Tests/RaceConsoleServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceConsoleServiceTests.cs
@@ -181,6 +181,43 @@ public class RaceConsoleServiceTests
             "Editing to the other option must flip the recorded winner");
     }
 
+    // ── Save / Close persistence ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void SaveProgress_PersistsAndKeepsRaceOpen()
+    {
+        var controller = new RaceController(TestSessionFactory.ProLadder());
+        var store = new RecordingSessionStore();
+        var service = new RaceConsoleService(controller, store);
+
+        service.SaveProgress();
+
+        Assert.AreEqual(1, store.PersistCount, "Save Progress must write through the session store");
+        Assert.IsFalse(controller.Session.IsClosed, "Save Progress keeps the race open");
+    }
+
+    [TestMethod]
+    public void CloseRace_MarksClosedAndPersists()
+    {
+        var controller = new RaceController(TestSessionFactory.ProLadder());
+        var store = new RecordingSessionStore();
+        var service = new RaceConsoleService(controller, store);
+
+        service.CloseRace();
+
+        Assert.AreEqual(1, store.PersistCount, "Close Race must write through the session store");
+        Assert.IsTrue(controller.Session.IsClosed, "Close Race marks the event finished");
+    }
+
+    [TestMethod]
+    public void PersistenceCommands_WithoutStore_Throw()
+    {
+        var service = new RaceConsoleService(new RaceController(TestSessionFactory.ProLadder()));
+
+        Assert.ThrowsExactly<System.InvalidOperationException>(() => service.SaveProgress());
+        Assert.ThrowsExactly<System.InvalidOperationException>(() => service.CloseRace());
+    }
+
     private static RaceController StartedProLadder(out RaceConsoleService service)
     {
         var controller = new RaceController(TestSessionFactory.ProLadder());

--- a/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
@@ -15,10 +15,12 @@ namespace RCDragManagerProd.AppServices
     public sealed class RaceConsoleService
     {
         private readonly RaceController _controller;
+        private readonly IRaceSessionStore _store;
 
-        public RaceConsoleService(RaceController controller)
+        public RaceConsoleService(RaceController controller, IRaceSessionStore store = null)
         {
             _controller = controller ?? throw new ArgumentNullException(nameof(controller));
+            _store = store;
         }
 
         /// <summary>Current console state snapshot.</summary>
@@ -154,6 +156,50 @@ namespace RCDragManagerProd.AppServices
             if (ok) _controller.PushNextMatch();
             return ok;
         }
+
+        /// <summary>
+        /// Captures a resumable checkpoint and writes it through the session store: the race
+        /// stays open and can be reopened later. Backs both "Save Progress" and the recovery
+        /// snapshot taken before an active-race reset.
+        /// </summary>
+        public void SaveProgress()
+        {
+            RequireStore();
+            _controller.SaveProgress();
+            _store.Persist();
+        }
+
+        /// <summary>
+        /// Finalises and closes the event: captures final state into the session, marks it
+        /// finished, and persists. Stat recomputation and leaving the console stay with the
+        /// caller (they are UI/lifecycle concerns).
+        /// </summary>
+        public void CloseRace()
+        {
+            RequireStore();
+            _controller.SaveSession();
+            _controller.CloseRace();
+            _store.Persist();
+        }
+
+        private void RequireStore()
+        {
+            if (_store == null)
+                throw new InvalidOperationException(
+                    "This RaceConsoleService was created without an IRaceSessionStore; persistence commands are unavailable.");
+        }
+    }
+
+    /// <summary>
+    /// Persistence seam for the race console: writes the current session (and parent
+    /// multi-class event, when hosted) through the repositories. The console form implements
+    /// this over its repositories so save/close orchestration can live in
+    /// <see cref="RaceConsoleService"/> and be tested with a fake store (issue #284/#283).
+    /// </summary>
+    public interface IRaceSessionStore
+    {
+        /// <summary>Writes the current race session through the repositories.</summary>
+        void Persist();
     }
 
     /// <summary>Result of <see cref="RaceConsoleService.SubmitWinnerFromButton"/>.</summary>

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs
@@ -364,8 +364,7 @@ namespace RCDragManagerProd.UI.Forms
 
             try
             {
-                _controller.SaveProgress();
-                PersistSession();
+                _raceConsole.SaveProgress();   // controller checkpoint + repository write (issue #284)
                 Logger.Log("[RESET] Recovery snapshot saved before active-race reset.");
             }
             catch (Exception ex)
@@ -387,8 +386,7 @@ namespace RCDragManagerProd.UI.Forms
                 return;
             }
 
-            _controller.SaveProgress();   // captures a resumable checkpoint, keeps race open
-            PersistSession();
+            _raceConsole.SaveProgress();   // checkpoint + persist, keeps race open (issue #284)
 
             RaceDialogs.Success(this, "Race progress saved. You can resume this race later.", "Progress Saved");
         }
@@ -408,9 +406,7 @@ namespace RCDragManagerProd.UI.Forms
             if (!confirmed)
                 return;
 
-            _controller.SaveSession();   // capture final state into the session
-            _controller.CloseRace();     // mark the event finished
-            PersistSession();
+            _raceConsole.CloseRace();    // capture final state, mark finished, persist (issue #284)
             _controller.RecomputeEventsWon(drivers, Program.ConnectionString);
 
             if (IsHostedMode)

--- a/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
+++ b/src/RCDragManagerProd/UI/Forms/Main/Form1.cs
@@ -13,7 +13,7 @@ using RCDragManagerProd.Repositories;
 
 namespace RCDragManagerProd.UI.Forms
 {
-    public partial class Form1 : Form
+    public partial class Form1 : Form, IRaceSessionStore
     {
         private List<Driver> drivers = new List<Driver>();
         private RaceSession currentSession;
@@ -41,7 +41,7 @@ namespace RCDragManagerProd.UI.Forms
         public Form1(RaceController controller)
         {
             _controller = controller ?? throw new ArgumentNullException(nameof(controller));
-            _raceConsole = new RaceConsoleService(_controller);
+            _raceConsole = new RaceConsoleService(_controller, this);
             InitializeComponent();
 
             btnEditResult.Click += btnEditResult_Click;
@@ -119,6 +119,11 @@ namespace RCDragManagerProd.UI.Forms
 
             base.OnFormClosed(e);
         }
+
+        // IRaceSessionStore: RaceConsoleService calls this to persist save/close orchestration
+        // through the form's repositories (issue #284). Callers guard quick sessions
+        // (currentSession == null) before invoking the persistence commands.
+        void IRaceSessionStore.Persist() => PersistSession();
         private sealed class WinnerButtonContext
         {
             public int MatchId { get; set; }


### PR DESCRIPTION
## Summary
Completes the race-console command extraction (#284, under #283) by moving the **save/close** orchestration out of `Form1`, behind a small persistence seam.

- **`IRaceSessionStore`** — a one-method seam (`Persist()`) the console form implements over its repositories. Lets save/close orchestration live in the service and be tested with a fake store, per #283's "put repository calls behind services" goal.
- **`RaceConsoleService.SaveProgress()`** — controller checkpoint + `Persist` (race stays open). Backs both "Save Progress" and the pre-reset recovery snapshot.
- **`RaceConsoleService.CloseRace()`** — `SaveSession` + `CloseRace` + `Persist` (event marked finished). Stat recompute and leaving the console stay with the form (UI/lifecycle).

`Form1` now implements `IRaceSessionStore` (`Persist` → the existing `PersistSession`) and delegates `btnSaveProgress_Click`, `btnCloseRace_Click`, and `SaveRecoverySnapshot` to the service.

## Behavior unchanged
The repository write still runs in the same spot (preserved ordering: SaveSession → CloseRace → Persist → RecomputeEventsWon), quick-session guards stay in the form, dialogs and `Close()`/hosted handoff stay in the form.

With this, the console's command workflow (build/start, advance, standings, buyback, winner, edit, save/close) is fully extracted into `RaceConsoleService` — **#284's command-handling goal is complete**. (Reset's UI clearing remains in the form; its recovery snapshot now routes through the service.)

## Test plan
- [x] MSBuild Debug — clean (only the pre-existing CS0618 warning)
- [x] `dotnet test` — **208 passed / 11 skipped / 0 failed** (3 new tests with a `RecordingSessionStore` double)

## Manual smoke check (please verify before merge — touches save/persist + close lifecycle)
1. **Save Progress** — mid-race, click Save Progress → "Progress Saved" message; reload the saved session later and it resumes where it was.
2. **Close Race** — click Close Race → confirm → event closes (and in a multi-class event, control returns to the multi-class screen; standalone closes the window).
3. **Reset an active race** — confirm → a recovery snapshot is written first (the race can be reloaded), then the bracket clears.
4. **Quick Session** — Save Progress says "nothing to save"; Close Race just closes — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)