### PR TITLE
feat(wpf): New Event Setup window + per-class config dialog (#2 of 8)

### DIFF
--- a/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
@@ -122,7 +122,9 @@
                                FontSize="{StaticResource FontSize.Xs}"
                                Foreground="{StaticResource Brush.TextMuted}"
                                Margin="0,0,0,8"/>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <!-- Fixed height so toggling fixed-dial-in / RR options never
+                         moves the roster grid below. -->
+                    <StackPanel Orientation="Horizontal" Height="30" VerticalAlignment="Center">
                         <RadioButton Style="{StaticResource Style.RadioButton}"
                                      Content="Heads Up" GroupName="ct"
                                      VerticalAlignment="Center"
@@ -144,7 +146,8 @@
                                        FontSize="{StaticResource FontSize.Sm}"
                                        Foreground="{StaticResource Brush.TextMuted}"
                                        VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <TextBox Style="{StaticResource Style.TextBox}" Width="70"
+                            <TextBox Style="{StaticResource Style.TextBox}" Width="70" Height="26"
+                                     VerticalContentAlignment="Center"
                                      Text="{Binding FixedDialInText, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
 
@@ -160,7 +163,8 @@
                                        FontSize="{StaticResource FontSize.Sm}"
                                        Foreground="{StaticResource Brush.TextMuted}"
                                        VerticalAlignment="Center" Margin="20,0,8,0"/>
-                            <TextBox Style="{StaticResource Style.TextBox}" Width="56"
+                            <TextBox Style="{StaticResource Style.TextBox}" Width="56" Height="26"
+                                     VerticalContentAlignment="Center"
                                      Text="{Binding RoundsToRun, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
                     </StackPanel>

--- a/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
@@ -117,62 +117,53 @@
                         </Button>
                     </UniformGrid>
 
-                    <!-- Class type + fixed dial-in -->
-                    <Grid Margin="0,0,0,4">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
+                    <!-- Class type + (inline) fixed dial-in + RR options -->
+                    <TextBlock Text="Class type"
+                               FontSize="{StaticResource FontSize.Xs}"
+                               Foreground="{StaticResource Brush.TextMuted}"
+                               Margin="0,0,0,8"/>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <RadioButton Style="{StaticResource Style.RadioButton}"
+                                     Content="Heads Up" GroupName="ct"
+                                     VerticalAlignment="Center"
+                                     IsChecked="{Binding IsHeadsUp}"/>
+                        <RadioButton Style="{StaticResource Style.RadioButton}"
+                                     Content="Bracket Class" GroupName="ct"
+                                     VerticalAlignment="Center"
+                                     IsChecked="{Binding IsBracket}"/>
+                        <RadioButton Style="{StaticResource Style.RadioButton}"
+                                     Content="Dial-In" GroupName="ct"
+                                     VerticalAlignment="Center"
+                                     IsChecked="{Binding IsDialIn}"/>
 
-                        <StackPanel Grid.Column="0">
-                            <TextBlock Text="Class type"
-                                       FontSize="{StaticResource FontSize.Xs}"
-                                       Foreground="{StaticResource Brush.TextMuted}"
-                                       Margin="0,0,0,8"/>
-                            <StackPanel Orientation="Horizontal">
-                                <RadioButton Style="{StaticResource Style.RadioButton}"
-                                             Content="Heads Up" GroupName="ct"
-                                             IsChecked="{Binding IsHeadsUp}"/>
-                                <RadioButton Style="{StaticResource Style.RadioButton}"
-                                             Content="Bracket Class" GroupName="ct"
-                                             IsChecked="{Binding IsBracket}"/>
-                                <RadioButton Style="{StaticResource Style.RadioButton}"
-                                             Content="Dial-In" GroupName="ct"
-                                             IsChecked="{Binding IsDialIn}"/>
-                            </StackPanel>
-                        </StackPanel>
-
-                        <StackPanel Grid.Column="1" Width="120"
+                        <!-- Fixed dial-in (Bracket Class only) -->
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                    Margin="6,0,0,0"
                                     Visibility="{Binding FixedDialInVisibility}">
                             <TextBlock Text="Fixed dial-in"
-                                       FontSize="{StaticResource FontSize.Xs}"
+                                       FontSize="{StaticResource FontSize.Sm}"
                                        Foreground="{StaticResource Brush.TextMuted}"
-                                       Margin="0,0,0,8"/>
-                            <TextBox Style="{StaticResource Style.TextBox}"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBox Style="{StaticResource Style.TextBox}" Width="70"
                                      Text="{Binding FixedDialInText, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
-                    </Grid>
 
-                    <!-- Round Robin options -->
-                    <Border Visibility="{Binding RrConfigVisibility}"
-                            Background="{StaticResource Brush.Chrome}"
-                            BorderBrush="{StaticResource Brush.BorderSubtle}"
-                            BorderThickness="1"
-                            CornerRadius="{StaticResource Radius.Panel}"
-                            Padding="14,12" Margin="0,14,0,0">
-                        <StackPanel Orientation="Horizontal">
+                        <!-- Round Robin options (RR race type only) -->
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                    Margin="20,0,0,0"
+                                    Visibility="{Binding RrConfigVisibility}">
                             <CheckBox Style="{StaticResource Style.CheckBox}"
-                                      Content="Buyback race (Standard)"
-                                      IsChecked="{Binding BuybackEnabled}"
-                                      VerticalAlignment="Center"/>
+                                      Content="Buyback race"
+                                      VerticalAlignment="Center"
+                                      IsChecked="{Binding BuybackEnabled}"/>
                             <TextBlock Text="Rounds"
                                        FontSize="{StaticResource FontSize.Sm}"
                                        Foreground="{StaticResource Brush.TextMuted}"
-                                       VerticalAlignment="Center" Margin="28,0,8,0"/>
-                            <TextBox Style="{StaticResource Style.TextBox}" Width="60"
+                                       VerticalAlignment="Center" Margin="20,0,8,0"/>
+                            <TextBox Style="{StaticResource Style.TextBox}" Width="56"
                                      Text="{Binding RoundsToRun, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
-                    </Border>
+                    </StackPanel>
 
                 </StackPanel>
             </Border>
@@ -230,6 +221,7 @@
                           CanUserAddRows="False" CanUserDeleteRows="False"
                           CanUserReorderColumns="False" CanUserResizeRows="False"
                           SelectionMode="Single"
+                          HeadersVisibility="Column"
                           GridLinesVisibility="Horizontal"
                           HorizontalGridLinesBrush="{StaticResource Brush.BorderSubtle}"
                           Background="{StaticResource Brush.Background}"

--- a/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
@@ -1,0 +1,305 @@
+<Window x:Class="RCDragManagerProd.WPF.Dialogs.ClassConfigDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configure class — RC Drag Manager"
+        Width="740" Height="660"
+        MinWidth="640" MinHeight="520"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="CanResizeWithGrip"
+        Background="{StaticResource Brush.Background}"
+        FontFamily="Segoe UI"
+        ShowInTaskbar="False">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="38" CornerRadius="0"
+                      GlassFrameThickness="0" ResizeBorderThickness="5"
+                      UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Background}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="38"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title bar -->
+            <Grid Grid.Row="0" Background="{StaticResource Brush.Chrome}">
+                <TextBlock x:Name="TbarTitle" Text="Configure class"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           FontSize="12" Foreground="{StaticResource Brush.TextHint}"
+                           FontWeight="Medium"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                            VerticalAlignment="Center" Margin="0,0,14,0">
+                    <Button Style="{StaticResource Style.WinCtrl.Close}" Click="BtnClose_Click"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Top config: name, race type, class type, RR -->
+            <Border Grid.Row="1"
+                    Background="{StaticResource Brush.Surface}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,0,0,1"
+                    Padding="24,18">
+                <StackPanel>
+
+                    <!-- Class name -->
+                    <TextBlock Text="Class name"
+                               FontSize="{StaticResource FontSize.Xs}"
+                               Foreground="{StaticResource Brush.TextMuted}"
+                               Margin="0,0,0,5"/>
+                    <TextBox Style="{StaticResource Style.TextBox}"
+                             Text="{Binding ClassName, UpdateSourceTrigger=PropertyChanged}"
+                             Margin="0,0,0,16"/>
+
+                    <!-- Race type cards -->
+                    <TextBlock Text="Race type"
+                               FontSize="{StaticResource FontSize.Xs}"
+                               Foreground="{StaticResource Brush.TextMuted}"
+                               Margin="0,0,0,6"/>
+                    <UniformGrid Columns="3" Margin="0,0,0,16">
+                        <Button Click="CardProLadder_Click" Margin="0,0,8,0">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource Style.RaceCard}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsProLadderSelected}" Value="True">
+                                            <Setter Property="BorderBrush" Value="{StaticResource Brush.Primary}"/>
+                                            <Setter Property="Background" Value="{StaticResource Brush.Raised}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <StackPanel>
+                                <TextBlock Text="Pro Ladder" FontSize="{StaticResource FontSize.Md}"
+                                           FontWeight="Medium" Foreground="{StaticResource Brush.TextPrimary}"/>
+                                <TextBlock Text="NHRA bracket" FontSize="{StaticResource FontSize.Xs}"
+                                           Foreground="{StaticResource Brush.TextMuted}" Margin="0,2,0,0"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="CardRandomDraw_Click" Margin="0,0,8,0">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource Style.RaceCard}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsRandomDrawSelected}" Value="True">
+                                            <Setter Property="BorderBrush" Value="{StaticResource Brush.Primary}"/>
+                                            <Setter Property="Background" Value="{StaticResource Brush.Raised}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <StackPanel>
+                                <TextBlock Text="Random Draw" FontSize="{StaticResource FontSize.Md}"
+                                           FontWeight="Medium" Foreground="{StaticResource Brush.TextPrimary}"/>
+                                <TextBlock Text="Single elim" FontSize="{StaticResource FontSize.Xs}"
+                                           Foreground="{StaticResource Brush.TextMuted}" Margin="0,2,0,0"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="CardRoundRobin_Click">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource Style.RaceCard}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsRoundRobinSelected}" Value="True">
+                                            <Setter Property="BorderBrush" Value="{StaticResource Brush.Primary}"/>
+                                            <Setter Property="Background" Value="{StaticResource Brush.Raised}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <StackPanel>
+                                <TextBlock Text="Round Robin" FontSize="{StaticResource FontSize.Md}"
+                                           FontWeight="Medium" Foreground="{StaticResource Brush.TextPrimary}"/>
+                                <TextBlock Text="Points based" FontSize="{StaticResource FontSize.Xs}"
+                                           Foreground="{StaticResource Brush.TextMuted}" Margin="0,2,0,0"/>
+                            </StackPanel>
+                        </Button>
+                    </UniformGrid>
+
+                    <!-- Class type + fixed dial-in -->
+                    <Grid Margin="0,0,0,4">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="Class type"
+                                       FontSize="{StaticResource FontSize.Xs}"
+                                       Foreground="{StaticResource Brush.TextMuted}"
+                                       Margin="0,0,0,8"/>
+                            <StackPanel Orientation="Horizontal">
+                                <RadioButton Style="{StaticResource Style.RadioButton}"
+                                             Content="Heads Up" GroupName="ct"
+                                             IsChecked="{Binding IsHeadsUp}"/>
+                                <RadioButton Style="{StaticResource Style.RadioButton}"
+                                             Content="Bracket Class" GroupName="ct"
+                                             IsChecked="{Binding IsBracket}"/>
+                                <RadioButton Style="{StaticResource Style.RadioButton}"
+                                             Content="Dial-In" GroupName="ct"
+                                             IsChecked="{Binding IsDialIn}"/>
+                            </StackPanel>
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="1" Width="120"
+                                    Visibility="{Binding FixedDialInVisibility}">
+                            <TextBlock Text="Fixed dial-in"
+                                       FontSize="{StaticResource FontSize.Xs}"
+                                       Foreground="{StaticResource Brush.TextMuted}"
+                                       Margin="0,0,0,8"/>
+                            <TextBox Style="{StaticResource Style.TextBox}"
+                                     Text="{Binding FixedDialInText, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Round Robin options -->
+                    <Border Visibility="{Binding RrConfigVisibility}"
+                            Background="{StaticResource Brush.Chrome}"
+                            BorderBrush="{StaticResource Brush.BorderSubtle}"
+                            BorderThickness="1"
+                            CornerRadius="{StaticResource Radius.Panel}"
+                            Padding="14,12" Margin="0,14,0,0">
+                        <StackPanel Orientation="Horizontal">
+                            <CheckBox Style="{StaticResource Style.CheckBox}"
+                                      Content="Buyback race (Standard)"
+                                      IsChecked="{Binding BuybackEnabled}"
+                                      VerticalAlignment="Center"/>
+                            <TextBlock Text="Rounds"
+                                       FontSize="{StaticResource FontSize.Sm}"
+                                       Foreground="{StaticResource Brush.TextMuted}"
+                                       VerticalAlignment="Center" Margin="28,0,8,0"/>
+                            <TextBox Style="{StaticResource Style.TextBox}" Width="60"
+                                     Text="{Binding RoundsToRun, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
+                    </Border>
+
+                </StackPanel>
+            </Border>
+
+            <!-- Roster -->
+            <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" Padding="24,12"
+                        BorderBrush="{StaticResource Brush.BorderSubtle}"
+                        BorderThickness="0,0,0,1">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0" Text="Drivers"
+                                   FontSize="{StaticResource FontSize.Xs}"
+                                   FontWeight="Medium"
+                                   Foreground="{StaticResource Brush.TextHint}"
+                                   VerticalAlignment="Center"/>
+
+                        <Border Grid.Column="1"
+                                Background="{StaticResource Brush.Chrome}"
+                                BorderBrush="{StaticResource Brush.Border}"
+                                BorderThickness="1" CornerRadius="5"
+                                Padding="8,4" Margin="16,0" HorizontalAlignment="Stretch"
+                                MaxWidth="280">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE721;" FontFamily="Segoe MDL2 Assets"
+                                           FontSize="13" Foreground="{StaticResource Brush.TextHint}"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBox Width="220" BorderThickness="0" Background="Transparent"
+                                         Foreground="{StaticResource Brush.TextPrimary}"
+                                         FontSize="{StaticResource FontSize.Sm}"
+                                         VerticalAlignment="Center"
+                                         Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}"/>
+                            </StackPanel>
+                        </Border>
+
+                        <Button Grid.Column="2"
+                                Style="{StaticResource Style.Button.Toolbar}"
+                                Content="Add new driver" Click="BtnAddNewDriver_Click"/>
+                    </Grid>
+                </Border>
+
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding Roster}"
+                          AutoGenerateColumns="False"
+                          CanUserAddRows="False" CanUserDeleteRows="False"
+                          CanUserReorderColumns="False" CanUserResizeRows="False"
+                          SelectionMode="Single"
+                          GridLinesVisibility="Horizontal"
+                          HorizontalGridLinesBrush="{StaticResource Brush.BorderSubtle}"
+                          Background="{StaticResource Brush.Background}"
+                          RowBackground="{StaticResource Brush.Background}"
+                          AlternatingRowBackground="{StaticResource Brush.Surface}"
+                          Foreground="{StaticResource Brush.TextPrimary}"
+                          FontSize="{StaticResource FontSize.Sm}"
+                          BorderThickness="0" RowHeight="34">
+                    <DataGrid.ColumnHeaderStyle>
+                        <Style TargetType="DataGridColumnHeader">
+                            <Setter Property="Background" Value="{StaticResource Brush.Chrome}"/>
+                            <Setter Property="Foreground" Value="{StaticResource Brush.TextHint}"/>
+                            <Setter Property="FontSize" Value="{StaticResource FontSize.Xs}"/>
+                            <Setter Property="FontWeight" Value="Medium"/>
+                            <Setter Property="Padding" Value="12,0"/>
+                            <Setter Property="Height" Value="30"/>
+                            <Setter Property="BorderBrush" Value="{StaticResource Brush.BorderSubtle}"/>
+                            <Setter Property="BorderThickness" Value="0,0,1,1"/>
+                            <Setter Property="SeparatorBrush" Value="{StaticResource Brush.BorderSubtle}"/>
+                        </Style>
+                    </DataGrid.ColumnHeaderStyle>
+                    <DataGrid.CellStyle>
+                        <Style TargetType="DataGridCell">
+                            <Setter Property="Padding" Value="12,0"/>
+                            <Setter Property="BorderThickness" Value="0"/>
+                            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="DataGridCell">
+                                        <Border Background="{TemplateBinding Background}"
+                                                Padding="{TemplateBinding Padding}">
+                                            <ContentPresenter VerticalAlignment="Center"/>
+                                        </Border>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </DataGrid.CellStyle>
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn Header="" Width="40" IsReadOnly="False">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <CheckBox Style="{StaticResource Style.CheckBox}"
+                                              HorizontalAlignment="Center"
+                                              IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Driver"   Binding="{Binding Name}"            Width="*"  IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Car"      Binding="{Binding CarName}"         Width="150" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Class"    Binding="{Binding ClassType}"       Width="90" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Dial-in"  Binding="{Binding DefaultDialInText}" Width="70" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Override" Binding="{Binding OverrideText, UpdateSourceTrigger=LostFocus}" Width="80" IsReadOnly="False"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+
+            <!-- Footer -->
+            <Border Grid.Row="3"
+                    Background="{StaticResource Brush.Chrome}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,1,0,0"
+                    Padding="24,14">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                            Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"/>
+                    <Button x:Name="BtnOk" Style="{StaticResource Style.Button.Dialog.Primary}"
+                            Content="Add class" Click="BtnOk_Click"/>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
@@ -220,12 +220,14 @@
                 </Border>
 
                 <DataGrid Grid.Row="1"
