### PR TITLE
feat(wpf): Load Saved Event window (#3 of 8)

### DIFF
--- a/src/RCDragManagerProd.WPF/ViewModels/LoadEventRow.cs
+++ b/src/RCDragManagerProd.WPF/ViewModels/LoadEventRow.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace RCDragManagerProd.WPF.ViewModels
+{
+    /// <summary>One saved session/event row in the Load window's list.</summary>
+    public sealed class LoadEventRow
+    {
+        public int Id { get; set; }
+        public bool IsMultiClass { get; set; }
+        public string EventName { get; set; }
+        public string Kind { get; set; }       // "Single class" / "Multi-class"
+        public string Detail { get; set; }     // race/class type, or class count
+        public DateTime EventDate { get; set; }
+
+        public string DateText =>
+            EventDate == DateTime.MinValue ? "Unknown date" : EventDate.ToString("ddd d MMM yyyy");
+    }
+}

--- a/src/RCDragManagerProd.WPF/ViewModels/LoadSessionViewModel.cs
+++ b/src/RCDragManagerProd.WPF/ViewModels/LoadSessionViewModel.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using RCDragManagerProd.AppServices;
+
+namespace RCDragManagerProd.WPF.ViewModels
+{
+    /// <summary>
+    /// Backs <c>LoadSessionWindow</c>: lists all saved single-class sessions and
+    /// multi-class events in one browsable list, with load + delete.
+    /// </summary>
+    public sealed class LoadSessionViewModel : INotifyPropertyChanged
+    {
+        private readonly LoadSessionService _service;
+
+        public ObservableCollection<LoadEventRow> Events { get; } = new ObservableCollection<LoadEventRow>();
+
+        private LoadEventRow _selected;
+        public LoadEventRow Selected
+        {
+            get => _selected;
+            set { _selected = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasSelection)); }
+        }
+
+        public bool HasSelection => _selected != null;
+
+        public Visibility EmptyVisibility =>
+            Events.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+
+        public LoadSessionViewModel(LoadSessionService service)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+        }
+
+        public void Load()
+        {
+            var rows = new List<LoadEventRow>();
+
+            foreach (var e in _service.ListMultiClassEvents())
+            {
+                rows.Add(new LoadEventRow
+                {
+                    Id = e.Id,
+                    IsMultiClass = true,
+                    EventName = string.IsNullOrWhiteSpace(e.EventName) ? "Multi-class event" : e.EventName,
+                    Kind = "Multi-class",
+                    Detail = $"{e.ClassCount} class{(e.ClassCount == 1 ? "" : "es")}",
+                    EventDate = e.EventDate
+                });
+            }
+
+            foreach (var s in _service.ListSessions())
+            {
+                rows.Add(new LoadEventRow
+                {
+                    Id = s.Id,
+                    IsMultiClass = false,
+                    EventName = string.IsNullOrWhiteSpace(s.EventName) ? "Untitled session" : s.EventName,
+                    Kind = "Single class",
+                    Detail = BuildDetail(s.RaceType, s.ClassType),
+                    EventDate = s.EventDate
+                });
+            }
+
+            Events.Clear();
+            foreach (var r in rows.OrderByDescending(r => r.EventDate))
+                Events.Add(r);
+
+            Selected = null;
+            OnPropertyChanged(nameof(EmptyVisibility));
+        }
+
+        public LoadResult LoadSelected()
+        {
+            if (_selected == null) return LoadResult.Fail("No event selected.");
+            return _selected.IsMultiClass
+                ? _service.LoadMultiClassEvent(_selected.Id)
+                : _service.LoadSingleClassSession(_selected.Id);
+        }
+
+        public void DeleteSelected()
+        {
+            if (_selected == null) return;
+            if (_selected.IsMultiClass) _service.DeleteMultiClassEvent(_selected.Id);
+            else _service.DeleteSession(_selected.Id);
+            Load();
+        }
+
+        private static string BuildDetail(string raceType, string classType)
+        {
+            var parts = new[] { raceType, classType }.Where(p => !string.IsNullOrWhiteSpace(p));
+            return string.Join(" · ", parts);
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string n = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+    }
+}

