### PR TITLE
refactor(load-session): extract LoadSessionService from LoadSessionForm (#288)

### DIFF
--- a/Docs/claude-context/UI-EXTRACTION-HANDOVER.md
+++ b/Docs/claude-context/UI-EXTRACTION-HANDOVER.md
@@ -1,0 +1,65 @@
+# Handover — RC Drag Manager: "forms are pure UI" extraction epic
+
+_Last updated: 2026-06-11_
+
+## The goal
+Reduce **every** WinForms form to *pure UI* (code-behind = control wiring + rendering +
+dialog show/close only; all workflow/validation/persistence delegated to services in
+`RCDragManagerProd.AppServices`). The app must look & behave **identically** (no visible
+change). Then **tag that commit as the clean "ready for new UI" release** so the new UI can
+be built on UI-independent services. This is the #283 epic.
+
+## Working agreement
+- Assistant acts as senior dev; the owner merges PRs manually and smoke-tests the UI. Pick
+  the next screen yourself — don't ask.
+- **One screen per branch/PR, batching several slices per branch** (owner asked for "more
+  per branch" — not one tiny PR per slice).
+- Per branch: create `<Screen>Service` → rewire the form → MSBuild → full `dotnet test`
+  (green) → stage **only the assistant's own files** (the working tree carries ~25 unrelated
+  dirty `Docs/`/`.claude/` files — keep them out of every commit) → file-based commit ending
+  with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` → push → **one** PR with a
+  manual smoke-test checklist → **wait for the owner's "merged"** (never auto-merge).
+
+## Key technical notes
+- **Build:** MSBuild via PowerShell (not Git Bash):
+  `& "C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe" "src\RCDragManagerProd\RCDragManagerProd.sln" /t:Build /p:Configuration=Debug /v:minimal /nologo`
+- **Test:** `dotnet test src\RCDragManagerProd.Tests\RCDragManagerProd.Tests.csproj --nologo -v minimal --blame-hang-timeout 90s`
+  — run **plain in the background**, never with a `2>&1 | Select-String` pipe (hangs PowerShell 5.1).
+- Namespace is **`AppServices`** (NOT `Application` — collides with `System.Windows.Forms.Application`).
+- New **production** `.cs` files need a `<Compile Include>` in the non-SDK
+  `RCDragManagerProd.csproj`; the test project is SDK-style (no entry needed).
+- MSTest throw assertion is `Assert.ThrowsExactly<T>` (not `ThrowsException`).
+  `TemporarySqliteDb` is a per-file private nested test helper (copy it; it's not shared).
+- Forms can't be GUI-verified by the assistant — that's why every PR ships a smoke checklist
+  for the owner to run before merging.
+
+## Done (merged)
+Race console (`Form1`) fully extracted into `RaceConsoleService` + `RaceConsoleViewModel`/
+builder (PRs #321/#323/#324/#325/#326): build/start, advance, standings, buyback,
+winner-submit (BYE + lane-swap mapping), edit-result, and save/close via an
+`IRaceSessionStore` seam. Plus bug fix #322 (QMDRA finals was clearing the match-up grid).
+
+## In flight
+**PR #327** `refactor/drivermanager-service-286` — `DriverManagerService` extracted from
+`DriverManagerForm` (#286). **Awaiting owner merge.** `main` is at the #326 merge.
+
+## Remaining batches to the tag (~5–7 PRs, rough order)
+1. **#288 LoadSessionForm** — load/delete sessions & events (do this next after #327 merges).
+2. **#287 MultiClassConfigDialog** (~677 lines, biggest) + **MultiClassSetupForm**.
+3. **#289 MultiClassRaceForm** — multi-class coordination, stats, completion.
+4. **Form1 residual** — setup-roster add/edit driver + qual-time validation in
+   `Form1.Events.cs`, and `OnTournamentCompleted` stats.
+5. Audit smaller forms/dialogs (Settings, DriverStats, Add*/Edit* dialogs) — extract any
+   validation; leave pure input dialogs as-is.
+6. Final grep audit (no repository / validation / business logic left in any form) →
+   **tag the release**.
+
+## First step in a new session
+Check whether PR #327 is merged (`gh pr view 327 --json state`).
+- **If merged:** sync `main`, delete the merged branch, then start **#288 LoadSessionForm**
+  (read `src/RCDragManagerProd/UI/Forms/Session/LoadSessionForm.cs`, extract load/delete of
+  sessions & events into a `LoadSessionService`).
+- **If not merged yet:** wait for the owner.
+
+Test baseline after #286: **215 passed / 11 skipped / 0 failed**. Known noise: CS0618 at
+`RaceController.EngineCalls.cs:46`; MSTEST0037 analyzer suggestions; 11 multi-class skips.

--- a/src/RCDragManagerProd.Tests/LoadSessionServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/LoadSessionServiceTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Covers <see cref="LoadSessionService"/> (issue #288) — the UI-independent saved-race
+/// loading operations the Load Session screen delegates to. Runs headless against an
+/// in-memory database, proving the form needs no repositories of its own.
+/// </summary>
+[TestClass]
+public class LoadSessionServiceTests
+{
+    private static LoadSessionService NewService(TemporarySqliteDb db)
+    {
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        return new LoadSessionService(
+            new RaceSessionRepository(db.ConnectionString),
+            new MultiClassEventRepository(db.ConnectionString));
+    }
+
+    // ── ListSessions ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ListSessions_EmptyDb_ReturnsEmptyList()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var sessions = service.ListSessions();
+
+        Assert.IsNotNull(sessions);
+        Assert.AreEqual(0, sessions.Count);
+    }
+
+    [TestMethod]
+    public void ListSessions_AfterSave_ReturnsSummaryRow()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        repo.SaveSession(MakeSession("Spring Nats", "Pro Mod", "Round Robin"));
+
+        var sessions = service.ListSessions();
+
+        Assert.AreEqual(1, sessions.Count);
+        Assert.AreEqual("Spring Nats", sessions[0].EventName);
+        Assert.AreEqual("Pro Mod", sessions[0].ClassType);
+        Assert.AreEqual("Round Robin", sessions[0].RaceType);
+    }
+
+    // ── ListMultiClassEvents ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ListMultiClassEvents_EmptyDb_ReturnsEmptyList()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var events = service.ListMultiClassEvents();
+
+        Assert.IsNotNull(events);
+        Assert.AreEqual(0, events.Count);
+    }
+
+    [TestMethod]
+    public void ListMultiClassEvents_AfterSave_ReturnsSummaryRow()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var multiRepo = new MultiClassEventRepository(db.ConnectionString);
+        var session1 = MakeSession("Class A", "Open", "Round Robin");
+        var session2 = MakeSession("Class B", "Pro", "Round Robin");
+        multiRepo.SaveEvent(new MultiClassEvent
+        {
+            EventName = "Big Weekend",
+            EventDate = new DateTime(2026, 3, 1),
+            ClassSessions = new List<RaceSession> { session1, session2 }
+        });
+
+        var events = service.ListMultiClassEvents();
+
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual("Big Weekend", events[0].EventName);
+        Assert.AreEqual(2, events[0].ClassCount);
+    }
+
+    // ── LoadSingleClassSession ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void LoadSingleClassSession_ValidId_WrapsInOneClassMultiClassEvent()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        var session = MakeSession("Summer Shoot-Out", "Sportsman", "Round Robin");
+        repo.SaveSession(session);
+        int id = service.ListSessions()[0].Id;
+
+        var result = service.LoadSingleClassSession(id);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Event);
+        Assert.AreEqual("Summer Shoot-Out", result.Event.EventName);
+        Assert.AreEqual(1, result.Event.ClassSessions.Count);
+        Assert.AreEqual("Sportsman", result.Event.ClassSessions[0].ClassType);
+    }
+
+    [TestMethod]
+    public void LoadSingleClassSession_InvalidId_ReturnsFailure()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var result = service.LoadSingleClassSession(999);
+
+        Assert.IsFalse(result.Success);
+        Assert.IsNull(result.Event);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.ErrorMessage));
+    }
+
+    [TestMethod]
+    public void LoadSingleClassSession_SessionWithDefaultDate_UsesNowAsEventDate()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        var session = MakeSession("No-Date Session", "Open", "Round Robin");
+        session.EventDate = default;
+        repo.SaveSession(session);
+        int id = service.ListSessions()[0].Id;
+
+        var result = service.LoadSingleClassSession(id);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreNotEqual(default(DateTime), result.Event.EventDate);
+    }
+
+    // ── LoadMultiClassEvent ───────────────────────────────────────────────────
+
+    [TestMethod]
+    public void LoadMultiClassEvent_ValidId_ReturnsEvent()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var multiRepo = new MultiClassEventRepository(db.ConnectionString);
+        var evt = new MultiClassEvent
+        {
+            EventName = "Autumn Opener",
+            EventDate = new DateTime(2026, 9, 15),
+            ClassSessions = new List<RaceSession> { MakeSession("Open A", "Open", "Round Robin") }
+        };
+        multiRepo.SaveEvent(evt);
+        int id = service.ListMultiClassEvents()[0].Id;
+
+        var result = service.LoadMultiClassEvent(id);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Event);
+        Assert.AreEqual("Autumn Opener", result.Event.EventName);
+    }
+
+    [TestMethod]
+    public void LoadMultiClassEvent_InvalidId_ReturnsFailure()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var result = service.LoadMultiClassEvent(999);
+
+        Assert.IsFalse(result.Success);
+        Assert.IsNull(result.Event);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.ErrorMessage));
+    }
+
+    // ── DeleteSession ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DeleteSession_RemovesRowFromList()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        repo.SaveSession(MakeSession("To Delete", "Open", "Round Robin"));
+        int id = service.ListSessions()[0].Id;
+
+        service.DeleteSession(id);
+
+        Assert.AreEqual(0, service.ListSessions().Count);
+    }
+
+    // ── DeleteMultiClassEvent ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DeleteMultiClassEvent_RemovesRowFromList()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var multiRepo = new MultiClassEventRepository(db.ConnectionString);
+        multiRepo.SaveEvent(new MultiClassEvent
+        {
+            EventName = "To Delete",
+            EventDate = DateTime.Now,
+            ClassSessions = new List<RaceSession> { MakeSession("C1", "Open", "Round Robin") }
+        });
+        int id = service.ListMultiClassEvents()[0].Id;
+
+        service.DeleteMultiClassEvent(id);
+
+        Assert.AreEqual(0, service.ListMultiClassEvents().Count);
+    }
+
+    // ── LoadResult ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void LoadResult_Ok_HasSuccessAndEvent()
+    {
+        var evt = new MultiClassEvent { EventName = "X", ClassSessions = new List<RaceSession>() };
+
+        var result = LoadResult.Ok(evt);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreSame(evt, result.Event);
+        Assert.IsNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public void LoadResult_Fail_HasErrorAndNoEvent()
+    {
+        var result = LoadResult.Fail("oops");
+
+        Assert.IsFalse(result.Success);
+        Assert.IsNull(result.Event);
+        Assert.AreEqual("oops", result.ErrorMessage);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static RaceSession MakeSession(string eventName, string classType, string raceType) =>
+        new RaceSession
+        {
+            EventName = eventName,
+            ClassType = classType,
+            RaceType = raceType,
+            EventDate = new DateTime(2026, 1, 1),
+            Drivers = new List<Driver>()
+        };
+
+    private sealed class TemporarySqliteDb : IDisposable
+    {
+        public TemporarySqliteDb()
+        {
+            DatabasePath = Path.Combine(
+                Path.GetTempPath(),
+                $"rcdragmanager-loadsession-svc-tests-{Guid.NewGuid():N}.db");
+        }
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try
+            {
+                if (File.Exists(DatabasePath))
+                    File.Delete(DatabasePath);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/src/RCDragManagerProd/AppServices/LoadSessionService.cs
+++ b/src/RCDragManagerProd/AppServices/LoadSessionService.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Logging;
+using RCDragManagerProd.Repositories;
+using RCDragManagerProd.ViewModels;
+
+namespace RCDragManagerProd.AppServices
+{
+    /// <summary>
+    /// UI-independent saved-race loading operations for the Load Session screen (issue #288).
+    /// Wraps <see cref="RaceSessionRepository"/> and <see cref="MultiClassEventRepository"/> so
+    /// the form holds no repositories and performs no persistence or domain assembly itself.
+    /// No WinForms references — the same operations can back a future UI and are covered by
+    /// headless tests against an in-memory database.
+    /// </summary>
+    public sealed class LoadSessionService
+    {
+        private readonly RaceSessionRepository _sessionRepo;
+        private readonly MultiClassEventRepository _multiClassRepo;
+
+        public LoadSessionService(RaceSessionRepository sessionRepo, MultiClassEventRepository multiClassRepo)
+        {
+            _sessionRepo = sessionRepo ?? throw new ArgumentNullException(nameof(sessionRepo));
+            _multiClassRepo = multiClassRepo ?? throw new ArgumentNullException(nameof(multiClassRepo));
+        }
+
+        // ── List ─────────────────────────────────────────────────────────────────
+
+        public List<RaceSessionSummary> ListSessions()
+        {
+            Logger.Log("[SVC][LoadSession] ListSessions()");
+            return _sessionRepo.GetAllSessions() ?? new List<RaceSessionSummary>();
+        }
+
+        public List<MultiClassEventSummary> ListMultiClassEvents()
+        {
+            Logger.Log("[SVC][LoadSession] ListMultiClassEvents()");
+            return _multiClassRepo.GetAllEvents() ?? new List<MultiClassEventSummary>();
+        }
+
+        // ── Load ─────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Loads a single-class session by id and wraps it into a one-class
+        /// <see cref="MultiClassEvent"/> ready to open in <c>MultiClassRaceForm</c>.
+        /// </summary>
+        public LoadResult LoadSingleClassSession(int id)
+        {
+            Logger.Log($"[SVC][LoadSession] LoadSingleClassSession(id={id})");
+            var session = _sessionRepo.LoadSession(id);
+            if (session == null)
+            {
+                Logger.Log("[SVC][LoadSession][WARN] Repository returned null session");
+                return LoadResult.Fail("Unable to load the selected session.");
+            }
+
+            var wrapped = new MultiClassEvent
+            {
+                EventName = session.EventName,
+                EventDate = session.EventDate != default ? session.EventDate : DateTime.Now,
+                ClassSessions = new List<RaceSession> { session }
+            };
+
+            Logger.Log($"[SVC][LoadSession] Wrapped '{wrapped.EventName}' (raceType='{session.RaceType}') into MultiClassEvent");
+            return LoadResult.Ok(wrapped);
+        }
+
+        /// <summary>Loads a multi-class event by id.</summary>
+        public LoadResult LoadMultiClassEvent(int id)
+        {
+            Logger.Log($"[SVC][LoadSession] LoadMultiClassEvent(id={id})");
+            var evt = _multiClassRepo.LoadEvent(id);
+            if (evt == null)
+            {
+                Logger.Log("[SVC][LoadSession][WARN] MultiClassEventRepository returned null");
+                return LoadResult.Fail("Unable to load the selected event.");
+            }
+
+            return LoadResult.Ok(evt);
+        }
+
+        // ── Delete ────────────────────────────────────────────────────────────────
+
+        public void DeleteSession(int id)
+        {
+            Logger.Log($"[SVC][LoadSession] DeleteSession(id={id})");
+            _sessionRepo.DeleteSession(id);
+        }
+
+        public void DeleteMultiClassEvent(int id)
+        {
+            Logger.Log($"[SVC][LoadSession] DeleteMultiClassEvent(id={id})");
+            _multiClassRepo.DeleteEvent(id);
+        }
+    }
+
+    /// <summary>Result returned by load operations — carries the loaded event or an error message.</summary>
+    public sealed class LoadResult
+    {
+        public bool Success { get; }
+        public string ErrorMessage { get; }
+        public MultiClassEvent Event { get; }
+
+        private LoadResult(bool success, string errorMessage, MultiClassEvent evt)
+        {
+            Success = success;
+            ErrorMessage = errorMessage;
+            Event = evt;
+        }
+
+        public static LoadResult Ok(MultiClassEvent evt) =>
+            new LoadResult(true, null, evt ?? throw new ArgumentNullException(nameof(evt)));
+
+        public static LoadResult Fail(string message) =>
+            new LoadResult(false, message ?? "Unknown error.", null);
+    }
+}

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -111,6 +111,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppServices\DriverManagerService.cs" />
+    <Compile Include="AppServices\LoadSessionService.cs" />
     <Compile Include="AppServices\RaceConsoleService.cs" />
     <Compile Include="AppServices\RaceConsoleViewModel.cs" />
     <Compile Include="AppServices\RaceConsoleViewModelBuilder.cs" />

--- a/src/RCDragManagerProd/UI/Forms/Session/LoadSessionForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/LoadSessionForm.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
-using RCDragManagerProd.Domain;
+using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Logging;
 using RCDragManagerProd.Repositories;
 using RCDragManagerProd.ViewModels;
@@ -10,31 +10,31 @@ namespace RCDragManagerProd.UI.Forms
 {
     public partial class LoadSessionForm : Form
     {
+        private readonly LoadSessionService _service;
         private readonly string _connectionString;
-        private readonly RaceSessionRepository _sessionRepository;
-        private readonly MultiClassEventRepository _multiClassRepo;
-
-        private List<RaceSessionSummary> _sessions;
-        private List<MultiClassEventSummary> _multiEvents;
-
-        /// <summary>Set when a single-class session is loaded (DialogResult.OK).</summary>
-        public RaceSession LoadedSession { get; private set; }
 
         public LoadSessionForm(string connectionString)
+            : this(
+                new LoadSessionService(
+                    new RaceSessionRepository(connectionString),
+                    new MultiClassEventRepository(connectionString)),
+                connectionString)
         {
+        }
+
+        internal LoadSessionForm(LoadSessionService service, string connectionString)
+        {
+            if (service == null) throw new ArgumentNullException(nameof(service));
             if (string.IsNullOrWhiteSpace(connectionString))
                 throw new ArgumentNullException(nameof(connectionString));
 
             Logger.Log("[UI][LoadSession] ctor");
+            _service = service;
             _connectionString = connectionString;
 
             InitializeComponent();
             ConfigureListView();
             ConfigureMultiClassListView();
-
-            _sessionRepository = new RaceSessionRepository(connectionString);
-            _multiClassRepo = new MultiClassEventRepository(connectionString);
-            Logger.Log("[UI][LoadSession] Repositories ready");
 
             LoadSessions();
             LoadMultiClassEvents();
@@ -64,12 +64,12 @@ namespace RCDragManagerProd.UI.Forms
             try
             {
                 Logger.Log("[UI][LoadSession] Loading single-class sessions…");
-                _sessions = _sessionRepository.GetAllSessions() ?? new List<RaceSessionSummary>();
+                var sessions = _service.ListSessions();
 
                 lvSessions.BeginUpdate();
                 lvSessions.Items.Clear();
 
-                foreach (var s in _sessions)
+                foreach (var s in sessions)
                 {
                     var item = new ListViewItem(s.EventName);
                     item.SubItems.Add(s.EventDate.ToString("yyyy-MM-dd HH:mm"));
@@ -80,7 +80,7 @@ namespace RCDragManagerProd.UI.Forms
                 }
 
                 lvSessions.EndUpdate();
-                Logger.Log($"[UI][LoadSession] Loaded {_sessions.Count} single-class sessions");
+                Logger.Log($"[UI][LoadSession] Loaded {sessions.Count} single-class sessions");
             }
             catch (Exception ex)
             {
@@ -113,12 +113,12 @@ namespace RCDragManagerProd.UI.Forms
             try
             {
                 Logger.Log("[UI][LoadSession] Loading multi-class events…");
-                _multiEvents = _multiClassRepo.GetAllEvents() ?? new List<MultiClassEventSummary>();
+                var events = _service.ListMultiClassEvents();
 
                 lvMultiClass.BeginUpdate();
                 lvMultiClass.Items.Clear();
 
-                foreach (var evt in _multiEvents)
+                foreach (var evt in events)
                 {
                     var item = new ListViewItem(evt.EventName);
                     item.SubItems.Add(evt.EventDate.ToString("yyyy-MM-dd"));
@@ -128,7 +128,7 @@ namespace RCDragManagerProd.UI.Forms
                 }
 
                 lvMultiClass.EndUpdate();
-                Logger.Log($"[UI][LoadSession] Loaded {_multiEvents.Count} multi-class events");
+                Logger.Log($"[UI][LoadSession] Loaded {events.Count} multi-class events");
             }
             catch (Exception ex)
             {
@@ -146,39 +146,28 @@ namespace RCDragManagerProd.UI.Forms
                 return;
             }
 
-            // Single-class load — wrap into a one-class MultiClassEvent and route through MultiClassRaceForm
+            // Single-class load
+            if (lvSessions.SelectedItems.Count == 0)
+            {
+                MessageBox.Show("Please select a session to load.", "No Session Selected",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            int selectedId = (int)lvSessions.SelectedItems[0].Tag;
+            Logger.Log($"[UI][LoadSession] Loading session id={selectedId}");
+
             try
             {
-                if (lvSessions.SelectedItems.Count == 0)
+                var result = _service.LoadSingleClassSession(selectedId);
+                if (!result.Success)
                 {
-                    MessageBox.Show("Please select a session to load.", "No Session Selected",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                int selectedId = (int)lvSessions.SelectedItems[0].Tag;
-                Logger.Log($"[UI][LoadSession] Loading session id={selectedId}");
-
-                LoadedSession = _sessionRepository.LoadSession(selectedId);
-                if (LoadedSession == null)
-                {
-                    Logger.Log("[UI][LoadSession][WARN] Repository returned null session");
-                    MessageBox.Show("Unable to load the selected session.", "Load Error",
+                    MessageBox.Show(result.ErrorMessage, "Load Error",
                         MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
-                var wrapped = new MultiClassEvent
-                {
-                    EventName = LoadedSession.EventName,
-                    EventDate = LoadedSession.EventDate != default ? LoadedSession.EventDate : DateTime.Now,
-                    ClassSessions = new List<RaceSession> { LoadedSession }
-                };
-                Logger.Log($"[UI][LoadSession] Wrapping single-class session '{wrapped.EventName}' (raceType='{LoadedSession.RaceType}') into MultiClassRaceForm");
-
-                var form = new MultiClassRaceForm(wrapped, _connectionString);
-                form.Show();
-                Close();
+                OpenEventAndClose(result.Event);
             }
             catch (Exception ex)
             {
@@ -190,30 +179,27 @@ namespace RCDragManagerProd.UI.Forms
 
         private void LoadSelectedMultiClassEvent()
         {
+            if (lvMultiClass.SelectedItems.Count == 0)
+            {
+                MessageBox.Show("Please select an event to load.", "No Event Selected",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            int selectedId = (int)lvMultiClass.SelectedItems[0].Tag;
+            Logger.Log($"[UI][LoadSession] Loading multi-class event id={selectedId}");
+
             try
             {
-                if (lvMultiClass.SelectedItems.Count == 0)
+                var result = _service.LoadMultiClassEvent(selectedId);
+                if (!result.Success)
                 {
-                    MessageBox.Show("Please select an event to load.", "No Event Selected",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                int selectedId = (int)lvMultiClass.SelectedItems[0].Tag;
-                Logger.Log($"[UI][LoadSession] Loading multi-class event id={selectedId}");
-
-                var evt = _multiClassRepo.LoadEvent(selectedId);
-                if (evt == null)
-                {
-                    Logger.Log("[UI][LoadSession][WARN] MultiClassEventRepository returned null");
-                    MessageBox.Show("Unable to load the selected event.", "Load Error",
+                    MessageBox.Show(result.ErrorMessage, "Load Error",
                         MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
-                var form = new MultiClassRaceForm(evt, _connectionString);
-                form.Show();
-                Close();
+                OpenEventAndClose(result.Event);
             }
             catch (Exception ex)
             {
@@ -221,6 +207,13 @@ namespace RCDragManagerProd.UI.Forms
                 MessageBox.Show("Failed to load event. Check the log for details.", "Load Error",
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+        }
+
+        private void OpenEventAndClose(RCDragManagerProd.Domain.MultiClassEvent evt)
+        {
+            var form = new MultiClassRaceForm(evt, _connectionString);
+            form.Show();
+            Close();
         }
 
         private void btnDelete_Click(object sender, EventArgs e)
@@ -232,27 +225,27 @@ namespace RCDragManagerProd.UI.Forms
             }
 
             // Single-class delete
+            if (lvSessions.SelectedItems.Count == 0)
+            {
+                MessageBox.Show("Please select a session to delete.", "No Session Selected",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            var confirm = MessageBox.Show(
+                "Are you sure you want to permanently delete this session?",
+                "Confirm Delete",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+
+            if (confirm != DialogResult.Yes) return;
+
+            int selectedId = (int)lvSessions.SelectedItems[0].Tag;
+            Logger.Log($"[UI][LoadSession] Deleting session id={selectedId}");
+
             try
             {
-                if (lvSessions.SelectedItems.Count == 0)
-                {
-                    MessageBox.Show("Please select a session to delete.", "No Session Selected",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                var confirm = MessageBox.Show(
-                    "Are you sure you want to permanently delete this session?",
-                    "Confirm Delete",
-                    MessageBoxButtons.YesNo,
-                    MessageBoxIcon.Warning);
-
-                if (confirm != DialogResult.Yes) return;
-
-                int selectedId = (int)lvSessions.SelectedItems[0].Tag;
-                Logger.Log($"[UI][LoadSession] Deleting session id={selectedId}");
-
-                _sessionRepository.DeleteSession(selectedId);
+                _service.DeleteSession(selectedId);
                 LoadSessions();
             }
             catch (Exception ex)
@@ -265,27 +258,27 @@ namespace RCDragManagerProd.UI.Forms
 
         private void DeleteSelectedMultiClassEvent()
         {
+            if (lvMultiClass.SelectedItems.Count == 0)
+            {
+                MessageBox.Show("Please select an event to delete.", "No Event Selected",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            var confirm = MessageBox.Show(
+                "Are you sure you want to permanently delete this multi-class event?",
+                "Confirm Delete",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+
+            if (confirm != DialogResult.Yes) return;
+
+            int selectedId = (int)lvMultiClass.SelectedItems[0].Tag;
+            Logger.Log($"[UI][LoadSession] Deleting multi-class event id={selectedId}");
+
             try
             {
-                if (lvMultiClass.SelectedItems.Count == 0)
-                {
-                    MessageBox.Show("Please select an event to delete.", "No Event Selected",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                var confirm = MessageBox.Show(
-                    "Are you sure you want to permanently delete this multi-class event?",
-                    "Confirm Delete",
-                    MessageBoxButtons.YesNo,
-                    MessageBoxIcon.Warning);
-
-                if (confirm != DialogResult.Yes) return;
-
-                int selectedId = (int)lvMultiClass.SelectedItems[0].Tag;
-                Logger.Log($"[UI][LoadSession] Deleting multi-class event id={selectedId}");
-
-                _multiClassRepo.DeleteEvent(selectedId);
+                _service.DeleteMultiClassEvent(selectedId);
                 LoadMultiClassEvents();
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

- Creates `LoadSessionService` in `AppServices` — wraps `RaceSessionRepository` + `MultiClassEventRepository`, exposes `ListSessions`, `ListMultiClassEvents`, `LoadSingleClassSession`, `LoadMultiClassEvent`, `DeleteSession`, `DeleteMultiClassEvent`
- Adds `LoadResult` value-object with `Ok(MultiClassEvent)` / `Fail(string)` factory methods
- Rewires `LoadSessionForm` to call service methods; form now handles only control wiring, list rendering, `MessageBox`, and opening `MultiClassRaceForm`
- 13 new headless tests in `LoadSessionServiceTests.cs` — 228 passed / 11 skipped / 0 failed

## Smoke-test checklist (owner to verify before merging)

- [ ] Open Landing page → "Load Event" opens the Load Session dialog
- [ ] Single-class tab: saved sessions appear in the list
- [ ] Select a single-class session and click Load → `MultiClassRaceForm` opens for that session; dialog closes
- [ ] Double-click a single-class row → same as above
- [ ] Multi-class tab: saved multi-class events appear in the list
- [ ] Select a multi-class event and click Load → `MultiClassRaceForm` opens; dialog closes
- [ ] Double-click a multi-class row → same as above
- [ ] Click Delete on a single-class session with confirmation → row is removed from list
- [ ] Click Delete on a multi-class event with confirmation → row is removed from list
- [ ] Cancel (or dismiss dialog) → returns to Landing page normally
- [ ] Load with nothing selected → shows "Please select" warning, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)