+                          x:Name="DgRoster"
                           ItemsSource="{Binding Roster}"
                           AutoGenerateColumns="False"
                           CanUserAddRows="False" CanUserDeleteRows="False"
                           CanUserReorderColumns="False" CanUserResizeRows="False"
                           SelectionMode="Single"
                           HeadersVisibility="Column"
+                          MouseDoubleClick="DgRoster_DoubleClick"
                           GridLinesVisibility="Horizontal"
                           HorizontalGridLinesBrush="{StaticResource Brush.BorderSubtle}"
                           Background="{StaticResource Brush.Background}"

--- a/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml.cs
@@ -1,0 +1,69 @@
+using System.Windows;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.WPF.ViewModels;
+
+namespace RCDragManagerProd.WPF.Dialogs
+{
+    public partial class ClassConfigDialog : Window
+    {
+        private readonly ClassConfigViewModel _vm;
+
+        /// <summary>The configured class, valid after a successful OK.</summary>
+        public ClassConfigDto Result { get; private set; }
+
+        public ClassConfigDialog(MultiClassSetupService service, ClassConfigDto existing = null)
+        {
+            InitializeComponent();
+            _vm = new ClassConfigViewModel(service, existing);
+            DataContext = _vm;
+
+            TbarTitle.Text = _vm.IsEdit ? "Edit class" : "Add class";
+            BtnOk.Content = _vm.IsEdit ? "Save class" : "Add class";
+        }
+
+        private void BtnClose_Click(object sender, RoutedEventArgs e) => Close();
+        private void BtnCancel_Click(object sender, RoutedEventArgs e) => Close();
+
+        // ── Race type cards ──────────────────────────────────────────────────
+
+        private void CardProLadder_Click(object sender, RoutedEventArgs e) =>
+            _vm.SelectedRaceType = ClassConfigViewModel.ProLadder;
+
+        private void CardRandomDraw_Click(object sender, RoutedEventArgs e) =>
+            _vm.SelectedRaceType = ClassConfigViewModel.RandomDraw;
+
+        private void CardRoundRobin_Click(object sender, RoutedEventArgs e) =>
+            _vm.SelectedRaceType = ClassConfigViewModel.RoundRobin;
+
+        // ── Add new driver ───────────────────────────────────────────────────
+
+        private void BtnAddNewDriver_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new QuickAddDriverDialog { Owner = this };
+            if (dlg.ShowDialog() != true) return;
+
+            var car = new Car
+            {
+                CarName = dlg.CarName,
+                ClassType = dlg.ClassType,
+                DefaultDialIn = dlg.DialIn
+            };
+            _vm.QuickAddDriver(dlg.DriverName, car);
+        }
+
+        // ── OK ───────────────────────────────────────────────────────────────
+
+        private void BtnOk_Click(object sender, RoutedEventArgs e)
+        {
+            var result = _vm.BuildResult(out var error);
+            if (result == null)
+            {
+                MessageBox.Show(error, "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            Result = result;
+            DialogResult = true;
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml.cs
@@ -1,4 +1,7 @@
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Domain;
 using RCDragManagerProd.WPF.ViewModels;
@@ -35,6 +38,28 @@ namespace RCDragManagerProd.WPF.Dialogs
 
         private void CardRoundRobin_Click(object sender, RoutedEventArgs e) =>
             _vm.SelectedRaceType = ClassConfigViewModel.RoundRobin;
+
+        // ── Roster double-click toggles inclusion ────────────────────────────
+
+        private void DgRoster_DoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            // Ignore double-clicks that land on the editable Override cell so the
+            // user can edit it without toggling the row.
+            if (FindParentCell(e.OriginalSource as DependencyObject) is DataGridCell cell &&
+                cell.Column?.Header is string header &&
+                header == "Override")
+                return;
+
+            if (DgRoster.SelectedItem is DriverRosterRow row)
+                row.IsChecked = !row.IsChecked;
+        }
+
+        private static DataGridCell FindParentCell(DependencyObject d)
+        {
+            while (d != null && !(d is DataGridCell))
+                d = VisualTreeHelper.GetParent(d);
+            return d as DataGridCell;
+        }
 
         // ── Add new driver ───────────────────────────────────────────────────
 

--- a/src/RCDragManagerProd.WPF/Dialogs/QuickAddDriverDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/QuickAddDriverDialog.xaml
@@ -1,0 +1,72 @@
+<Window x:Class="RCDragManagerProd.WPF.Dialogs.QuickAddDriverDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Add driver"
+        Width="380"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        KeyDown="Window_KeyDown"
+        Background="{StaticResource Brush.Surface}"
+        FontFamily="Segoe UI"
+        ShowInTaskbar="False">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="0" GlassFrameThickness="0"
+                      ResizeBorderThickness="0" UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Surface}"
+            BorderBrush="{StaticResource Brush.Border}"
+            BorderThickness="1">
+        <StackPanel Margin="24,22">
+
+            <TextBlock Text="Add driver"
+                       FontSize="{StaticResource FontSize.Lg}"
+                       FontWeight="Medium"
+                       Foreground="{StaticResource Brush.TextPrimary}"
+                       Margin="0,0,0,18"/>
+
+            <StackPanel Margin="0,0,0,14">
+                <TextBlock Text="Driver name"
+                           FontSize="{StaticResource FontSize.Xs}"
+                           Foreground="{StaticResource Brush.TextMuted}"
+                           Margin="0,0,0,5"/>
+                <TextBox x:Name="TxtDriverName" Style="{StaticResource Style.TextBox}"/>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,14">
+                <TextBlock Text="Car name"
+                           FontSize="{StaticResource FontSize.Xs}"
+                           Foreground="{StaticResource Brush.TextMuted}"
+                           Margin="0,0,0,5"/>
+                <TextBox x:Name="TxtCarName" Style="{StaticResource Style.TextBox}"/>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,14">
+                <TextBlock Text="Class type (optional)"
+                           FontSize="{StaticResource FontSize.Xs}"
+                           Foreground="{StaticResource Brush.TextMuted}"
+                           Margin="0,0,0,5"/>
+                <TextBox x:Name="TxtClassType" Style="{StaticResource Style.TextBox}"/>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,24">
+                <TextBlock Text="Default dial-in (optional)"
+                           FontSize="{StaticResource FontSize.Xs}"
+                           Foreground="{StaticResource Brush.TextMuted}"
+                           Margin="0,0,0,5"/>
+                <TextBox x:Name="TxtDialIn" Style="{StaticResource Style.TextBox}"/>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                        Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"/>
+                <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                        Content="Add" Click="BtnSave_Click"/>
+            </StackPanel>
+
+        </StackPanel>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Dialogs/QuickAddDriverDialog.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/QuickAddDriverDialog.xaml.cs
@@ -1,0 +1,47 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace RCDragManagerProd.WPF.Dialogs
+{
+    public partial class QuickAddDriverDialog : Window
+    {
+        public string DriverName => TxtDriverName.Text.Trim();
+        public string CarName => TxtCarName.Text.Trim();
+        public string ClassType => TxtClassType.Text.Trim();
+        public double? DialIn { get; private set; }
+
+        public QuickAddDriverDialog()
+        {
+            InitializeComponent();
+            TxtDriverName.Focus();
+        }
+
+        private void BtnSave_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(TxtDriverName.Text))
+            {
+                TxtDriverName.BorderBrush = FindResource("Brush.Danger") as System.Windows.Media.Brush;
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(TxtCarName.Text))
+            {
+                TxtCarName.BorderBrush = FindResource("Brush.Danger") as System.Windows.Media.Brush;
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(TxtDialIn.Text) &&
+                double.TryParse(TxtDialIn.Text.Trim(), out var parsed))
+                DialIn = parsed;
+
+            DialogResult = true;
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e) =>
+            DialogResult = false;
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape) DialogResult = false;
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Resources/Styles.xaml
+++ b/src/RCDragManagerProd.WPF/Resources/Styles.xaml
@@ -389,6 +389,124 @@
         <Setter Property="Foreground" Value="{StaticResource Brush.TextMuted}"/>
     </Style>
 
+    <!-- ── CheckBox (dark) ────────────────────────────────────────────────── -->
+
+    <Style x:Key="Style.CheckBox" TargetType="CheckBox">
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="FontSize" Value="{StaticResource FontSize.Sm}"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CheckBox">
+                    <StackPanel Orientation="Horizontal" Background="Transparent">
+                        <Border x:Name="box" Width="17" Height="17"
+                                CornerRadius="4"
+                                Background="{StaticResource Brush.Chrome}"
+                                BorderBrush="{StaticResource Brush.Border}"
+                                BorderThickness="1"
+                                VerticalAlignment="Center">
+                            <TextBlock x:Name="tick" Text="&#xE73E;"
+                                       FontFamily="Segoe MDL2 Assets"
+                                       FontSize="11" Foreground="White"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       Visibility="Collapsed"/>
+                        </Border>
+                        <ContentPresenter Margin="8,0,0,0" VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="box" Property="Background" Value="{StaticResource Brush.Primary}"/>
+                            <Setter TargetName="box" Property="BorderBrush" Value="{StaticResource Brush.Primary}"/>
+                            <Setter TargetName="tick" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="box" Property="BorderBrush" Value="{StaticResource Brush.Primary}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── RadioButton (dark) ─────────────────────────────────────────────── -->
+
+    <Style x:Key="Style.RadioButton" TargetType="RadioButton">
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="FontSize" Value="{StaticResource FontSize.Md}"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Margin" Value="0,0,18,0"/>
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RadioButton">
+                    <StackPanel Orientation="Horizontal" Background="Transparent">
+                        <Grid Width="17" Height="17" VerticalAlignment="Center">
+                            <Ellipse x:Name="ring"
+                                     Stroke="{StaticResource Brush.Border}" StrokeThickness="1"
+                                     Fill="{StaticResource Brush.Chrome}"/>
+                            <Ellipse x:Name="dot" Width="7" Height="7"
+                                     Fill="{StaticResource Brush.Primary}" Visibility="Collapsed"/>
+                        </Grid>
+                        <ContentPresenter Margin="8,0,0,0" VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="ring" Property="Stroke" Value="{StaticResource Brush.Primary}"/>
+                            <Setter TargetName="dot" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="ring" Property="Stroke" Value="{StaticResource Brush.Primary}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── Race-type selectable card ──────────────────────────────────────── -->
+
+    <Style x:Key="Style.RaceCard" TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource Brush.Chrome}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Padding" Value="14,12"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{StaticResource Radius.Panel}"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource Brush.PrimaryHover}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── DatePicker (dark text box portion) ─────────────────────────────── -->
+
+    <Style x:Key="Style.DatePicker" TargetType="DatePicker">
+        <Setter Property="Background" Value="{StaticResource Brush.Chrome}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="FontSize" Value="{StaticResource FontSize.Md}"/>
+        <Setter Property="Padding" Value="6,4"/>
+    </Style>
+
     <!-- ── ScrollViewer (keep background transparent in dark mode) ────────── -->
 
     <Style TargetType="ScrollViewer">

