### PR TITLE
refactor(setup): extract MultiClassSetupService from setup/config dialog forms (#287)

### DIFF
--- a/Docs/claude-context/UI-EXTRACTION-HANDOVER.md
+++ b/Docs/claude-context/UI-EXTRACTION-HANDOVER.md
@@ -1,0 +1,65 @@
+# Handover — RC Drag Manager: "forms are pure UI" extraction epic
+
+_Last updated: 2026-06-11_
+
+## The goal
+Reduce **every** WinForms form to *pure UI* (code-behind = control wiring + rendering +
+dialog show/close only; all workflow/validation/persistence delegated to services in
+`RCDragManagerProd.AppServices`). The app must look & behave **identically** (no visible
+change). Then **tag that commit as the clean "ready for new UI" release** so the new UI can
+be built on UI-independent services. This is the #283 epic.
+
+## Working agreement
+- Assistant acts as senior dev; the owner merges PRs manually and smoke-tests the UI. Pick
+  the next screen yourself — don't ask.
+- **One screen per branch/PR, batching several slices per branch** (owner asked for "more
+  per branch" — not one tiny PR per slice).
+- Per branch: create `<Screen>Service` → rewire the form → MSBuild → full `dotnet test`
+  (green) → stage **only the assistant's own files** (the working tree carries ~25 unrelated
+  dirty `Docs/`/`.claude/` files — keep them out of every commit) → file-based commit ending
+  with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` → push → **one** PR with a
+  manual smoke-test checklist → **wait for the owner's "merged"** (never auto-merge).
+
+## Key technical notes
+- **Build:** MSBuild via PowerShell (not Git Bash):
+  `& "C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe" "src\RCDragManagerProd\RCDragManagerProd.sln" /t:Build /p:Configuration=Debug /v:minimal /nologo`
+- **Test:** `dotnet test src\RCDragManagerProd.Tests\RCDragManagerProd.Tests.csproj --nologo -v minimal --blame-hang-timeout 90s`
+  — run **plain in the background**, never with a `2>&1 | Select-String` pipe (hangs PowerShell 5.1).
+- Namespace is **`AppServices`** (NOT `Application` — collides with `System.Windows.Forms.Application`).
+- New **production** `.cs` files need a `<Compile Include>` in the non-SDK
+  `RCDragManagerProd.csproj`; the test project is SDK-style (no entry needed).
+- MSTest throw assertion is `Assert.ThrowsExactly<T>` (not `ThrowsException`).
+  `TemporarySqliteDb` is a per-file private nested test helper (copy it; it's not shared).
+- Forms can't be GUI-verified by the assistant — that's why every PR ships a smoke checklist
+  for the owner to run before merging.
+
+## Done (merged)
+Race console (`Form1`) fully extracted into `RaceConsoleService` + `RaceConsoleViewModel`/
+builder (PRs #321/#323/#324/#325/#326): build/start, advance, standings, buyback,
+winner-submit (BYE + lane-swap mapping), edit-result, and save/close via an
+`IRaceSessionStore` seam. Plus bug fix #322 (QMDRA finals was clearing the match-up grid).
+
+## In flight
+**PR #327** `refactor/drivermanager-service-286` — `DriverManagerService` extracted from
+`DriverManagerForm` (#286). **Awaiting owner merge.** `main` is at the #326 merge.
+
+## Remaining batches to the tag (~5–7 PRs, rough order)
+1. **#288 LoadSessionForm** — load/delete sessions & events (do this next after #327 merges).
+2. **#287 MultiClassConfigDialog** (~677 lines, biggest) + **MultiClassSetupForm**.
+3. **#289 MultiClassRaceForm** — multi-class coordination, stats, completion.
+4. **Form1 residual** — setup-roster add/edit driver + qual-time validation in
+   `Form1.Events.cs`, and `OnTournamentCompleted` stats.
+5. Audit smaller forms/dialogs (Settings, DriverStats, Add*/Edit* dialogs) — extract any
+   validation; leave pure input dialogs as-is.
+6. Final grep audit (no repository / validation / business logic left in any form) →
+   **tag the release**.
+
+## First step in a new session
+Check whether PR #327 is merged (`gh pr view 327 --json state`).
+- **If merged:** sync `main`, delete the merged branch, then start **#288 LoadSessionForm**
+  (read `src/RCDragManagerProd/UI/Forms/Session/LoadSessionForm.cs`, extract load/delete of
+  sessions & events into a `LoadSessionService`).
+- **If not merged yet:** wait for the owner.
+
+Test baseline after #286: **215 passed / 11 skipped / 0 failed**. Known noise: CS0618 at
+`RaceController.EngineCalls.cs:46`; MSTEST0037 analyzer suggestions; 11 multi-class skips.

--- a/src/RCDragManagerProd.Tests/LoadSessionServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/LoadSessionServiceTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Covers <see cref="LoadSessionService"/> (issue #288) — the UI-independent saved-race
+/// loading operations the Load Session screen delegates to. Runs headless against an
+/// in-memory database, proving the form needs no repositories of its own.
+/// </summary>
+[TestClass]
+public class LoadSessionServiceTests
+{
+    private static LoadSessionService NewService(TemporarySqliteDb db)
+    {
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        return new LoadSessionService(
+            new RaceSessionRepository(db.ConnectionString),
+            new MultiClassEventRepository(db.ConnectionString));
+    }
+
+    // ── ListSessions ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ListSessions_EmptyDb_ReturnsEmptyList()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var sessions = service.ListSessions();
+
+        Assert.IsNotNull(sessions);
+        Assert.AreEqual(0, sessions.Count);
+    }
+
+    [TestMethod]
+    public void ListSessions_AfterSave_ReturnsSummaryRow()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        repo.SaveSession(MakeSession("Spring Nats", "Pro Mod", "Round Robin"));
+
+        var sessions = service.ListSessions();
+
+        Assert.AreEqual(1, sessions.Count);
+        Assert.AreEqual("Spring Nats", sessions[0].EventName);
+        Assert.AreEqual("Pro Mod", sessions[0].ClassType);
+        Assert.AreEqual("Round Robin", sessions[0].RaceType);
+    }
+
+    // ── ListMultiClassEvents ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ListMultiClassEvents_EmptyDb_ReturnsEmptyList()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var events = service.ListMultiClassEvents();
+
+        Assert.IsNotNull(events);
+        Assert.AreEqual(0, events.Count);
+    }
+
+    [TestMethod]
+    public void ListMultiClassEvents_AfterSave_ReturnsSummaryRow()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var multiRepo = new MultiClassEventRepository(db.ConnectionString);
+        var session1 = MakeSession("Class A", "Open", "Round Robin");
+        var session2 = MakeSession("Class B", "Pro", "Round Robin");
+        multiRepo.SaveEvent(new MultiClassEvent
+        {
+            EventName = "Big Weekend",
+            EventDate = new DateTime(2026, 3, 1),
+            ClassSessions = new List<RaceSession> { session1, session2 }
+        });
+
+        var events = service.ListMultiClassEvents();
+
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual("Big Weekend", events[0].EventName);
+        Assert.AreEqual(2, events[0].ClassCount);
+    }
+
+    // ── LoadSingleClassSession ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void LoadSingleClassSession_ValidId_WrapsInOneClassMultiClassEvent()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        var session = MakeSession("Summer Shoot-Out", "Sportsman", "Round Robin");
+        repo.SaveSession(session);
+        int id = service.ListSessions()[0].Id;
+
+        var result = service.LoadSingleClassSession(id);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Event);
+        Assert.AreEqual("Summer Shoot-Out", result.Event.EventName);
+        Assert.AreEqual(1, result.Event.ClassSessions.Count);
+        Assert.AreEqual("Sportsman", result.Event.ClassSessions[0].ClassType);
+    }
+
+    [TestMethod]
+    public void LoadSingleClassSession_InvalidId_ReturnsFailure()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var result = service.LoadSingleClassSession(999);
+
+        Assert.IsFalse(result.Success);
+        Assert.IsNull(result.Event);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.ErrorMessage));
+    }
+
+    [TestMethod]
+    public void LoadSingleClassSession_SessionWithDefaultDate_UsesNowAsEventDate()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        var session = MakeSession("No-Date Session", "Open", "Round Robin");
+        session.EventDate = default;
+        repo.SaveSession(session);
+        int id = service.ListSessions()[0].Id;
+
+        var result = service.LoadSingleClassSession(id);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreNotEqual(default(DateTime), result.Event.EventDate);
+    }
+
+    // ── LoadMultiClassEvent ───────────────────────────────────────────────────
+
+    [TestMethod]
+    public void LoadMultiClassEvent_ValidId_ReturnsEvent()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var multiRepo = new MultiClassEventRepository(db.ConnectionString);
+        var evt = new MultiClassEvent
+        {
+            EventName = "Autumn Opener",
+            EventDate = new DateTime(2026, 9, 15),
+            ClassSessions = new List<RaceSession> { MakeSession("Open A", "Open", "Round Robin") }
+        };
+        multiRepo.SaveEvent(evt);
+        int id = service.ListMultiClassEvents()[0].Id;
+
+        var result = service.LoadMultiClassEvent(id);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Event);
+        Assert.AreEqual("Autumn Opener", result.Event.EventName);
+    }
+
+    [TestMethod]
+    public void LoadMultiClassEvent_InvalidId_ReturnsFailure()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var result = service.LoadMultiClassEvent(999);
+
+        Assert.IsFalse(result.Success);
+        Assert.IsNull(result.Event);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.ErrorMessage));
+    }
+
+    // ── DeleteSession ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DeleteSession_RemovesRowFromList()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        repo.SaveSession(MakeSession("To Delete", "Open", "Round Robin"));
+        int id = service.ListSessions()[0].Id;
+
+        service.DeleteSession(id);
+
+        Assert.AreEqual(0, service.ListSessions().Count);
+    }
+
+    // ── DeleteMultiClassEvent ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DeleteMultiClassEvent_RemovesRowFromList()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var multiRepo = new MultiClassEventRepository(db.ConnectionString);
+        multiRepo.SaveEvent(new MultiClassEvent
+        {
+            EventName = "To Delete",
+            EventDate = DateTime.Now,
+            ClassSessions = new List<RaceSession> { MakeSession("C1", "Open", "Round Robin") }
+        });
+        int id = service.ListMultiClassEvents()[0].Id;
+
+        service.DeleteMultiClassEvent(id);
+
+        Assert.AreEqual(0, service.ListMultiClassEvents().Count);
+    }
+
+    // ── LoadResult ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void LoadResult_Ok_HasSuccessAndEvent()
+    {
+        var evt = new MultiClassEvent { EventName = "X", ClassSessions = new List<RaceSession>() };
+
+        var result = LoadResult.Ok(evt);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreSame(evt, result.Event);
+        Assert.IsNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public void LoadResult_Fail_HasErrorAndNoEvent()
+    {
+        var result = LoadResult.Fail("oops");
+
+        Assert.IsFalse(result.Success);
+        Assert.IsNull(result.Event);
+        Assert.AreEqual("oops", result.ErrorMessage);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static RaceSession MakeSession(string eventName, string classType, string raceType) =>
+        new RaceSession
+        {
+            EventName = eventName,
+            ClassType = classType,
+            RaceType = raceType,
+            EventDate = new DateTime(2026, 1, 1),
+            Drivers = new List<Driver>()
+        };
+
+    private sealed class TemporarySqliteDb : IDisposable
+    {
+        public TemporarySqliteDb()
+        {
+            DatabasePath = Path.Combine(
+                Path.GetTempPath(),
+                $"rcdragmanager-loadsession-svc-tests-{Guid.NewGuid():N}.db");
+        }
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try
+            {
+                if (File.Exists(DatabasePath))
+                    File.Delete(DatabasePath);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/src/RCDragManagerProd.Tests/MultiClassSetupServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/MultiClassSetupServiceTests.cs
@@ -1,0 +1,406 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Covers <see cref="MultiClassSetupService"/> (issue #287) — the UI-independent race setup
+/// and class configuration operations the Multi-Class Setup and Config Dialog screens delegate
+/// to. Runs headless against an in-memory database.
+/// </summary>
+[TestClass]
+public class MultiClassSetupServiceTests
+{
+    private static MultiClassSetupService NewService(TemporarySqliteDb db)
+    {
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        return new MultiClassSetupService(new DriverRepository(db.ConnectionString));
+    }
+
+    // ── GetAllDrivers ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void GetAllDrivers_EmptyDb_ReturnsEmptyList()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        Assert.AreEqual(0, svc.GetAllDrivers().Count);
+    }
+
+    // ── QuickAddDriver ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void QuickAddDriver_PersistsDriverWithCar()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        svc.QuickAddDriver("Jake Miller", new Car { CarName = "Rocket", ClassType = "Pro", DefaultDialIn = 3.9 });
+
+        var drivers = svc.GetAllDrivers();
+        Assert.AreEqual(1, drivers.Count);
+        Assert.AreEqual("Jake Miller", drivers[0].Name);
+        Assert.AreEqual(1, drivers[0].Cars.Count);
+        Assert.AreEqual("Rocket", drivers[0].Cars[0].CarName);
+    }
+
+    // ── ValidateClassName ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ValidateClassName_BlankName_ReturnsError()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        Assert.IsNotNull(svc.ValidateClassName("", new[] { "Open" }));
+        Assert.IsNotNull(svc.ValidateClassName("   ", new[] { "Open" }));
+    }
+
+    [TestMethod]
+    public void ValidateClassName_UniqueNonEmpty_ReturnsNull()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        Assert.IsNull(svc.ValidateClassName("Pro Mod", new[] { "Open", "Bracket" }));
+    }
+
+    [TestMethod]
+    public void ValidateClassName_DuplicateExactMatch_ReturnsError()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        Assert.IsNotNull(svc.ValidateClassName("Open", new[] { "Open", "Bracket" }));
+    }
+
+    [TestMethod]
+    public void ValidateClassName_DuplicateCaseInsensitive_ReturnsError()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        Assert.IsNotNull(svc.ValidateClassName("open", new[] { "Open", "Bracket" }));
+    }
+
+    // ── ValidateCanStart ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ValidateCanStart_AllClassesHaveDrivers_ReturnsNull()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var classes = new[]
+        {
+            new ClassConfigDto { ClassName = "A", DriverEntries = new List<RaceSessionDriverEntry> { MakeEntry(1) } },
+            new ClassConfigDto { ClassName = "B", DriverEntries = new List<RaceSessionDriverEntry> { MakeEntry(2) } }
+        };
+
+        Assert.IsNull(svc.ValidateCanStart(classes));
+    }
+
+    [TestMethod]
+    public void ValidateCanStart_ClassWithZeroDrivers_ReturnsError()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var classes = new[]
+        {
+            new ClassConfigDto { ClassName = "Empty", DriverEntries = new List<RaceSessionDriverEntry>() }
+        };
+
+        Assert.IsNotNull(svc.ValidateCanStart(classes));
+    }
+
+    [TestMethod]
+    public void ValidateCanStart_SingleClassWithDrivers_ReturnsNull()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var classes = new[]
+        {
+            new ClassConfigDto { ClassName = "Pro", DriverEntries = new List<RaceSessionDriverEntry> { MakeEntry(1) } }
+        };
+
+        Assert.IsNull(svc.ValidateCanStart(classes));
+    }
+
+    // ── BuildDriverEntries ────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void BuildDriverEntries_HeadsUp_SetsDialInToNull()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var drivers = new List<Driver>
+        {
+            new Driver { Id = 1, Name = "Ann", Cars = new List<Car> { new Car { CarID = 10, DefaultDialIn = 4.5 } } }
+        };
+
+        var entries = svc.BuildDriverEntries(new[] { 1 }, drivers, "Heads Up", null, null, "HU");
+
+        Assert.AreEqual(1, entries.Count);
+        Assert.IsNull(entries[0].DialIn);
+    }
+
+    [TestMethod]
+    public void BuildDriverEntries_BracketClass_AppliesFixedDialIn()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var drivers = new List<Driver>
+        {
+            new Driver { Id = 1, Name = "Bob", Cars = new List<Car> { new Car { CarID = 11, DefaultDialIn = 4.0 } } }
+        };
+
+        var entries = svc.BuildDriverEntries(new[] { 1 }, drivers, "Bracket Class", 3.85, null, "BK");
+
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual(3.85, entries[0].DialIn);
+    }
+
+    [TestMethod]
+    public void BuildDriverEntries_DialIn_UsesPerDriverOverride()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var drivers = new List<Driver>
+        {
+            new Driver { Id = 1, Name = "Carol", Cars = new List<Car> { new Car { CarID = 12, DefaultDialIn = 4.1 } } }
+        };
+        var overrides = new Dictionary<int, double?> { [1] = 3.92 };
+
+        var entries = svc.BuildDriverEntries(new[] { 1 }, drivers, "Dial-In", null, overrides, "DI");
+
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual(3.92, entries[0].DialIn);
+    }
+
+    [TestMethod]
+    public void BuildDriverEntries_DialIn_FallsBackToCarDefault_WhenNoOverride()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var drivers = new List<Driver>
+        {
+            new Driver { Id = 2, Name = "Dan", Cars = new List<Car> { new Car { CarID = 13, DefaultDialIn = 4.25 } } }
+        };
+
+        var entries = svc.BuildDriverEntries(new[] { 2 }, drivers, "Dial-In", null, null, "DI");
+
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual(4.25, entries[0].DialIn);
+    }
+
+    [TestMethod]
+    public void BuildDriverEntries_SetsClassNameOnEachEntry()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var drivers = new List<Driver>
+        {
+            new Driver { Id = 1, Name = "Eve", Cars = new List<Car> { new Car { CarID = 14 } } }
+        };
+
+        var entries = svc.BuildDriverEntries(new[] { 1 }, drivers, "Heads Up", null, null, "Pro Mod");
+
+        Assert.AreEqual("Pro Mod", entries[0].ClassType);
+    }
+
+    [TestMethod]
+    public void BuildDriverEntries_SkipsIdNotInDriverList()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var drivers = new List<Driver>
+        {
+            new Driver { Id = 1, Name = "Fred", Cars = new List<Car> { new Car { CarID = 15 } } }
+        };
+
+        var entries = svc.BuildDriverEntries(new[] { 1, 99 }, drivers, "Heads Up", null, null, "X");
+
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual(1, entries[0].DriverID);
+    }
+
+    // ── StartEvent ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void StartEvent_BuildsMultiClassEventWithOneSectionPerClass()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+        var repo = new DriverRepository(db.ConnectionString);
+        var driver = repo.AddDriverAndReturn("Gina");
+
+        var classes = new[]
+        {
+            new ClassConfigDto
+            {
+                ClassName    = "Open A",
+                RaceType     = RaceTypes.RoundRobin,
+                ClassType    = "Heads Up",
+                Variant      = "Standard",
+                RoundsToRun  = 3,
+                DriverEntries = new List<RaceSessionDriverEntry> { MakeEntry(driver.Id) }
+            },
+            new ClassConfigDto
+            {
+                ClassName    = "Bracket B",
+                RaceType     = RaceTypes.RoundRobin,
+                ClassType    = "Bracket Class",
+                FixedDialIn  = 4.0,
+                Variant      = "QMDRA",
+                RoundsToRun  = 2,
+                DriverEntries = new List<RaceSessionDriverEntry> { MakeEntry(driver.Id) }
+            }
+        };
+
+        var result = svc.StartEvent("Summer Nats", new DateTime(2026, 8, 10), classes);
+
+        Assert.AreEqual("Summer Nats", result.EventName);
+        Assert.AreEqual(new DateTime(2026, 8, 10), result.EventDate);
+        Assert.AreEqual(2, result.ClassSessions.Count);
+        Assert.AreEqual("Open A", result.ClassSessions[0].ClassType);
+        Assert.AreEqual("Bracket B", result.ClassSessions[1].ClassType);
+    }
+
+    [TestMethod]
+    public void StartEvent_MapsRoundRobinVariantAndRounds()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+        var repo = new DriverRepository(db.ConnectionString);
+        var driver = repo.AddDriverAndReturn("Harry");
+
+        var classes = new[]
+        {
+            new ClassConfigDto
+            {
+                ClassName    = "RR Class",
+                RaceType     = RaceTypes.RoundRobin,
+                ClassType    = "Heads Up",
+                Variant      = "QMDRA",
+                RoundsToRun  = 4,
+                DriverEntries = new List<RaceSessionDriverEntry> { MakeEntry(driver.Id) }
+            }
+        };
+
+        var result = svc.StartEvent("Test Event", DateTime.Today, classes);
+
+        var session = result.ClassSessions[0];
+        Assert.AreEqual("QMDRA", session.RoundRobinVariant);
+        Assert.AreEqual(4, session.RoundsToRun);
+    }
+
+    [TestMethod]
+    public void StartEvent_IncrementsEventsEnteredForEachDriver()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+        var repo = new DriverRepository(db.ConnectionString);
+        var d1 = repo.AddDriverAndReturn("Ivan");
+        var d2 = repo.AddDriverAndReturn("Julia");
+
+        var classes = new[]
+        {
+            new ClassConfigDto
+            {
+                ClassName    = "Class A",
+                RaceType     = RaceTypes.RoundRobin,
+                Variant      = "Standard",
+                RoundsToRun  = 3,
+                DriverEntries = new List<RaceSessionDriverEntry> { MakeEntry(d1.Id), MakeEntry(d2.Id) }
+            }
+        };
+
+        svc.StartEvent("Event", DateTime.Today, classes);
+
+        Assert.AreEqual(1, repo.GetDriverById(d1.Id).EventsEntered);
+        Assert.AreEqual(1, repo.GetDriverById(d2.Id).EventsEntered);
+    }
+
+    // ── RoundRobin variant mapping ─────────────────────────────────────────────
+
+    [TestMethod]
+    public void StartEvent_NonRRClass_ClearsVariantAndRounds()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+        var repo = new DriverRepository(db.ConnectionString);
+        var driver = repo.AddDriverAndReturn("Karl");
+
+        var classes = new[]
+        {
+            new ClassConfigDto
+            {
+                ClassName    = "Pro Ladder",
+                RaceType     = "Pro Ladder",
+                ClassType    = "Heads Up",
+                Variant      = "Standard",
+                RoundsToRun  = 3,
+                DriverEntries = new List<RaceSessionDriverEntry> { MakeEntry(driver.Id) }
+            }
+        };
+
+        var result = svc.StartEvent("Event", DateTime.Today, classes);
+        var session = result.ClassSessions[0];
+
+        Assert.IsNull(session.RoundRobinVariant);
+        Assert.IsNull(session.RoundsToRun);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static RaceSessionDriverEntry MakeEntry(int driverId) =>
+        new RaceSessionDriverEntry { DriverID = driverId, DriverName = "Driver " + driverId };
+
+    private sealed class TemporarySqliteDb : IDisposable
+    {
+        public TemporarySqliteDb()
+        {
+            DatabasePath = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"rcdragmanager-multiclasssetup-svc-tests-{Guid.NewGuid():N}.db");
+        }
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try { if (File.Exists(DatabasePath)) File.Delete(DatabasePath); } catch { }
+        }
+    }
+}
+
+/// <summary>Extension to DriverRepository for test helpers only.</summary>
+internal static class DriverRepositoryTestExtensions
+{
+    public static Driver AddDriverAndReturn(this DriverRepository repo, string name)
+    {
+        var driver = new Driver
+        {
+            Name  = name,
+            Cars  = new List<Car> { new Car { CarName = "Car", ClassType = "Open" } }
+        };
+        repo.AddDriver(driver);
+        return repo.GetAllDrivers().First(d => d.Name == name);
+    }
+}

--- a/src/RCDragManagerProd/AppServices/LoadSessionService.cs
+++ b/src/RCDragManagerProd/AppServices/LoadSessionService.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Logging;
+using RCDragManagerProd.Repositories;
+using RCDragManagerProd.ViewModels;
+
+namespace RCDragManagerProd.AppServices
+{
+    /// <summary>
+    /// UI-independent saved-race loading operations for the Load Session screen (issue #288).
+    /// Wraps <see cref="RaceSessionRepository"/> and <see cref="MultiClassEventRepository"/> so
+    /// the form holds no repositories and performs no persistence or domain assembly itself.
+    /// No WinForms references — the same operations can back a future UI and are covered by
+    /// headless tests against an in-memory database.
+    /// </summary>
+    public sealed class LoadSessionService
+    {
+        private readonly RaceSessionRepository _sessionRepo;
+        private readonly MultiClassEventRepository _multiClassRepo;
+
+        public LoadSessionService(RaceSessionRepository sessionRepo, MultiClassEventRepository multiClassRepo)
+        {
+            _sessionRepo = sessionRepo ?? throw new ArgumentNullException(nameof(sessionRepo));
+            _multiClassRepo = multiClassRepo ?? throw new ArgumentNullException(nameof(multiClassRepo));
+        }
+
+        // ── List ─────────────────────────────────────────────────────────────────
+
+        public List<RaceSessionSummary> ListSessions()
+        {
+            Logger.Log("[SVC][LoadSession] ListSessions()");
+            return _sessionRepo.GetAllSessions() ?? new List<RaceSessionSummary>();
+        }
+
+        public List<MultiClassEventSummary> ListMultiClassEvents()
+        {
+            Logger.Log("[SVC][LoadSession] ListMultiClassEvents()");
+            return _multiClassRepo.GetAllEvents() ?? new List<MultiClassEventSummary>();
+        }
+
+        // ── Load ─────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Loads a single-class session by id and wraps it into a one-class
+        /// <see cref="MultiClassEvent"/> ready to open in <c>MultiClassRaceForm</c>.
+        /// </summary>
+        public LoadResult LoadSingleClassSession(int id)
+        {
+            Logger.Log($"[SVC][LoadSession] LoadSingleClassSession(id={id})");
+            var session = _sessionRepo.LoadSession(id);
+            if (session == null)
+            {
+                Logger.Log("[SVC][LoadSession][WARN] Repository returned null session");
+                return LoadResult.Fail("Unable to load the selected session.");
+            }
+
+            var wrapped = new MultiClassEvent
+            {
+                EventName = session.EventName,
+                EventDate = session.EventDate != default ? session.EventDate : DateTime.Now,
+                ClassSessions = new List<RaceSession> { session }
+            };
+
+            Logger.Log($"[SVC][LoadSession] Wrapped '{wrapped.EventName}' (raceType='{session.RaceType}') into MultiClassEvent");
+            return LoadResult.Ok(wrapped);
+        }
+
+        /// <summary>Loads a multi-class event by id.</summary>
+        public LoadResult LoadMultiClassEvent(int id)
+        {
+            Logger.Log($"[SVC][LoadSession] LoadMultiClassEvent(id={id})");
+            var evt = _multiClassRepo.LoadEvent(id);
+            if (evt == null)
+            {
+                Logger.Log("[SVC][LoadSession][WARN] MultiClassEventRepository returned null");
+                return LoadResult.Fail("Unable to load the selected event.");
+            }
+
+            return LoadResult.Ok(evt);
+        }
+
+        // ── Delete ────────────────────────────────────────────────────────────────
+
+        public void DeleteSession(int id)
+        {
+            Logger.Log($"[SVC][LoadSession] DeleteSession(id={id})");
+            _sessionRepo.DeleteSession(id);
+        }
+
+        public void DeleteMultiClassEvent(int id)
+        {
+            Logger.Log($"[SVC][LoadSession] DeleteMultiClassEvent(id={id})");
+            _multiClassRepo.DeleteEvent(id);
+        }
+    }
+
+    /// <summary>Result returned by load operations — carries the loaded event or an error message.</summary>
+    public sealed class LoadResult
+    {
+        public bool Success { get; }
+        public string ErrorMessage { get; }
+        public MultiClassEvent Event { get; }
+
+        private LoadResult(bool success, string errorMessage, MultiClassEvent evt)
+        {
+            Success = success;
+            ErrorMessage = errorMessage;
+            Event = evt;
+        }
+
+        public static LoadResult Ok(MultiClassEvent evt) =>
+            new LoadResult(true, null, evt ?? throw new ArgumentNullException(nameof(evt)));
+
+        public static LoadResult Fail(string message) =>
+            new LoadResult(false, message ?? "Unknown error.", null);
+    }
+}

--- a/src/RCDragManagerProd/AppServices/MultiClassSetupService.cs
+++ b/src/RCDragManagerProd/AppServices/MultiClassSetupService.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Logging;
+using RCDragManagerProd.Repositories;
+
+namespace RCDragManagerProd.AppServices
+{
+    /// <summary>
+    /// UI-independent race setup and class configuration operations for the Multi-Class
+    /// Setup and Class Config screens (issue #287). Wraps <see cref="DriverRepository"/>
+    /// so neither form holds a repository or performs persistence, validation, or domain
+    /// assembly itself. No WinForms references — the same operations can back a future
+    /// UI and are covered by headless tests against an in-memory database.
+    /// </summary>
+    public sealed class MultiClassSetupService
+    {
+        private readonly DriverRepository _driverRepo;
+
+        public MultiClassSetupService(DriverRepository driverRepo)
+        {
+            _driverRepo = driverRepo ?? throw new ArgumentNullException(nameof(driverRepo));
+        }
+
+        // ── Driver access ─────────────────────────────────────────────────────
+
+        public List<Driver> GetAllDrivers() => _driverRepo.GetAllDrivers() ?? new List<Driver>();
+
+        /// <summary>Adds a new driver with their first car and persists immediately.</summary>
+        public Driver QuickAddDriver(string driverName, Car car)
+        {
+            if (string.IsNullOrWhiteSpace(driverName))
+                throw new ArgumentException("Driver name must not be empty.", nameof(driverName));
+            if (car == null) throw new ArgumentNullException(nameof(car));
+
+            var driver = new Driver
+            {
+                Name  = driverName,
+                Notes = "",
+                State = "",
+                Cars  = new List<Car> { car }
+            };
+            _driverRepo.AddDriver(driver);
+            Logger.Log($"[SVC][MultiClassSetup] QuickAddDriver '{driverName}'");
+            return driver;
+        }
+
+        // ── Validation ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns an error message if <paramref name="name"/> is blank or duplicates a name in
+        /// <paramref name="existingNames"/> (case-insensitive); otherwise returns null.
+        /// </summary>
+        public string ValidateClassName(string name, IEnumerable<string> existingNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return "Class name must not be empty.";
+
+            foreach (var existing in existingNames ?? Enumerable.Empty<string>())
+            {
+                if (string.Equals(existing, name, StringComparison.OrdinalIgnoreCase))
+                    return $"A class named '{name}' already exists. Please use a different name.";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns an error message if any class has zero drivers; otherwise returns null.
+        /// </summary>
+        public string ValidateCanStart(IEnumerable<ClassConfigDto> classes)
+        {
+            foreach (var cc in classes ?? Enumerable.Empty<ClassConfigDto>())
+            {
+                if (cc.DriverEntries == null || cc.DriverEntries.Count == 0)
+                    return $"Class '{cc.ClassName}' has no drivers. Add at least one driver or remove the class.";
+            }
+            return null;
+        }
+
+        // ── Driver entry construction ─────────────────────────────────────────
+
+        /// <summary>
+        /// Builds the <see cref="RaceSessionDriverEntry"/> list from the driver selection state
+        /// collected by the UI. Class type determines how dial-in is assigned:
+        /// <list type="bullet">
+        /// <item>Bracket Class → <paramref name="fixedDialIn"/> applied to every driver.</item>
+        /// <item>Heads Up → null (no dial-in).</item>
+        /// <item>Dial-In → per-driver override from <paramref name="dialInOverrides"/> if present,
+        ///   otherwise the driver's car default dial-in.</item>
+        /// </list>
+        /// </summary>
+        public List<RaceSessionDriverEntry> BuildDriverEntries(
+            IEnumerable<int> checkedDriverIds,
+            IReadOnlyList<Driver> allDrivers,
+            string classType,
+            double? fixedDialIn,
+            IDictionary<int, double?> dialInOverrides,
+            string className)
+        {
+            bool isHeadsUp = string.Equals(classType, "Heads Up", StringComparison.OrdinalIgnoreCase);
+            bool isBracket = string.Equals(classType, "Bracket Class", StringComparison.OrdinalIgnoreCase);
+
+            var entries = new List<RaceSessionDriverEntry>();
+
+            foreach (var driverId in checkedDriverIds ?? Enumerable.Empty<int>())
+            {
+                var driver = allDrivers?.FirstOrDefault(d => d.Id == driverId);
+                if (driver == null) continue;
+
+                var car = driver.Cars?.FirstOrDefault();
+
+                double? dialIn;
+                if (isBracket)
+                    dialIn = fixedDialIn;
+                else if (isHeadsUp)
+                    dialIn = null;
+                else
+                    dialIn = dialInOverrides != null && dialInOverrides.TryGetValue(driverId, out var ov)
+                        ? ov
+                        : car?.DefaultDialIn;
+
+                entries.Add(new RaceSessionDriverEntry
+                {
+                    DriverID   = driver.Id,
+                    DriverName = driver.Name,
+                    CarID      = car?.CarID ?? 0,
+                    CarName    = car?.CarName ?? "",
+                    ClassType  = className,
+                    DialIn     = dialIn
+                });
+            }
+
+            return entries;
+        }
+
+        // ── Event construction ────────────────────────────────────────────────
+
+        /// <summary>
+        /// Increments each driver's events-entered counter, then assembles and returns the
+        /// <see cref="MultiClassEvent"/> (with one <see cref="RaceSession"/> per class).
+        /// </summary>
+        public MultiClassEvent StartEvent(string eventName, DateTime date, IEnumerable<ClassConfigDto> classes)
+        {
+            var classesList = (classes ?? throw new ArgumentNullException(nameof(classes))).ToList();
+
+            foreach (var cc in classesList)
+                foreach (var entry in cc.DriverEntries ?? Enumerable.Empty<RaceSessionDriverEntry>())
+                    _driverRepo.IncrementEventsEntered(entry.DriverID);
+
+            var multiEvent = new MultiClassEvent
+            {
+                EventName    = eventName?.Trim() ?? "",
+                EventDate    = date.Date
+            };
+
+            foreach (var cc in classesList)
+            {
+                bool isRR = string.Equals(cc.RaceType, RaceTypes.RoundRobin, StringComparison.OrdinalIgnoreCase);
+
+                var session = new RaceSession
+                {
+                    EventName         = multiEvent.EventName,
+                    EventDate         = multiEvent.EventDate,
+                    RaceType          = cc.RaceType ?? RaceTypes.RoundRobin,
+                    ClassType         = cc.ClassName,
+                    FixedDialIn       = cc.FixedDialIn,
+                    RoundRobinVariant = isRR ? cc.Variant : null,
+                    RoundsToRun       = isRR ? cc.RoundsToRun : null,
+                    DriverEntries     = cc.DriverEntries
+                };
+                multiEvent.ClassSessions.Add(session);
+
+                if (isRR)
+                    Logger.Log($"[SVC][MultiClassSetup] RR class '{cc.ClassName}' → Variant='{session.RoundRobinVariant}', Rounds={session.RoundsToRun}");
+            }
+
+            return multiEvent;
+        }
+    }
+
+    /// <summary>
+    /// Carries the configuration for a single class between the Config Dialog, Setup Form,
+    /// and <see cref="MultiClassSetupService"/>. Replaces the private <c>ClassConfig</c>
+    /// inner class that used to live in <c>MultiClassSetupForm</c>.
+    /// </summary>
+    public sealed class ClassConfigDto
+    {
+        public string ClassName { get; set; }
+        public string RaceType { get; set; }
+        public string ClassType { get; set; }
+        public double? FixedDialIn { get; set; }
+        public string Variant { get; set; }
+        public int? RoundsToRun { get; set; }
+        public List<RaceSessionDriverEntry> DriverEntries { get; set; }
+    }
+}

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
     <Compile Include="AppServices\DriverManagerService.cs" />
     <Compile Include="AppServices\LoadSessionService.cs" />
+    <Compile Include="AppServices\MultiClassSetupService.cs" />
     <Compile Include="AppServices\RaceConsoleService.cs" />
     <Compile Include="AppServices\RaceConsoleViewModel.cs" />
     <Compile Include="AppServices\RaceConsoleViewModelBuilder.cs" />

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -111,6 +111,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppServices\DriverManagerService.cs" />
+    <Compile Include="AppServices\LoadSessionService.cs" />
     <Compile Include="AppServices\RaceConsoleService.cs" />
     <Compile Include="AppServices\RaceConsoleViewModel.cs" />
     <Compile Include="AppServices\RaceConsoleViewModelBuilder.cs" />

--- a/src/RCDragManagerProd/UI/Forms/Session/LoadSessionForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/LoadSessionForm.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
-using RCDragManagerProd.Domain;
+using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Logging;
 using RCDragManagerProd.Repositories;
 using RCDragManagerProd.ViewModels;
@@ -10,31 +10,31 @@ namespace RCDragManagerProd.UI.Forms
 {
     public partial class LoadSessionForm : Form
     {
+        private readonly LoadSessionService _service;
         private readonly string _connectionString;
-        private readonly RaceSessionRepository _sessionRepository;
-        private readonly MultiClassEventRepository _multiClassRepo;
-
-        private List<RaceSessionSummary> _sessions;
-        private List<MultiClassEventSummary> _multiEvents;
-
-        /// <summary>Set when a single-class session is loaded (DialogResult.OK).</summary>
-        public RaceSession LoadedSession { get; private set; }
 
         public LoadSessionForm(string connectionString)
+            : this(
+                new LoadSessionService(
+                    new RaceSessionRepository(connectionString),
+                    new MultiClassEventRepository(connectionString)),
+                connectionString)
         {
+        }
+
+        internal LoadSessionForm(LoadSessionService service, string connectionString)
+        {
+            if (service == null) throw new ArgumentNullException(nameof(service));
             if (string.IsNullOrWhiteSpace(connectionString))
                 throw new ArgumentNullException(nameof(connectionString));
 
             Logger.Log("[UI][LoadSession] ctor");
+            _service = service;
             _connectionString = connectionString;
 
             InitializeComponent();
             ConfigureListView();
             ConfigureMultiClassListView();
-
-            _sessionRepository = new RaceSessionRepository(connectionString);
-            _multiClassRepo = new MultiClassEventRepository(connectionString);
-            Logger.Log("[UI][LoadSession] Repositories ready");
 
             LoadSessions();
             LoadMultiClassEvents();
@@ -64,12 +64,12 @@ namespace RCDragManagerProd.UI.Forms
             try
             {
                 Logger.Log("[UI][LoadSession] Loading single-class sessions…");
-                _sessions = _sessionRepository.GetAllSessions() ?? new List<RaceSessionSummary>();
+                var sessions = _service.ListSessions();
 
                 lvSessions.BeginUpdate();
                 lvSessions.Items.Clear();
 
-                foreach (var s in _sessions)
+                foreach (var s in sessions)
                 {
                     var item = new ListViewItem(s.EventName);
                     item.SubItems.Add(s.EventDate.ToString("yyyy-MM-dd HH:mm"));
@@ -80,7 +80,7 @@ namespace RCDragManagerProd.UI.Forms
                 }
 
                 lvSessions.EndUpdate();
-                Logger.Log($"[UI][LoadSession] Loaded {_sessions.Count} single-class sessions");
+                Logger.Log($"[UI][LoadSession] Loaded {sessions.Count} single-class sessions");
             }
             catch (Exception ex)
             {
@@ -113,12 +113,12 @@ namespace RCDragManagerProd.UI.Forms
             try
             {
                 Logger.Log("[UI][LoadSession] Loading multi-class events…");
-                _multiEvents = _multiClassRepo.GetAllEvents() ?? new List<MultiClassEventSummary>();
+                var events = _service.ListMultiClassEvents();
 
                 lvMultiClass.BeginUpdate();
                 lvMultiClass.Items.Clear();
 
-                foreach (var evt in _multiEvents)
+                foreach (var evt in events)
                 {
                     var item = new ListViewItem(evt.EventName);
                     item.SubItems.Add(evt.EventDate.ToString("yyyy-MM-dd"));
@@ -128,7 +128,7 @@ namespace RCDragManagerProd.UI.Forms
                 }
 
                 lvMultiClass.EndUpdate();
-                Logger.Log($"[UI][LoadSession] Loaded {_multiEvents.Count} multi-class events");
+                Logger.Log($"[UI][LoadSession] Loaded {events.Count} multi-class events");
             }
             catch (Exception ex)
             {
@@ -146,39 +146,28 @@ namespace RCDragManagerProd.UI.Forms
                 return;
             }
 
-            // Single-class load — wrap into a one-class MultiClassEvent and route through MultiClassRaceForm
+            // Single-class load
+            if (lvSessions.SelectedItems.Count == 0)
+            {
+                MessageBox.Show("Please select a session to load.", "No Session Selected",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            int selectedId = (int)lvSessions.SelectedItems[0].Tag;
+            Logger.Log($"[UI][LoadSession] Loading session id={selectedId}");
+
             try
             {
-                if (lvSessions.SelectedItems.Count == 0)
+                var result = _service.LoadSingleClassSession(selectedId);
+                if (!result.Success)
                 {
-                    MessageBox.Show("Please select a session to load.", "No Session Selected",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                int selectedId = (int)lvSessions.SelectedItems[0].Tag;
-                Logger.Log($"[UI][LoadSession] Loading session id={selectedId}");
-
-                LoadedSession = _sessionRepository.LoadSession(selectedId);
-                if (LoadedSession == null)
-                {
-                    Logger.Log("[UI][LoadSession][WARN] Repository returned null session");
-                    MessageBox.Show("Unable to load the selected session.", "Load Error",
+                    MessageBox.Show(result.ErrorMessage, "Load Error",
                         MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
-                var wrapped = new MultiClassEvent
-                {
-                    EventName = LoadedSession.EventName,
-                    EventDate = LoadedSession.EventDate != default ? LoadedSession.EventDate : DateTime.Now,
-                    ClassSessions = new List<RaceSession> { LoadedSession }
-                };
-                Logger.Log($"[UI][LoadSession] Wrapping single-class session '{wrapped.EventName}' (raceType='{LoadedSession.RaceType}') into MultiClassRaceForm");
-
-                var form = new MultiClassRaceForm(wrapped, _connectionString);
-                form.Show();
-                Close();
+                OpenEventAndClose(result.Event);
             }
             catch (Exception ex)
             {
@@ -190,30 +179,27 @@ namespace RCDragManagerProd.UI.Forms
 
         private void LoadSelectedMultiClassEvent()
         {
+            if (lvMultiClass.SelectedItems.Count == 0)
+            {
+                MessageBox.Show("Please select an event to load.", "No Event Selected",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            int selectedId = (int)lvMultiClass.SelectedItems[0].Tag;
+            Logger.Log($"[UI][LoadSession] Loading multi-class event id={selectedId}");
+
             try
             {
-                if (lvMultiClass.SelectedItems.Count == 0)
+                var result = _service.LoadMultiClassEvent(selectedId);
+                if (!result.Success)
                 {
-                    MessageBox.Show("Please select an event to load.", "No Event Selected",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                int selectedId = (int)lvMultiClass.SelectedItems[0].Tag;
-                Logger.Log($"[UI][LoadSession] Loading multi-class event id={selectedId}");
-
-                var evt = _multiClassRepo.LoadEvent(selectedId);
-                if (evt == null)
-                {
-                    Logger.Log("[UI][LoadSession][WARN] MultiClassEventRepository returned null");
-                    MessageBox.Show("Unable to load the selected event.", "Load Error",
+                    MessageBox.Show(result.ErrorMessage, "Load Error",
                         MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
-                var form = new MultiClassRaceForm(evt, _connectionString);
-                form.Show();
-                Close();
+                OpenEventAndClose(result.Event);
             }
             catch (Exception ex)
             {
@@ -221,6 +207,13 @@ namespace RCDragManagerProd.UI.Forms
                 MessageBox.Show("Failed to load event. Check the log for details.", "Load Error",
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+        }
+
+        private void OpenEventAndClose(RCDragManagerProd.Domain.MultiClassEvent evt)
+        {
+            var form = new MultiClassRaceForm(evt, _connectionString);
+            form.Show();
+            Close();
         }
 
         private void btnDelete_Click(object sender, EventArgs e)
@@ -232,27 +225,27 @@ namespace RCDragManagerProd.UI.Forms
             }
 
             // Single-class delete
+            if (lvSessions.SelectedItems.Count == 0)
+            {
+                MessageBox.Show("Please select a session to delete.", "No Session Selected",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            var confirm = MessageBox.Show(
+                "Are you sure you want to permanently delete this session?",
+                "Confirm Delete",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+
+            if (confirm != DialogResult.Yes) return;
+
+            int selectedId = (int)lvSessions.SelectedItems[0].Tag;
+            Logger.Log($"[UI][LoadSession] Deleting session id={selectedId}");
+
             try
             {
-                if (lvSessions.SelectedItems.Count == 0)
-                {
-                    MessageBox.Show("Please select a session to delete.", "No Session Selected",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                var confirm = MessageBox.Show(
-                    "Are you sure you want to permanently delete this session?",
-                    "Confirm Delete",
-                    MessageBoxButtons.YesNo,
-                    MessageBoxIcon.Warning);
-
-                if (confirm != DialogResult.Yes) return;
-
-                int selectedId = (int)lvSessions.SelectedItems[0].Tag;
-                Logger.Log($"[UI][LoadSession] Deleting session id={selectedId}");
-
-                _sessionRepository.DeleteSession(selectedId);
+                _service.DeleteSession(selectedId);
                 LoadSessions();
             }
             catch (Exception ex)
@@ -265,27 +258,27 @@ namespace RCDragManagerProd.UI.Forms
 
         private void DeleteSelectedMultiClassEvent()
         {
+            if (lvMultiClass.SelectedItems.Count == 0)
+            {
+                MessageBox.Show("Please select an event to delete.", "No Event Selected",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            var confirm = MessageBox.Show(
+                "Are you sure you want to permanently delete this multi-class event?",
+                "Confirm Delete",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+
+            if (confirm != DialogResult.Yes) return;
+
+            int selectedId = (int)lvMultiClass.SelectedItems[0].Tag;
+            Logger.Log($"[UI][LoadSession] Deleting multi-class event id={selectedId}");
+
             try
             {
-                if (lvMultiClass.SelectedItems.Count == 0)
-                {
-                    MessageBox.Show("Please select an event to delete.", "No Event Selected",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                var confirm = MessageBox.Show(
-                    "Are you sure you want to permanently delete this multi-class event?",
-                    "Confirm Delete",
-                    MessageBoxButtons.YesNo,
-                    MessageBoxIcon.Warning);
-
-                if (confirm != DialogResult.Yes) return;
-
-                int selectedId = (int)lvMultiClass.SelectedItems[0].Tag;
-                Logger.Log($"[UI][LoadSession] Deleting multi-class event id={selectedId}");
-
-                _multiClassRepo.DeleteEvent(selectedId);
+                _service.DeleteMultiClassEvent(selectedId);
                 LoadMultiClassEvents();
             }
             catch (Exception ex)

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassConfigDialog.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Domain;
 using RCDragManagerProd.Logging;
 using RCDragManagerProd.Repositories;
@@ -27,7 +28,7 @@ namespace RCDragManagerProd.UI.Forms
 
     public partial class MultiClassConfigDialog : Form
     {
-        private readonly DriverRepository _driverRepo;
+        private readonly MultiClassSetupService _service;
         private List<Driver> _allDrivers = new List<Driver>();
         private readonly Dictionary<int, double?> _dialInOverrides = new Dictionary<int, double?>();
         private readonly HashSet<int> _checkedDriverIds = new HashSet<int>();
@@ -53,10 +54,15 @@ namespace RCDragManagerProd.UI.Forms
 
         public MultiClassConfigDialog(string connectionString,
                                        MultiClassConfigDialogValues existing = null)
+            : this(new MultiClassSetupService(new DriverRepository(connectionString)), existing)
         {
-            InitializeComponent();
+        }
 
-            _driverRepo = new DriverRepository(connectionString);
+        internal MultiClassConfigDialog(MultiClassSetupService service,
+                                        MultiClassConfigDialogValues existing = null)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+            InitializeComponent();
 
             CreateSearchControl();
             LoadDrivers();
@@ -148,7 +154,7 @@ namespace RCDragManagerProd.UI.Forms
 
         private void LoadDrivers()
         {
-            _allDrivers = _driverRepo.GetAllDrivers() ?? new List<Driver>();
+            _allDrivers = _service.GetAllDrivers();
         }
 
         private void SearchChanged(object sender, EventArgs e)
@@ -368,19 +374,13 @@ namespace RCDragManagerProd.UI.Forms
             {
                 if (addDialog.ShowDialog(this) != DialogResult.OK) return;
 
-                var newDriver = new Driver { Name = addDialog.DriverName, Cars = new List<Car>() };
-                _driverRepo.AddDriver(newDriver);
-
-                var insertedDriver = _driverRepo.GetAllDrivers()
-                    .First(d => d.Name == newDriver.Name);
-
-                var newCar = new Car
+                var car = new Car
                 {
-                    CarName = addDialog.CarName,
-                    ClassType = addDialog.ClassType,
+                    CarName       = addDialog.CarName,
+                    ClassType     = addDialog.ClassType,
                     DefaultDialIn = addDialog.DialIn
                 };
-                _driverRepo.AddCar(insertedDriver.Id, newCar);
+                _service.QuickAddDriver(addDialog.DriverName, car);
             }
 
             LoadDrivers();
@@ -635,34 +635,13 @@ namespace RCDragManagerProd.UI.Forms
                 Logger.Log($"[MULTICLASS][CFG][RR] '{className}' → Variant='{Variant}', RoundsToRun={(RoundsToRun.HasValue ? RoundsToRun.Value.ToString() : "null")}");
             }
 
-            BuiltDriverEntries = new List<RaceSessionDriverEntry>();
-            foreach (var driverId in _checkedDriverIds)
-            {
-                var driver = _allDrivers.FirstOrDefault(d => d.Id == driverId);
-                if (driver == null) continue;
-
-                var car = driver.Cars?.FirstOrDefault();
-
-                double? dialIn;
-                if (rbBracket.Checked)
-                    dialIn = FixedDialIn;
-                else if (rbHeadsUp.Checked)
-                    dialIn = null;
-                else
-                    dialIn = _dialInOverrides.TryGetValue(driverId, out var overrideVal)
-                        ? overrideVal
-                        : car?.DefaultDialIn;
-
-                BuiltDriverEntries.Add(new RaceSessionDriverEntry
-                {
-                    DriverID   = driver.Id,
-                    DriverName = driver.Name,
-                    CarID      = car?.CarID ?? 0,
-                    CarName    = car?.CarName ?? "",
-                    ClassType  = ClassName,
-                    DialIn     = dialIn
-                });
-            }
+            BuiltDriverEntries = _service.BuildDriverEntries(
+                _checkedDriverIds,
+                _allDrivers,
+                ClassType,
+                FixedDialIn,
+                _dialInOverrides,
+                ClassName);
 
             DialogResult = DialogResult.OK;
             Close();

--- a/src/RCDragManagerProd/UI/Forms/Session/MultiClassSetupForm.cs
+++ b/src/RCDragManagerProd/UI/Forms/Session/MultiClassSetupForm.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
+using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Domain;
 using RCDragManagerProd.Logging;
 using RCDragManagerProd.Repositories;
@@ -9,30 +10,21 @@ namespace RCDragManagerProd.UI.Forms
 {
     public partial class MultiClassSetupForm : Form
     {
-        private readonly string _connectionString;
-        private readonly DriverRepository _driverRepo;
+        private readonly MultiClassSetupService _service;
 
-        private readonly List<ClassConfig> _classList = new List<ClassConfig>();
+        private readonly List<ClassConfigDto> _classList = new List<ClassConfigDto>();
 
         public MultiClassEvent MultiClassEventResult { get; private set; }
 
-        private class ClassConfig
+        public MultiClassSetupForm(string connectionString)
+            : this(new MultiClassSetupService(new DriverRepository(connectionString)))
         {
-            public string ClassName { get; set; }
-            public string RaceType { get; set; }
-            public string ClassType { get; set; }
-            public double? FixedDialIn { get; set; }
-            public string Variant { get; set; }
-            public int? RoundsToRun { get; set; }
-            public List<RaceSessionDriverEntry> DriverEntries { get; set; }
         }
 
-        public MultiClassSetupForm(string connectionString)
+        internal MultiClassSetupForm(MultiClassSetupService service)
         {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
             InitializeComponent();
-
-            _connectionString = connectionString;
-            _driverRepo = new DriverRepository(connectionString);
 
             btnAddClass.Click += BtnAddClass_Click;
             btnEditClass.Click += BtnEditClass_Click;
@@ -48,17 +40,17 @@ namespace RCDragManagerProd.UI.Forms
 
         // ── Class list management ─────────────────────────────────────────────
 
-        private void AddClass(ClassConfig config)
+        private void AddClass(ClassConfigDto config)
         {
-            foreach (var existing in _classList)
+            var existingNames = new List<string>();
+            foreach (var cc in _classList)
+                existingNames.Add(cc.ClassName);
+
+            string error = _service.ValidateClassName(config.ClassName, existingNames);
+            if (error != null)
             {
-                if (string.Equals(existing.ClassName, config.ClassName, StringComparison.OrdinalIgnoreCase))
-                {
-                    MessageBox.Show($"A class named '{config.ClassName}' already exists. " +
-                                    "Please use a different name.",
-                                    "Duplicate Class", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
+                MessageBox.Show(error, "Duplicate Class", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
             }
 
             _classList.Add(config);
@@ -92,11 +84,11 @@ namespace RCDragManagerProd.UI.Forms
 
         private void BtnAddClass_Click(object sender, EventArgs e)
         {
-            using (var dlg = new MultiClassConfigDialog(_connectionString))
+            using (var dlg = new MultiClassConfigDialog(_service))
             {
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
-                    AddClass(new ClassConfig
+                    AddClass(new ClassConfigDto
                     {
                         ClassName     = dlg.ClassName,
                         RaceType      = dlg.RaceType,
@@ -127,11 +119,11 @@ namespace RCDragManagerProd.UI.Forms
                 DriverEntries = cc.DriverEntries
             };
 
-            using (var dlg = new MultiClassConfigDialog(_connectionString, existing))
+            using (var dlg = new MultiClassConfigDialog(_service, existing))
             {
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
-                    _classList[idx] = new ClassConfig
+                    _classList[idx] = new ClassConfigDto
                     {
                         ClassName     = dlg.ClassName,
                         RaceType      = dlg.RaceType,
@@ -153,57 +145,29 @@ namespace RCDragManagerProd.UI.Forms
 
         private void BtnStartRace_Click(object sender, EventArgs e)
         {
-            foreach (var cc in _classList)
+            string error = _service.ValidateCanStart(_classList);
+            if (error != null)
             {
-                if (cc.DriverEntries.Count == 0)
-                {
-                    MessageBox.Show(
-                        $"Class '{cc.ClassName}' has no drivers. " +
-                        "Add at least one driver or remove the class.",
-                        "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
+                MessageBox.Show(error, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
             }
 
-            foreach (var cc in _classList)
+            try
             {
-                foreach (var entry in cc.DriverEntries)
-                {
-                    _driverRepo.IncrementEventsEntered(entry.DriverID);
-                }
+                MultiClassEventResult = _service.StartEvent(
+                    txtEventName.Text.Trim(),
+                    dtpEventDate.Value.Date,
+                    _classList);
+
+                DialogResult = DialogResult.OK;
+                Close();
             }
-
-            MultiClassEventResult = new MultiClassEvent
+            catch (Exception ex)
             {
-                EventName = txtEventName.Text.Trim(),
-                EventDate = dtpEventDate.Value.Date
-            };
-
-            foreach (var cc in _classList)
-            {
-                bool isRR = string.Equals(cc.RaceType, RaceTypes.RoundRobin, StringComparison.OrdinalIgnoreCase);
-
-                var session = new RaceSession
-                {
-                    EventName          = MultiClassEventResult.EventName,
-                    EventDate          = MultiClassEventResult.EventDate,
-                    RaceType           = cc.RaceType ?? RaceTypes.RoundRobin,
-                    ClassType          = cc.ClassName,
-                    FixedDialIn        = cc.FixedDialIn,
-                    RoundRobinVariant  = isRR ? cc.Variant : null,
-                    RoundsToRun        = isRR ? cc.RoundsToRun : null,
-                    DriverEntries      = cc.DriverEntries
-                };
-                MultiClassEventResult.ClassSessions.Add(session);
-
-                if (isRR)
-                {
-                    Logger.Log($"[MULTICLASS][START][RR] Class '{cc.ClassName}' → Variant='{session.RoundRobinVariant}', RoundsToRun={(session.RoundsToRun.HasValue ? session.RoundsToRun.Value.ToString() : "null")}");
-                }
+                Logger.Log($"[UI][MultiClassSetup] StartEvent failed: {ex}");
+                MessageBox.Show("Failed to start the race event. Check the log for details.",
+                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
-
-            DialogResult = DialogResult.OK;
-            Close();
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- Extracts `MultiClassSetupService` (new `AppServices` class) from `MultiClassSetupForm` and `MultiClassConfigDialog`
- Service covers: driver loading, quick-add, class-name validation, can-start validation, driver-entry construction, event assembly
- Introduces `ClassConfigDto` replacing the private `ClassConfig` inner class in `MultiClassSetupForm`
- Both forms now hold only a service reference — no repositories, no business logic

## Test plan
- [ ] Build solution (Rebuild All) — 0 errors expected
- [ ] Run all tests — 247 passed / 11 skipped / 0 failed expected
- [ ] Smoke-test: open Multi-Class Setup form, add a class (Add Class → fill config, add drivers, OK), verify class appears in list
- [ ] Edit an existing class via the Edit Class button and double-click shortcut
- [ ] Remove a class
- [ ] Start Race — verify the event opens in `MultiClassRaceForm`
- [ ] Quick-add a driver from within the Config Dialog — verify driver appears in list

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)