--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
@@ -57,9 +57,16 @@ namespace RCDragManagerProd.WPF.Windows
 
         private void BtnLoadSaved_Click(object sender, RoutedEventArgs e)
         {
-            // TODO: open load-session dialog when it is ported
-            MessageBox.Show("Load saved event — coming soon.", "RC Drag Manager",
-                MessageBoxButton.OK, MessageBoxImage.Information);
+            var load = new LoadSessionWindow(_connectionString) { Owner = this };
+            if (load.ShowDialog() == true && load.ResumedEvent != null)
+            {
+                // Race console not ported yet — confirm the load resolved.
+                MessageBox.Show(
+                    $"Loaded '{load.ResumedEvent.EventName}'.\n\n" +
+                    "The race console is coming in a later screen.",
+                    "RC Drag Manager", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            _vm.Load();
         }
 
         private void EventCard_Click(object sender, RoutedEventArgs e)

--- a/src/RCDragManagerProd.WPF/Windows/LoadSessionWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/LoadSessionWindow.xaml
@@ -1,0 +1,151 @@
+<Window x:Class="RCDragManagerProd.WPF.Windows.LoadSessionWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Load Event — RC Drag Manager"
+        Width="760" Height="560"
+        MinWidth="620" MinHeight="420"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="CanResizeWithGrip"
+        Background="{StaticResource Brush.Background}"
+        FontFamily="Segoe UI">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="38" CornerRadius="0"
+                      GlassFrameThickness="0" ResizeBorderThickness="5"
+                      UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Background}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="38"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title bar -->
+            <Grid Grid.Row="0" Background="{StaticResource Brush.Chrome}">
+                <TextBlock Text="Load event"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           FontSize="12" Foreground="{StaticResource Brush.TextHint}"
+                           FontWeight="Medium"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                            VerticalAlignment="Center" Margin="0,0,14,0">
+                    <Button Style="{StaticResource Style.WinCtrl.Close}" Click="BtnClose_Click"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Header -->
+            <Border Grid.Row="1"
+                    Background="{StaticResource Brush.Surface}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,0,0,1"
+                    Padding="24,16">
+                <StackPanel>
+                    <TextBlock Text="Saved events"
+                               FontSize="{StaticResource FontSize.Xl}"
+                               FontWeight="Medium"
+                               Foreground="{StaticResource Brush.TextPrimary}"/>
+                    <TextBlock Text="Select an event to resume or delete"
+                               FontSize="{StaticResource FontSize.Xs}"
+                               Foreground="{StaticResource Brush.TextMuted}"
+                               Margin="0,2,0,0"/>
+                </StackPanel>
+            </Border>
+
+            <!-- List -->
+            <Grid Grid.Row="2">
+                <DataGrid x:Name="DgEvents"
+                          ItemsSource="{Binding Events}"
+                          SelectedItem="{Binding Selected}"
+                          AutoGenerateColumns="False"
+                          CanUserAddRows="False" CanUserDeleteRows="False"
+                          CanUserReorderColumns="False" CanUserResizeRows="False"
+                          IsReadOnly="True" SelectionMode="Single"
+                          HeadersVisibility="Column"
+                          GridLinesVisibility="Horizontal"
+                          HorizontalGridLinesBrush="{StaticResource Brush.BorderSubtle}"
+                          Background="{StaticResource Brush.Background}"
+                          RowBackground="{StaticResource Brush.Background}"
+                          AlternatingRowBackground="{StaticResource Brush.Surface}"
+                          Foreground="{StaticResource Brush.TextPrimary}"
+                          FontSize="{StaticResource FontSize.Sm}"
+                          BorderThickness="0" RowHeight="40"
+                          MouseDoubleClick="DgEvents_DoubleClick">
+                    <DataGrid.ColumnHeaderStyle>
+                        <Style TargetType="DataGridColumnHeader">
+                            <Setter Property="Background" Value="{StaticResource Brush.Chrome}"/>
+                            <Setter Property="Foreground" Value="{StaticResource Brush.TextHint}"/>
+                            <Setter Property="FontSize" Value="{StaticResource FontSize.Xs}"/>
+                            <Setter Property="FontWeight" Value="Medium"/>
+                            <Setter Property="Padding" Value="16,0"/>
+                            <Setter Property="Height" Value="30"/>
+                            <Setter Property="BorderBrush" Value="{StaticResource Brush.BorderSubtle}"/>
+                            <Setter Property="BorderThickness" Value="0,0,1,1"/>
+                            <Setter Property="SeparatorBrush" Value="{StaticResource Brush.BorderSubtle}"/>
+                        </Style>
+                    </DataGrid.ColumnHeaderStyle>
+                    <DataGrid.CellStyle>
+                        <Style TargetType="DataGridCell">
+                            <Setter Property="Padding" Value="16,0"/>
+                            <Setter Property="BorderThickness" Value="0"/>
+                            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="DataGridCell">
+                                        <Border Background="{TemplateBinding Background}"
+                                                Padding="{TemplateBinding Padding}">
+                                            <ContentPresenter VerticalAlignment="Center"/>
+                                        </Border>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                            <Style.Triggers>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter Property="Background" Value="{StaticResource Brush.Primary}"/>
+                                    <Setter Property="Foreground" Value="White"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </DataGrid.CellStyle>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Event"  Binding="{Binding EventName}" Width="*"/>
+                        <DataGridTextColumn Header="Date"   Binding="{Binding DateText}"  Width="150"/>
+                        <DataGridTextColumn Header="Type"   Binding="{Binding Kind}"      Width="110"/>
+                        <DataGridTextColumn Header="Detail" Binding="{Binding Detail}"    Width="150"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <!-- Empty state -->
+                <TextBlock Text="No saved events yet."
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           FontSize="{StaticResource FontSize.Md}"
+                           Foreground="{StaticResource Brush.TextHint}"
+                           Visibility="{Binding EmptyVisibility}"/>
+            </Grid>
+
+            <!-- Footer -->
+            <Border Grid.Row="3"
+                    Background="{StaticResource Brush.Chrome}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,1,0,0"
+                    Padding="24,14">
+                <Grid>
+                    <Button HorizontalAlignment="Left"
+                            Style="{StaticResource Style.Button.Toolbar.Danger}"
+                            Content="Delete" Click="BtnDelete_Click"
+                            IsEnabled="{Binding HasSelection}"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                                Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                                Content="Load event" Click="BtnLoad_Click"
+                                IsEnabled="{Binding HasSelection}"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Windows/LoadSessionWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LoadSessionWindow.xaml.cs
@@ -1,0 +1,63 @@
+using System.Windows;
+using System.Windows.Input;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+using RCDragManagerProd.WPF.ViewModels;
+
+namespace RCDragManagerProd.WPF.Windows
+{
+    public partial class LoadSessionWindow : Window
+    {
+        private readonly LoadSessionViewModel _vm;
+
+        /// <summary>The event chosen to resume, valid after a successful load (DialogResult true).</summary>
+        public MultiClassEvent ResumedEvent { get; private set; }
+
+        public LoadSessionWindow(string connectionString)
+        {
+            InitializeComponent();
+            var service = new LoadSessionService(
+                new RaceSessionRepository(connectionString),
+                new MultiClassEventRepository(connectionString));
+            _vm = new LoadSessionViewModel(service);
+            DataContext = _vm;
+            _vm.Load();
+        }
+
+        private void BtnClose_Click(object sender, RoutedEventArgs e) => Close();
+        private void BtnCancel_Click(object sender, RoutedEventArgs e) => Close();
+
+        private void BtnLoad_Click(object sender, RoutedEventArgs e)
+        {
+            if (_vm.Selected == null) return;
+
+            var result = _vm.LoadSelected();
+            if (!result.Success)
+            {
+                MessageBox.Show(result.ErrorMessage, "Load error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            ResumedEvent = result.Event;
+            DialogResult = true;
+        }
+
+        private void BtnDelete_Click(object sender, RoutedEventArgs e)
+        {
+            if (_vm.Selected == null) return;
+            var confirm = MessageBox.Show(
+                $"Permanently delete '{_vm.Selected.EventName}'? This cannot be undone.",
+                "Delete event", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (confirm != MessageBoxResult.Yes) return;
+            _vm.DeleteSelected();
+        }
+
+        private void DgEvents_DoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (_vm.Selected != null)
+                BtnLoad_Click(sender, e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Third WPF screen — browse and resume saved events.

- **LoadSessionWindow** — one combined DataGrid listing all saved single-class sessions *and* multi-class events, newest first, with Event / Date / Type / Detail columns. Matches the design language of the landing page (which already unifies both).
- **Load** (button or double-click) resolves the selected event through `LoadSessionService` and exposes it as `ResumedEvent`; **Delete** removes it with a confirmation prompt.
- **Empty state** shown when nothing is saved.
- `LoadSessionViewModel` + `LoadEventRow` back the window.
- **Landing page** — the "Load saved event" button now opens this window. The race console isn't built yet, so a successful load shows a coming-soon confirmation (one-line change to wire the console in screen #4).

## Test plan

- [ ] Landing → Load saved event → window opens dark-themed
- [ ] All saved sessions + multi-class events listed, newest first
- [ ] Type column shows "Single class" / "Multi-class"; Detail shows race/class type or class count
- [ ] Select + Load (or double-click) → coming-soon confirmation with the event name
- [ ] Select + Delete → confirm prompt → row removed
- [ ] No saved events → empty-state message
- [ ] No white strips; dark scrollbar on overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)