--- a/src/RCDragManagerProd.WPF/Resources/Styles.xaml
+++ b/src/RCDragManagerProd.WPF/Resources/Styles.xaml
@@ -496,15 +496,167 @@
         </Setter>
     </Style>
 
-    <!-- ── DatePicker (dark text box portion) ─────────────────────────────── -->
+    <!-- ── DatePicker (fully dark) ────────────────────────────────────────── -->
+
+    <!-- Editable text portion -->
+    <Style TargetType="DatePickerTextBox">
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="CaretBrush" Value="{StaticResource Brush.Primary}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="DatePickerTextBox">
+                    <Border Background="{TemplateBinding Background}" Padding="8,0">
+                        <ScrollViewer x:Name="PART_ContentHost" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Day cells -->
+    <Style TargetType="CalendarDayButton">
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="FontSize" Value="{StaticResource FontSize.Sm}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CalendarDayButton">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}"
+                            CornerRadius="4" Margin="1">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource Brush.Raised}"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource Brush.Primary}"/>
+                            <Setter Property="Foreground" Value="White"/>
+                        </Trigger>
+                        <Trigger Property="IsToday" Value="True">
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource Brush.Primary}"/>
+                            <Setter TargetName="bd" Property="BorderThickness" Value="1"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{StaticResource Brush.TextHint}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Month / year cells -->
+    <Style TargetType="CalendarButton">
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="FontSize" Value="{StaticResource FontSize.Sm}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CalendarButton">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}"
+                            CornerRadius="4" Margin="1" Padding="4">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource Brush.Raised}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Calendar header + grid container -->
+    <Style TargetType="CalendarItem">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CalendarItem">
+                    <Border Background="{StaticResource Brush.Surface}"
+                            BorderBrush="{StaticResource Brush.Border}"
+                            BorderThickness="1" CornerRadius="6" Padding="6">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+
+                            <!-- Header: prev / title / next -->
+                            <Grid Grid.Row="0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Button x:Name="PART_PreviousButton" Grid.Column="0"
+                                        Foreground="{StaticResource Brush.TextSecondary}"
+                                        Background="Transparent" BorderThickness="0"
+                                        Cursor="Hand" Content="&#x25C0;" FontSize="10"/>
+                                <Button x:Name="PART_HeaderButton" Grid.Column="1"
+                                        Foreground="{StaticResource Brush.TextPrimary}"
+                                        Background="Transparent" BorderThickness="0"
+                                        Cursor="Hand" FontWeight="Medium"
+                                        FontSize="13"/>
+                                <Button x:Name="PART_NextButton" Grid.Column="2"
+                                        Foreground="{StaticResource Brush.TextSecondary}"
+                                        Background="Transparent" BorderThickness="0"
+                                        Cursor="Hand" Content="&#x25B6;" FontSize="10"/>
+                            </Grid>
+
+                            <Grid x:Name="PART_MonthView" Grid.Row="2" Margin="0,6,0,0"
+                                  Visibility="Visible"/>
+                            <Grid x:Name="PART_YearView" Grid.Row="2" Margin="0,6,0,0"
+                                  Visibility="Hidden"/>
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="Calendar">
+        <Setter Property="Background" Value="{StaticResource Brush.Surface}"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+    </Style>
 
     <Style x:Key="Style.DatePicker" TargetType="DatePicker">
-        <Setter Property="Background" Value="{StaticResource Brush.Chrome}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
-        <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
         <Setter Property="FontSize" Value="{StaticResource FontSize.Md}"/>
-        <Setter Property="Padding" Value="6,4"/>
+        <Setter Property="Height" Value="32"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="DatePicker">
+                    <Border Background="{StaticResource Brush.Chrome}"
+                            BorderBrush="{StaticResource Brush.Border}"
+                            BorderThickness="1"
+                            CornerRadius="{StaticResource Radius.Button}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <DatePickerTextBox x:Name="PART_TextBox" Grid.Column="0"
+                                               VerticalAlignment="Center"/>
+                            <Button x:Name="PART_Button" Grid.Column="1"
+                                    Width="30" Cursor="Hand"
+                                    Background="Transparent" BorderThickness="0"
+                                    Foreground="{StaticResource Brush.TextSecondary}"
+                                    Content="&#xE787;" FontFamily="Segoe MDL2 Assets"
+                                    FontSize="14"/>
+                            <Popup x:Name="PART_Popup" StaysOpen="False"
+                                   AllowsTransparency="True"
+                                   Placement="Bottom" PlacementTarget="{Binding ElementName=PART_TextBox}"/>
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- ── ScrollViewer (keep background transparent in dark mode) ────────── -->

--- a/src/RCDragManagerProd.WPF/ViewModels/ClassConfigViewModel.cs
+++ b/src/RCDragManagerProd.WPF/ViewModels/ClassConfigViewModel.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+
+namespace RCDragManagerProd.WPF.ViewModels
+{
+    /// <summary>
+    /// Backs <c>ClassConfigDialog</c>: class name, race type (Pro Ladder /
+    /// Random Draw / Round Robin), class type (Heads Up / Bracket Class /
+    /// Dial-In), Round-Robin options, and the selectable driver roster.
+    /// </summary>
+    public sealed class ClassConfigViewModel : INotifyPropertyChanged
+    {
+        public const string ProLadder  = "Pro Ladder";
+        public const string RandomDraw  = "Random Draw";
+        public const string RoundRobin  = "Round Robin";
+
+        private readonly MultiClassSetupService _service;
+        private readonly List<DriverRosterRow> _allRows = new List<DriverRosterRow>();
+
+        public ObservableCollection<DriverRosterRow> Roster { get; } = new ObservableCollection<DriverRosterRow>();
+
+        public bool IsEdit { get; }
+
+        public ClassConfigViewModel(MultiClassSetupService service, ClassConfigDto existing = null)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+            IsEdit = existing != null;
+
+            LoadRoster();
+            _selectedRaceType = RoundRobin;
+            _isHeadsUp = true;
+
+            if (existing != null)
+                ApplyExisting(existing);
+
+            RefreshRoster();
+        }
+
+        // ── Class name ────────────────────────────────────────────────────────
+
+        private string _className = "";
+        public string ClassName
+        {
+            get => _className;
+            set { _className = value; OnPropertyChanged(); }
+        }
+
+        // ── Race type (card selection) ────────────────────────────────────────
+
+        private string _selectedRaceType;
+        public string SelectedRaceType
+        {
+            get => _selectedRaceType;
+            set
+            {
+                _selectedRaceType = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsProLadderSelected));
+                OnPropertyChanged(nameof(IsRandomDrawSelected));
+                OnPropertyChanged(nameof(IsRoundRobinSelected));
+                OnPropertyChanged(nameof(RrConfigVisibility));
+            }
+        }
+
+        public bool IsProLadderSelected  => _selectedRaceType == ProLadder;
+        public bool IsRandomDrawSelected => _selectedRaceType == RandomDraw;
+        public bool IsRoundRobinSelected => _selectedRaceType == RoundRobin;
+
+        public Visibility RrConfigVisibility =>
+            IsRoundRobinSelected ? Visibility.Visible : Visibility.Collapsed;
+
+        // ── Class type (radio) ────────────────────────────────────────────────
+
+        private bool _isHeadsUp;
+        public bool IsHeadsUp
+        {
+            get => _isHeadsUp;
+            set { _isHeadsUp = value; OnPropertyChanged(); OnClassTypeChanged(); }
+        }
+
+        private bool _isBracket;
+        public bool IsBracket
+        {
+            get => _isBracket;
+            set { _isBracket = value; OnPropertyChanged(); OnClassTypeChanged(); }
+        }
+
+        private bool _isDialIn;
+        public bool IsDialIn
+        {
+            get => _isDialIn;
+            set { _isDialIn = value; OnPropertyChanged(); OnClassTypeChanged(); }
+        }
+
+        private void OnClassTypeChanged()
+        {
+            OnPropertyChanged(nameof(FixedDialInVisibility));
+            OnPropertyChanged(nameof(OverrideColumnEnabled));
+        }
+
+        public Visibility FixedDialInVisibility =>
+            _isBracket ? Visibility.Visible : Visibility.Collapsed;
+
+        public bool OverrideColumnEnabled => _isDialIn;
+
+        private string _fixedDialInText = "";
+        public string FixedDialInText
+        {
+            get => _fixedDialInText;
+            set { _fixedDialInText = value; OnPropertyChanged(); }
+        }
+
+        // ── Round Robin options ───────────────────────────────────────────────
+
+        private bool _buybackEnabled = true;
+        public bool BuybackEnabled
+        {
+            get => _buybackEnabled;
+            set { _buybackEnabled = value; OnPropertyChanged(); }
+        }
+
+        private int _roundsToRun = 3;
+        public int RoundsToRun
+        {
+            get => _roundsToRun;
+            set { _roundsToRun = value; OnPropertyChanged(); }
+        }
+
+        // ── Search ────────────────────────────────────────────────────────────
+
+        private string _search = "";
+        public string Search
+        {
+            get => _search;
+            set { _search = value ?? ""; OnPropertyChanged(); RefreshRoster(); }
+        }
+
+        public int CheckedCount => _allRows.Count(r => r.IsChecked);
+
+        // ── Roster loading ────────────────────────────────────────────────────
+
+        private void LoadRoster()
+        {
+            _allRows.Clear();
+            foreach (var d in _service.GetAllDrivers())
+            {
+                var car = d.Cars?.FirstOrDefault();
+                _allRows.Add(new DriverRosterRow
+                {
+                    DriverId = d.Id,
+                    Name = d.Name,
+                    CarName = car?.CarName ?? "",
+                    ClassType = car?.ClassType ?? "",
+                    State = d.State ?? "",
+                    DefaultDialIn = car?.DefaultDialIn
+                });
+            }
+        }
+
+        private void RefreshRoster()
+        {
+            Roster.Clear();
+            foreach (var r in _allRows
+                         .Where(r => string.IsNullOrWhiteSpace(_search) ||
+                                     (r.Name ?? "").IndexOf(_search, StringComparison.OrdinalIgnoreCase) >= 0)
+                         .OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase))
+                Roster.Add(r);
+        }
+
+        public void QuickAddDriver(string name, Car car)
+        {
+            _service.QuickAddDriver(name, car);
+            // Preserve current checked/override state by reloading then re-applying.
+            var checkedIds = new HashSet<int>(_allRows.Where(r => r.IsChecked).Select(r => r.DriverId));
+            var overrides = _allRows.Where(r => !string.IsNullOrWhiteSpace(r.OverrideText))
+                                    .ToDictionary(r => r.DriverId, r => r.OverrideText);
+            LoadRoster();
+            foreach (var r in _allRows)
+            {
+                if (checkedIds.Contains(r.DriverId)) r.IsChecked = true;
+                if (overrides.TryGetValue(r.DriverId, out var ov)) r.OverrideText = ov;
+            }
+            RefreshRoster();
+        }
+
+        // ── Apply existing (edit mode) ────────────────────────────────────────
+
+        private void ApplyExisting(ClassConfigDto c)
+        {
+            ClassName = c.ClassName ?? "";
+            SelectedRaceType = string.IsNullOrEmpty(c.RaceType) ? RoundRobin : c.RaceType;
+
+            if (string.Equals(c.ClassType, "Bracket Class", StringComparison.OrdinalIgnoreCase))
+            {
+                _isHeadsUp = false; _isBracket = true; _isDialIn = false;
+                if (c.FixedDialIn.HasValue) FixedDialInText = c.FixedDialIn.Value.ToString("0.000");
+            }
+            else if (string.Equals(c.ClassType, "Dial-In", StringComparison.OrdinalIgnoreCase))
+            {
+                _isHeadsUp = false; _isBracket = false; _isDialIn = true;
+            }
+            else
+            {
+                _isHeadsUp = true; _isBracket = false; _isDialIn = false;
+            }
+            OnPropertyChanged(nameof(IsHeadsUp));
+            OnPropertyChanged(nameof(IsBracket));
+            OnPropertyChanged(nameof(IsDialIn));
+            OnClassTypeChanged();
+
+            BuybackEnabled = !string.Equals(c.Variant, "QMDRA", StringComparison.OrdinalIgnoreCase);
+            if (c.RoundsToRun.HasValue) RoundsToRun = c.RoundsToRun.Value;
+
+            bool wasDialIn = string.Equals(c.ClassType, "Dial-In", StringComparison.OrdinalIgnoreCase);
+            foreach (var entry in c.DriverEntries ?? new List<RaceSessionDriverEntry>())
+            {
+                var row = _allRows.FirstOrDefault(r => r.DriverId == entry.DriverID);
+                if (row == null) continue;
+                row.IsChecked = true;
+                if (wasDialIn && entry.DialIn.HasValue)
+                    row.OverrideText = entry.DialIn.Value.ToString("0.000");
+            }
+        }
+
+        // ── Build result ──────────────────────────────────────────────────────
+
+        /// <summary>Validates and produces the configured class, or returns null with an error message.</summary>
+        public ClassConfigDto BuildResult(out string error)
+        {
+            error = null;
+
+            if (string.IsNullOrWhiteSpace(ClassName))
+            {
+                error = "Please enter a class name.";
+                return null;
+            }
+
+            string classType = _isBracket ? "Bracket Class" : _isDialIn ? "Dial-In" : "Heads Up";
+
+            double? fixedDialIn = null;
+            if (_isBracket && double.TryParse(FixedDialInText.Trim(), out var fd))
+                fixedDialIn = fd;
+
+            string variant = null;
+            int? rounds = null;
+            if (IsRoundRobinSelected)
+            {
+                variant = BuybackEnabled ? "Standard" : "QMDRA";
+                if (RoundsToRun <= 0)
+                {
+                    error = "Rounds must be at least 1.";
+                    return null;
+                }
+                rounds = RoundsToRun;
+            }
+
+            var checkedIds = _allRows.Where(r => r.IsChecked).Select(r => r.DriverId).ToList();
+
+            var overrides = new Dictionary<int, double?>();
+            if (_isDialIn)
+                foreach (var r in _allRows.Where(r => r.IsChecked && !string.IsNullOrWhiteSpace(r.OverrideText)))
+                    if (double.TryParse(r.OverrideText.Trim(), out var ov))
+                        overrides[r.DriverId] = ov;
+
+            var allDrivers = _service.GetAllDrivers();
+            var entries = _service.BuildDriverEntries(
+                checkedIds, allDrivers, classType, fixedDialIn, overrides, ClassName.Trim());
+
+            return new ClassConfigDto
+            {
+                ClassName = ClassName.Trim(),
+                RaceType = SelectedRaceType,
+                ClassType = classType,
+                FixedDialIn = fixedDialIn,
+                Variant = variant,
+                RoundsToRun = rounds,
+                DriverEntries = entries
+            };
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string n = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+    }
+}

--- a/src/RCDragManagerProd.WPF/ViewModels/DriverRosterRow.cs
+++ b/src/RCDragManagerProd.WPF/ViewModels/DriverRosterRow.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace RCDragManagerProd.WPF.ViewModels
+{
+    /// <summary>
+    /// One selectable driver row in the class-config roster. Tracks inclusion
+    /// (<see cref="IsChecked"/>) and an optional per-driver dial-in override
+    /// (<see cref="OverrideText"/>, only meaningful for Dial-In classes).
+    /// </summary>
+    public sealed class DriverRosterRow : INotifyPropertyChanged
+    {
+        public int DriverId { get; set; }
+        public string Name { get; set; }
+        public string CarName { get; set; }
+        public string ClassType { get; set; }
+        public string State { get; set; }
+        public double? DefaultDialIn { get; set; }
+
+        public string DefaultDialInText =>
+            DefaultDialIn.HasValue ? DefaultDialIn.Value.ToString("0.000") : "";
+
+        private bool _isChecked;
+        public bool IsChecked
+        {
+            get => _isChecked;
+            set { _isChecked = value; OnPropertyChanged(); }
+        }
+
+        private string _overrideText = "";
+        public string OverrideText
+        {
+            get => _overrideText;
+            set { _overrideText = value ?? ""; OnPropertyChanged(); }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string n = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+    }
+}

--- a/src/RCDragManagerProd.WPF/ViewModels/SetupViewModel.cs
+++ b/src/RCDragManagerProd.WPF/ViewModels/SetupViewModel.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+
+namespace RCDragManagerProd.WPF.ViewModels
+{
+    /// <summary>
+    /// Backs <c>SetupWindow</c>: event name + date and the list of configured
+    /// classes. Wraps <see cref="MultiClassSetupService"/> for validation and
+    /// event construction.
+    /// </summary>
+    public sealed class SetupViewModel : INotifyPropertyChanged
+    {
+        private readonly MultiClassSetupService _service;
+        private readonly MultiClassEventRepository _eventRepo;
+
+        public ObservableCollection<ClassRow> Classes { get; } = new ObservableCollection<ClassRow>();
+
+        /// <summary>The underlying configured classes, parallel to <see cref="Classes"/>.</summary>
+        private readonly List<ClassConfigDto> _configs = new List<ClassConfigDto>();
+
+        public MultiClassSetupService Service => _service;
+
+        public SetupViewModel(MultiClassSetupService service, MultiClassEventRepository eventRepo)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+            _eventRepo = eventRepo ?? throw new ArgumentNullException(nameof(eventRepo));
+        }
+
+        private string _eventName = "";
+        public string EventName
+        {
+            get => _eventName;
+            set { _eventName = value; OnPropertyChanged(); }
+        }
+
+        private DateTime _eventDate = DateTime.Today;
+        public DateTime EventDate
+        {
+            get => _eventDate;
+            set { _eventDate = value; OnPropertyChanged(); }
+        }
+
+        private ClassRow _selectedClass;
+        public ClassRow SelectedClass
+        {
+            get => _selectedClass;
+            set { _selectedClass = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasSelection)); }
+        }
+
+        public bool HasSelection => _selectedClass != null;
+
+        // ── Class list management ─────────────────────────────────────────────
+
+        /// <summary>Adds a configured class. Returns an error string if the name clashes, else null.</summary>
+        public string AddClass(ClassConfigDto config)
+        {
+            var existing = _configs.Select(c => c.ClassName);
+            string error = _service.ValidateClassName(config.ClassName, existing);
+            if (error != null) return error;
+
+            _configs.Add(config);
+            Classes.Add(ToRow(config));
+            return null;
+        }
+
+        public ClassConfigDto GetConfig(int index) =>
+            index >= 0 && index < _configs.Count ? _configs[index] : null;
+
+        public void ReplaceClass(int index, ClassConfigDto config)
+        {
+            if (index < 0 || index >= _configs.Count) return;
+            _configs[index] = config;
+            Classes[index] = ToRow(config);
+        }
+
+        public void RemoveClass(int index)
+        {
+            if (index < 0 || index >= _configs.Count) return;
+            _configs.RemoveAt(index);
+            Classes.RemoveAt(index);
+        }
+
+        public int IndexOf(ClassRow row) => Classes.IndexOf(row);
+
+        // ── Start ─────────────────────────────────────────────────────────────
+
+        public string ValidateCanStart() => _service.ValidateCanStart(_configs);
+
+        /// <summary>Builds, persists, and returns the new event.</summary>
+        public MultiClassEvent StartEvent()
+        {
+            var evt = _service.StartEvent(EventName?.Trim() ?? "", EventDate.Date, _configs);
+            _eventRepo.SaveEvent(evt);
+            return evt;
+        }
+
+        private static ClassRow ToRow(ClassConfigDto c) => new ClassRow
+        {
+            ClassName = c.ClassName,
+            RaceType = c.RaceType ?? "",
+            ClassType = c.ClassType ?? "",
+            Rounds = c.RoundsToRun.HasValue ? c.RoundsToRun.Value.ToString() : "—",
+            DriverCount = c.DriverEntries?.Count ?? 0
+        };
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string n = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+    }
+
+    public sealed class ClassRow
+    {
+        public string ClassName { get; set; }
+        public string RaceType { get; set; }
+        public string ClassType { get; set; }
+        public string Rounds { get; set; }
+        public int DriverCount { get; set; }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
@@ -43,9 +43,16 @@ namespace RCDragManagerProd.WPF.Windows
 
         private void BtnStartNewEvent_Click(object sender, RoutedEventArgs e)
         {
-            // TODO: open setup dialog when it is ported
-            MessageBox.Show("New event setup — coming soon.", "RC Drag Manager",
-                MessageBoxButton.OK, MessageBoxImage.Information);
+            var setup = new SetupWindow(_connectionString) { Owner = this };
+            if (setup.ShowDialog() == true)
+            {
+                // Race console not ported yet — confirm creation and refresh the list.
+                MessageBox.Show(
+                    $"Event '{setup.CreatedEvent.EventName}' created and saved.\n\n" +
+                    "The race console is coming in a later screen.",
+                    "RC Drag Manager", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            _vm.Load();
         }
 
         private void BtnLoadSaved_Click(object sender, RoutedEventArgs e)

--- a/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml
@@ -1,0 +1,187 @@
+<Window x:Class="RCDragManagerProd.WPF.Windows.SetupWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="New Event — RC Drag Manager"
+        Width="780" Height="600"
+        MinWidth="640" MinHeight="460"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="CanResizeWithGrip"
+        Background="{StaticResource Brush.Background}"
+        FontFamily="Segoe UI">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="38" CornerRadius="0"
+                      GlassFrameThickness="0" ResizeBorderThickness="5"
+                      UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Background}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="38"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title bar -->
+            <Grid Grid.Row="0" Background="{StaticResource Brush.Chrome}">
+                <TextBlock Text="New event"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           FontSize="12" Foreground="{StaticResource Brush.TextHint}"
+                           FontWeight="Medium"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                            VerticalAlignment="Center" Margin="0,0,14,0">
+                    <Button Style="{StaticResource Style.WinCtrl.Close}" Click="BtnClose_Click"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Event header: name + date -->
+            <Border Grid.Row="1"
+                    Background="{StaticResource Brush.Surface}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,0,0,1"
+                    Padding="24,18">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="20"/>
+                        <ColumnDefinition Width="180"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0">
+                        <TextBlock Text="Event name"
+                                   FontSize="{StaticResource FontSize.Xs}"
+                                   Foreground="{StaticResource Brush.TextMuted}"
+                                   Margin="0,0,0,5"/>
+                        <TextBox x:Name="TxtEventName"
+                                 Style="{StaticResource Style.TextBox}"
+                                 Text="{Binding EventName, UpdateSourceTrigger=PropertyChanged}"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="2">
+                        <TextBlock Text="Date"
+                                   FontSize="{StaticResource FontSize.Xs}"
+                                   Foreground="{StaticResource Brush.TextMuted}"
+                                   Margin="0,0,0,5"/>
+                        <DatePicker Style="{StaticResource Style.DatePicker}"
+                                    SelectedDate="{Binding EventDate}"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- Classes -->
+            <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" Padding="24,12"
+                        BorderBrush="{StaticResource Brush.BorderSubtle}"
+                        BorderThickness="0,0,0,1">
+                    <Grid>
+                        <TextBlock Text="Classes"
+                                   FontSize="{StaticResource FontSize.Xs}"
+                                   FontWeight="Medium"
+                                   Foreground="{StaticResource Brush.TextHint}"
+                                   VerticalAlignment="Center"/>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Button Style="{StaticResource Style.Button.Toolbar}"
+                                    Content="Add class" Click="BtnAddClass_Click" Margin="0,0,6,0"/>
+                            <Button Style="{StaticResource Style.Button.Toolbar}"
+                                    Content="Edit" Click="BtnEditClass_Click" Margin="0,0,6,0"
+                                    IsEnabled="{Binding HasSelection}"/>
+                            <Button Style="{StaticResource Style.Button.Toolbar.Danger}"
+                                    Content="Remove" Click="BtnRemoveClass_Click"
+                                    IsEnabled="{Binding HasSelection}"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <DataGrid Grid.Row="1"
+                          x:Name="DgClasses"
+                          ItemsSource="{Binding Classes}"
+                          SelectedItem="{Binding SelectedClass}"
+                          AutoGenerateColumns="False"
+                          CanUserAddRows="False" CanUserDeleteRows="False"
+                          CanUserReorderColumns="False" CanUserResizeRows="False"
+                          IsReadOnly="True" SelectionMode="Single"
+                          GridLinesVisibility="Horizontal"
+                          HorizontalGridLinesBrush="{StaticResource Brush.BorderSubtle}"
+                          Background="{StaticResource Brush.Background}"
+                          RowBackground="{StaticResource Brush.Background}"
+                          AlternatingRowBackground="{StaticResource Brush.Surface}"
+                          Foreground="{StaticResource Brush.TextPrimary}"
+                          FontSize="{StaticResource FontSize.Sm}"
+                          BorderThickness="0" RowHeight="36"
+                          MouseDoubleClick="DgClasses_DoubleClick">
+                    <DataGrid.ColumnHeaderStyle>
+                        <Style TargetType="DataGridColumnHeader">
+                            <Setter Property="Background" Value="{StaticResource Brush.Chrome}"/>
+                            <Setter Property="Foreground" Value="{StaticResource Brush.TextHint}"/>
+                            <Setter Property="FontSize" Value="{StaticResource FontSize.Xs}"/>
+                            <Setter Property="FontWeight" Value="Medium"/>
+                            <Setter Property="Padding" Value="16,0"/>
+                            <Setter Property="Height" Value="30"/>
+                            <Setter Property="BorderBrush" Value="{StaticResource Brush.BorderSubtle}"/>
+                            <Setter Property="BorderThickness" Value="0,0,1,1"/>
+                            <Setter Property="SeparatorBrush" Value="{StaticResource Brush.BorderSubtle}"/>
+                        </Style>
+                    </DataGrid.ColumnHeaderStyle>
+                    <DataGrid.CellStyle>
+                        <Style TargetType="DataGridCell">
+                            <Setter Property="Padding" Value="16,0"/>
+                            <Setter Property="BorderThickness" Value="0"/>
+                            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="DataGridCell">
+                                        <Border Background="{TemplateBinding Background}"
+                                                Padding="{TemplateBinding Padding}">
+                                            <ContentPresenter VerticalAlignment="Center"/>
+                                        </Border>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                            <Style.Triggers>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter Property="Background" Value="{StaticResource Brush.Primary}"/>
+                                    <Setter Property="Foreground" Value="White"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </DataGrid.CellStyle>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Class"      Binding="{Binding ClassName}"   Width="*"/>
+                        <DataGridTextColumn Header="Race type"  Binding="{Binding RaceType}"    Width="130"/>
+                        <DataGridTextColumn Header="Class type" Binding="{Binding ClassType}"   Width="120"/>
+                        <DataGridTextColumn Header="Rounds"     Binding="{Binding Rounds}"      Width="70"/>
+                        <DataGridTextColumn Header="Drivers"    Binding="{Binding DriverCount}" Width="70"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+
+            <!-- Footer: cancel / start -->
+            <Border Grid.Row="3"
+                    Background="{StaticResource Brush.Chrome}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,1,0,0"
+                    Padding="24,14">
+                <Grid>
+                    <TextBlock Text="Add at least one class with drivers to start."
+                               FontSize="{StaticResource FontSize.Xs}"
+                               Foreground="{StaticResource Brush.TextHint}"
+                               VerticalAlignment="Center"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                                Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                                Content="Start event" Click="BtnStart_Click"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml
@@ -108,6 +108,7 @@
                           CanUserAddRows="False" CanUserDeleteRows="False"
                           CanUserReorderColumns="False" CanUserResizeRows="False"
                           IsReadOnly="True" SelectionMode="Single"
+                          HeadersVisibility="Column"
                           GridLinesVisibility="Horizontal"
                           HorizontalGridLinesBrush="{StaticResource Brush.BorderSubtle}"
                           Background="{StaticResource Brush.Background}"

--- a/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml.cs
@@ -1,0 +1,82 @@
+using System.Windows;
+using System.Windows.Input;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+using RCDragManagerProd.WPF.Dialogs;
+using RCDragManagerProd.WPF.ViewModels;
+
+namespace RCDragManagerProd.WPF.Windows
+{
+    public partial class SetupWindow : Window
+    {
+        private readonly SetupViewModel _vm;
+
+        /// <summary>The created event, available to the caller after a successful Start.</summary>
+        public MultiClassEvent CreatedEvent { get; private set; }
+
+        public SetupWindow(string connectionString)
+        {
+            InitializeComponent();
+            var service = new MultiClassSetupService(new DriverRepository(connectionString));
+            var eventRepo = new MultiClassEventRepository(connectionString);
+            _vm = new SetupViewModel(service, eventRepo);
+            DataContext = _vm;
+        }
+
+        private void BtnClose_Click(object sender, RoutedEventArgs e) => Close();
+        private void BtnCancel_Click(object sender, RoutedEventArgs e) => Close();
+
+        // ── Class list ───────────────────────────────────────────────────────
+
+        private void BtnAddClass_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new ClassConfigDialog(_vm.Service) { Owner = this };
+            if (dlg.ShowDialog() != true) return;
+
+            var error = _vm.AddClass(dlg.Result);
+            if (error != null)
+                MessageBox.Show(error, "Duplicate class", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+
+        private void BtnEditClass_Click(object sender, RoutedEventArgs e)
+        {
+            int idx = _vm.IndexOf(_vm.SelectedClass);
+            var existing = _vm.GetConfig(idx);
+            if (existing == null) return;
+
+            var dlg = new ClassConfigDialog(_vm.Service, existing) { Owner = this };
+            if (dlg.ShowDialog() != true) return;
+
+            _vm.ReplaceClass(idx, dlg.Result);
+        }
+
+        private void BtnRemoveClass_Click(object sender, RoutedEventArgs e)
+        {
+            int idx = _vm.IndexOf(_vm.SelectedClass);
+            if (idx < 0) return;
+            _vm.RemoveClass(idx);
+        }
+
+        private void DgClasses_DoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (_vm.SelectedClass != null)
+                BtnEditClass_Click(sender, e);
+        }
+
+        // ── Start ────────────────────────────────────────────────────────────
+
+        private void BtnStart_Click(object sender, RoutedEventArgs e)
+        {
+            var error = _vm.ValidateCanStart();
+            if (error != null)
+            {
+                MessageBox.Show(error, "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            CreatedEvent = _vm.StartEvent();
+            DialogResult = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Screen #2 of the WPF rebuild — the "Start new event" flow.

### SetupWindow
- Event name + date picker
- Classes DataGrid with Add / Edit / Remove (double-click a row to edit)
- "Start event" builds and **persists** the `MultiClassEvent` via `MultiClassEventRepository`, so the new event immediately shows up in the landing page's Recent events list

### ClassConfigDialog (per class)
- Class name
- Race-type **cards**: Pro Ladder / Random Draw / Round Robin (selected card gets an orange border)
- Class-type radios: Heads Up / Bracket Class / Dial-In — fixed dial-in field appears for Bracket
- Round-Robin options (shown only for RR): buyback toggle + rounds
- Driver **roster** DataGrid: include checkbox, live search, default dial-in, per-driver override column, and an inline "Add new driver"

### Supporting
- `QuickAddDriverDialog` — borderless dark dialog (driver + car in one)
- `SetupViewModel`, `ClassConfigViewModel`, `DriverRosterRow` wrap `MultiClassSetupService`
- New shared styles: dark `CheckBox`, `RadioButton`, race-type card, `DatePicker`
- Landing "Start new event" button is now live

> Note: the race **console** isn't ported yet (screen #4), so after Start the event is saved and a confirmation is shown. Chaining into the console will come with that screen.

## Test plan

- [ ] Landing → Start new event → window opens dark-themed
- [ ] Enter name + date
- [ ] Add class → config dialog opens; pick race type (card highlights), class type, drivers
- [ ] Round Robin selected → buyback + rounds appear; other types hide them
- [ ] Bracket Class selected → fixed dial-in field appears
- [ ] Search filters the roster; checking drivers persists across searches
- [ ] Dial-In class → override column accepts per-driver values
- [ ] Add new driver inline → appears in roster
- [ ] Add class → row appears in setup grid; Edit reopens with values; Remove deletes
- [ ] Duplicate class name → rejected
- [ ] Start with no classes / empty class → validation warning
- [ ] Start valid event → confirmation, and it appears in Recent events on the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)