### PR TITLE
feat(wpf): single-class Race Console (#4 of 8, stage 1)

### DIFF
--- a/src/RCDragManagerProd.WPF/Converters.cs
+++ b/src/RCDragManagerProd.WPF/Converters.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace RCDragManagerProd.WPF
+{
+    /// <summary>true → Visible, false → Collapsed.</summary>
+    public sealed class BoolToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+            (value is bool b && b) ? Visibility.Visible : Visibility.Collapsed;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+            value is Visibility v && v == Visibility.Visible;
+    }
+
+    /// <summary>true → Collapsed, false → Visible.</summary>
+    public sealed class InverseBoolToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+            (value is bool b && b) ? Visibility.Collapsed : Visibility.Visible;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+            value is Visibility v && v != Visibility.Visible;
+    }
+}

--- a/src/RCDragManagerProd.WPF/Dialogs/BuybackDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/BuybackDialog.xaml
@@ -1,0 +1,57 @@
+<Window x:Class="RCDragManagerProd.WPF.Dialogs.BuybackDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Buybacks"
+        Width="400" Height="460"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        KeyDown="Window_KeyDown"
+        Background="{StaticResource Brush.Surface}"
+        FontFamily="Segoe UI"
+        ShowInTaskbar="False">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="0" GlassFrameThickness="0"
+                      ResizeBorderThickness="0" UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Surface}"
+            BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
+        <Grid Margin="20,18">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Text="Select buyback drivers"
+                       FontSize="{StaticResource FontSize.Lg}" FontWeight="Medium"
+                       Foreground="{StaticResource Brush.TextPrimary}"/>
+            <TextBlock Grid.Row="1" Text="These drivers enter the Losers Bracket."
+                       FontSize="{StaticResource FontSize.Xs}"
+                       Foreground="{StaticResource Brush.TextMuted}" Margin="0,2,0,12"/>
+
+            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="IcDrivers">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Style="{StaticResource Style.CheckBox}"
+                                      Content="{Binding Name}"
+                                      IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                      Margin="0,5"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+
+            <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,14,0,0">
+                <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                        Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"/>
+                <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                        Content="Confirm" Click="BtnConfirm_Click"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Dialogs/BuybackDialog.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/BuybackDialog.xaml.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using RCDragManagerProd.Domain;
+
+namespace RCDragManagerProd.WPF.Dialogs
+{
+    public partial class BuybackDialog : Window
+    {
+        private readonly List<BuybackRow> _rows;
+
+        public List<Driver> SelectedDrivers { get; private set; } = new List<Driver>();
+
+        public BuybackDialog(IList<Driver> eligible)
+        {
+            InitializeComponent();
+            _rows = eligible.Select(d => new BuybackRow { Driver = d, Name = d.Name }).ToList();
+            IcDrivers.ItemsSource = _rows;
+        }
+
+        private void BtnConfirm_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedDrivers = _rows.Where(r => r.IsChecked).Select(r => r.Driver).ToList();
+            DialogResult = true;
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e) => DialogResult = false;
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape) DialogResult = false;
+        }
+
+        private sealed class BuybackRow : INotifyPropertyChanged
+        {
+            public Driver Driver { get; set; }
+            public string Name { get; set; }
+
+            private bool _isChecked;
+            public bool IsChecked
+            {
+                get => _isChecked;
+                set { _isChecked = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsChecked))); }
+            }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Dialogs/DialInDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/DialInDialog.xaml
@@ -1,0 +1,42 @@
+<Window x:Class="RCDragManagerProd.WPF.Dialogs.DialInDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Dial-in"
+        Width="340"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        KeyDown="Window_KeyDown"
+        Background="{StaticResource Brush.Surface}"
+        FontFamily="Segoe UI"
+        ShowInTaskbar="False">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="0" GlassFrameThickness="0"
+                      ResizeBorderThickness="0" UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Surface}"
+            BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
+        <StackPanel Margin="24,22">
+            <TextBlock x:Name="TitleText"
+                       FontSize="{StaticResource FontSize.Lg}" FontWeight="Medium"
+                       Foreground="{StaticResource Brush.TextPrimary}" Margin="0,0,0,18"/>
+
+            <StackPanel Margin="0,0,0,22">
+                <TextBlock Text="Dial-in (seconds) — leave blank to clear"
+                           FontSize="{StaticResource FontSize.Xs}"
+                           Foreground="{StaticResource Brush.TextMuted}" Margin="0,0,0,5"/>
+                <TextBox x:Name="TxtDialIn" Style="{StaticResource Style.TextBox}"/>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                        Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"/>
+                <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                        Content="Save" Click="BtnSave_Click"/>
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Dialogs/DialInDialog.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/DialInDialog.xaml.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace RCDragManagerProd.WPF.Dialogs
+{
+    public partial class DialInDialog : Window
+    {
+        public double DialIn { get; private set; }
+        public bool Cleared { get; private set; }
+
+        public DialInDialog(string driverName, double? current)
+        {
+            InitializeComponent();
+            TitleText.Text = $"Dial-in — {driverName}";
+            TxtDialIn.Text = current?.ToString("0.000") ?? "";
+            TxtDialIn.Focus();
+            TxtDialIn.SelectAll();
+        }
+
+        private void BtnSave_Click(object sender, RoutedEventArgs e)
+        {
+            var val = TxtDialIn.Text.Trim();
+            if (string.IsNullOrEmpty(val))
+            {
+                Cleared = true;
+                DialogResult = true;
+                return;
+            }
+            if (!double.TryParse(val, out var parsed) || parsed <= 0)
+            {
+                TxtDialIn.BorderBrush = FindResource("Brush.Danger") as System.Windows.Media.Brush;
+                return;
+            }
+            DialIn = parsed;
+            DialogResult = true;
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e) => DialogResult = false;
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape) DialogResult = false;
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Dialogs/EditResultDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/EditResultDialog.xaml
@@ -1,0 +1,39 @@
+<Window x:Class="RCDragManagerProd.WPF.Dialogs.EditResultDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Edit result"
+        Width="420"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        KeyDown="Window_KeyDown"
+        Background="{StaticResource Brush.Surface}"
+        FontFamily="Segoe UI"
+        ShowInTaskbar="False">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="0" GlassFrameThickness="0"
+                      ResizeBorderThickness="0" UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Surface}"
+            BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
+        <StackPanel Margin="24,22">
+            <TextBlock x:Name="TitleText"
+                       FontSize="{StaticResource FontSize.Lg}" FontWeight="Medium"
+                       Foreground="{StaticResource Brush.TextPrimary}" Margin="0,0,0,4"/>
+            <TextBlock Text="Choose the correct winner:"
+                       FontSize="{StaticResource FontSize.Xs}"
+                       Foreground="{StaticResource Brush.TextMuted}" Margin="0,0,0,16"/>
+
+            <Button x:Name="Btn1" Style="{StaticResource Style.Button.Winner}"
+                    Click="Btn1_Click" Margin="0,0,0,8" HorizontalAlignment="Stretch"/>
+            <Button x:Name="Btn2" Style="{StaticResource Style.Button.Winner}"
+                    Click="Btn2_Click" Margin="0,0,0,18" HorizontalAlignment="Stretch"/>
+
+            <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                    Content="Cancel" Click="BtnCancel_Click" HorizontalAlignment="Right"/>
+        </StackPanel>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Dialogs/EditResultDialog.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/EditResultDialog.xaml.cs
@@ -1,0 +1,32 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace RCDragManagerProd.WPF.Dialogs
+{
+    public partial class EditResultDialog : Window
+    {
+        /// <summary>0 = cancelled, 1 = Driver1 wins, 2 = Driver2 wins (engine option semantics).</summary>
+        public int Choice { get; private set; }
+
+        public EditResultDialog(int matchId, string roundLabel, string d1, string d2, bool bye1, bool bye2)
+        {
+            InitializeComponent();
+            TitleText.Text = $"Edit result — M{matchId} ({roundLabel})";
+            Btn1.Content = $"Set winner: {d1}";
+            Btn2.Content = $"Set winner: {d2}";
+            Btn1.IsEnabled = !bye1;
+            Btn2.IsEnabled = !bye2;
+        }
+
+        private void Btn1_Click(object sender, RoutedEventArgs e) { Choice = 1; DialogResult = true; }
+        private void Btn2_Click(object sender, RoutedEventArgs e) { Choice = 2; DialogResult = true; }
+        private void BtnCancel_Click(object sender, RoutedEventArgs e) { Choice = 0; DialogResult = false; }
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape) { Choice = 0; DialogResult = false; }
+            else if ((e.Key == Key.D1 || e.Key == Key.NumPad1) && Btn1.IsEnabled) { Choice = 1; DialogResult = true; }
+            else if ((e.Key == Key.D2 || e.Key == Key.NumPad2) && Btn2.IsEnabled) { Choice = 2; DialogResult = true; }
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Dialogs/EditResultPickWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/EditResultPickWindow.xaml
@@ -1,0 +1,82 @@
+<Window x:Class="RCDragManagerProd.WPF.Dialogs.EditResultPickWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Pick result"
+        Width="420" Height="440"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        KeyDown="Window_KeyDown"
+        Background="{StaticResource Brush.Surface}"
+        FontFamily="Segoe UI"
+        ShowInTaskbar="False">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="0" GlassFrameThickness="0"
+                      ResizeBorderThickness="0" UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Surface}"
+            BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
+        <Grid Margin="20,18">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Text="Select the match result to change"
+                       FontSize="{StaticResource FontSize.Lg}" FontWeight="Medium"
+                       Foreground="{StaticResource Brush.TextPrimary}" Margin="0,0,0,12"/>
+
+            <DataGrid Grid.Row="1" x:Name="Dg"
+                      AutoGenerateColumns="False" CanUserAddRows="False"
+                      CanUserDeleteRows="False" CanUserReorderColumns="False"
+                      CanUserResizeRows="False" IsReadOnly="True" SelectionMode="Single"
+                      HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                      HorizontalGridLinesBrush="{StaticResource Brush.BorderSubtle}"
+                      Background="{StaticResource Brush.Background}"
+                      RowBackground="{StaticResource Brush.Background}"
+                      AlternatingRowBackground="{StaticResource Brush.Chrome}"
+                      Foreground="{StaticResource Brush.TextPrimary}"
+                      FontSize="{StaticResource FontSize.Sm}"
+                      BorderThickness="0" RowHeight="32"
+                      MouseDoubleClick="Dg_DoubleClick">
+                <DataGrid.CellStyle>
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="Padding" Value="10,0"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="DataGridCell">
+                                    <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                                        <ContentPresenter VerticalAlignment="Center"/>
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                        <Style.Triggers>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter Property="Background" Value="{StaticResource Brush.Primary}"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </DataGrid.CellStyle>
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="M#"     Binding="{Binding MatchLabel}" Width="50"/>
+                    <DataGridTextColumn Header="Winner" Binding="{Binding Winner}"     Width="*"/>
+                    <DataGridTextColumn Header="Loser"  Binding="{Binding Loser}"      Width="*"/>
+                </DataGrid.Columns>
+            </DataGrid>
+
+            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,14,0,0">
+                <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                        Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"/>
+                <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                        Content="Edit" Click="BtnEdit_Click"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Dialogs/EditResultPickWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/EditResultPickWindow.xaml.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+using RCDragManagerProd.WPF.ViewModels;
+
+namespace RCDragManagerProd.WPF.Dialogs
+{
+    public partial class EditResultPickWindow : Window
+    {
+        public int SelectedMatchId { get; private set; }
+
+        public EditResultPickWindow(IList<WinnerDisplayRow> results)
+        {
+            InitializeComponent();
+            Dg.ItemsSource = results;
+        }
+
+        private void BtnEdit_Click(object sender, RoutedEventArgs e) => Confirm();
+        private void Dg_DoubleClick(object sender, MouseButtonEventArgs e) => Confirm();
+
+        private void Confirm()
+        {
+            if (Dg.SelectedItem is WinnerDisplayRow row && row.MatchId > 0)
+            {
+                SelectedMatchId = row.MatchId;
+                DialogResult = true;
+            }
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e) => DialogResult = false;
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape) DialogResult = false;
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Resources/Styles.xaml
+++ b/src/RCDragManagerProd.WPF/Resources/Styles.xaml
@@ -389,6 +389,47 @@
         <Setter Property="Foreground" Value="{StaticResource Brush.TextMuted}"/>
     </Style>
 
+    <!-- ── Winner button (big, race console) ──────────────────────────────── -->
+
+    <Style x:Key="Style.Button.Winner" TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource Brush.Raised}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource Brush.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+        <Setter Property="FontSize" Value="{StaticResource FontSize.Lg}"/>
+        <Setter Property="FontWeight" Value="Medium"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Padding" Value="14,12"/>
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{StaticResource Radius.Panel}"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource Brush.Primary}"/>
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource Brush.Primary}"/>
+                            <Setter Property="Foreground" Value="White"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource Brush.PrimaryPressed}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- ── CheckBox (dark) ────────────────────────────────────────────────── -->
 
     <Style x:Key="Style.CheckBox" TargetType="CheckBox">

--- a/src/RCDragManagerProd.WPF/ViewModels/ConsoleRows.cs
+++ b/src/RCDragManagerProd.WPF/ViewModels/ConsoleRows.cs
@@ -1,0 +1,34 @@
+namespace RCDragManagerProd.WPF.ViewModels
+{
+    /// <summary>A row in the pairings (bracket) list — either a round header or a match.</summary>
+    public sealed class PairingDisplayRow
+    {
+        public bool IsHeader { get; set; }
+        public string HeaderText { get; set; }
+        public string MatchLabel { get; set; }
+        public string Driver1 { get; set; }
+        public string Driver2 { get; set; }
+        public bool Bye1 { get; set; }
+        public bool Bye2 { get; set; }
+    }
+
+    /// <summary>A row in the winners (results) list — either a round header or a result.</summary>
+    public sealed class WinnerDisplayRow
+    {
+        public bool IsHeader { get; set; }
+        public string HeaderText { get; set; }
+        public string MatchLabel { get; set; }
+        public string Winner { get; set; }
+        public string Loser { get; set; }
+        public int MatchId { get; set; }
+    }
+
+    /// <summary>A row in the console driver list.</summary>
+    public sealed class ConsoleDriverRow
+    {
+        public int DriverId { get; set; }
+        public string Name { get; set; }
+        public string QualText { get; set; }
+        public string DialInText { get; set; }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Windows;
 using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Repositories;
@@ -44,15 +45,32 @@ namespace RCDragManagerProd.WPF.Windows
         private void BtnStartNewEvent_Click(object sender, RoutedEventArgs e)
         {
             var setup = new SetupWindow(_connectionString) { Owner = this };
-            if (setup.ShowDialog() == true)
+            if (setup.ShowDialog() == true && setup.CreatedEvent != null)
             {
-                // Race console not ported yet — confirm creation and refresh the list.
-                MessageBox.Show(
-                    $"Event '{setup.CreatedEvent.EventName}' created and saved.\n\n" +
-                    "The race console is coming in a later screen.",
-                    "RC Drag Manager", MessageBoxButton.OK, MessageBoxImage.Information);
+                OpenConsole(setup.CreatedEvent, restore: false);
             }
             _vm.Load();
+        }
+
+        // Temporary single-class launch: opens the race console on the event's first
+        // class session. The multi-class tab wrapper replaces this in the next screen.
+        private void OpenConsole(RCDragManagerProd.Domain.MultiClassEvent evt, bool restore)
+        {
+            var session = evt?.ClassSessions?.FirstOrDefault();
+            if (session == null)
+            {
+                MessageBox.Show("This event has no class sessions to race.", "RC Drag Manager",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var controller = new RCDragManagerProd.Controllers.RaceController(session);
+            var console = new RaceConsoleWindow(controller, _connectionString) { Owner = this };
+            console.Show();
+            if (restore)
+            {
+                try { controller.RestoreFromSave(); } catch { }
+            }
         }
 
         private void BtnLoadSaved_Click(object sender, RoutedEventArgs e)
@@ -60,11 +78,7 @@ namespace RCDragManagerProd.WPF.Windows
             var load = new LoadSessionWindow(_connectionString) { Owner = this };
             if (load.ShowDialog() == true && load.ResumedEvent != null)
             {
-                // Race console not ported yet — confirm the load resolved.
-                MessageBox.Show(
-                    $"Loaded '{load.ResumedEvent.EventName}'.\n\n" +
-                    "The race console is coming in a later screen.",
-                    "RC Drag Manager", MessageBoxButton.OK, MessageBoxImage.Information);
+                OpenConsole(load.ResumedEvent, restore: true);
             }
             _vm.Load();
         }

--- a/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml
@@ -248,11 +248,12 @@
 
                 <Border Grid.Column="1" Background="{StaticResource Brush.BorderSubtle}"/>
 
-                <!-- Bracket -->
+                <!-- Bracket + current-match winner buttons -->
                 <Grid Grid.Column="2">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Border Grid.Row="0" Padding="16,10,16,8"
                             BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,0,0,1">
@@ -262,6 +263,38 @@
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="10,6">
                         <ItemsControl x:Name="IcPairings" ItemTemplate="{StaticResource PairingRowTemplate}"/>
                     </ScrollViewer>
+
+                    <!-- Current match: now-racing label + the two winner buttons -->
+                    <Border Grid.Row="2" Padding="14,12"
+                            Background="{StaticResource Brush.Surface}"
+                            BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,1,0,0">
+                        <StackPanel>
+                            <TextBlock x:Name="LblNowRacing" Text="No active match"
+                                       FontSize="{StaticResource FontSize.Xs}" FontWeight="Medium"
+                                       Foreground="{StaticResource Brush.TextHint}"
+                                       HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Button Grid.Column="0" x:Name="BtnWinner1"
+                                        Style="{StaticResource Style.Button.Winner}"
+                                        Content="—" Click="BtnWinner1_Click"
+                                        MouseRightButtonUp="BtnWinner1_RightClick"
+                                        IsEnabled="False"/>
+                                <TextBlock Grid.Column="1" Text="vs" VerticalAlignment="Center"
+                                           Foreground="{StaticResource Brush.TextHint}"
+                                           FontSize="{StaticResource FontSize.Sm}" Margin="12,0"/>
+                                <Button Grid.Column="2" x:Name="BtnWinner2"
+                                        Style="{StaticResource Style.Button.Winner}"
+                                        Content="—" Click="BtnWinner2_Click"
+                                        MouseRightButtonUp="BtnWinner2_RightClick"
+                                        IsEnabled="False"/>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
                 </Grid>
 
                 <Border Grid.Column="3" Background="{StaticResource Brush.BorderSubtle}"/>
@@ -305,63 +338,42 @@
                 </Grid>
             </Grid>
 
-            <!-- Race queue bar -->
+            <!-- Action bar: queue + primary actions -->
             <Border Grid.Row="3"
                     Background="{StaticResource Brush.Chrome}"
                     BorderBrush="{StaticResource Brush.BorderSubtle}"
                     BorderThickness="0,1,0,0"
-                    Padding="20,14">
+                    Padding="20,12">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <!-- Now racing + winner buttons -->
-                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                        <TextBlock x:Name="LblNowRacing" Text="No active match"
-                                   FontSize="{StaticResource FontSize.Xs}"
-                                   FontWeight="Medium"
-                                   Foreground="{StaticResource Brush.TextHint}"
-                                   Margin="0,0,0,8"/>
-                        <StackPanel Orientation="Horizontal">
-                            <Button x:Name="BtnWinner1" Style="{StaticResource Style.Button.Winner}"
-                                    Content="—" Click="BtnWinner1_Click"
-                                    MouseRightButtonUp="BtnWinner1_RightClick"
-                                    Width="240" Margin="0,0,10,0" IsEnabled="False"/>
-                            <TextBlock Text="vs" VerticalAlignment="Center"
-                                       Foreground="{StaticResource Brush.TextHint}"
-                                       FontSize="{StaticResource FontSize.Sm}" Margin="0,0,10,0"/>
-                            <Button x:Name="BtnWinner2" Style="{StaticResource Style.Button.Winner}"
-                                    Content="—" Click="BtnWinner2_Click"
-                                    MouseRightButtonUp="BtnWinner2_RightClick"
-                                    Width="240" IsEnabled="False"/>
-                        </StackPanel>
-                    </StackPanel>
-
                     <!-- Queue -->
-                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="24,0">
-                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                            <TextBlock Text="On deck" Width="60"
-                                       FontSize="{StaticResource FontSize.Xs}"
-                                       Foreground="{StaticResource Brush.TextHint}"/>
-                            <TextBlock x:Name="LblOnDeck" Text="—"
-                                       FontSize="{StaticResource FontSize.Sm}"
-                                       Foreground="{StaticResource Brush.TextSecondary}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="In the hole" Width="60"
-                                       FontSize="{StaticResource FontSize.Xs}"
-                                       Foreground="{StaticResource Brush.TextHint}"/>
-                            <TextBlock x:Name="LblInHole" Text="—"
-                                       FontSize="{StaticResource FontSize.Sm}"
-                                       Foreground="{StaticResource Brush.TextSecondary}"/>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                        <StackPanel Margin="0,0,28,0">
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                <TextBlock Text="On deck" Width="64"
+                                           FontSize="{StaticResource FontSize.Xs}"
+                                           Foreground="{StaticResource Brush.TextHint}"/>
+                                <TextBlock x:Name="LblOnDeck" Text="—"
+                                           FontSize="{StaticResource FontSize.Sm}"
+                                           Foreground="{StaticResource Brush.TextSecondary}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="In the hole" Width="64"
+                                           FontSize="{StaticResource FontSize.Xs}"
+                                           Foreground="{StaticResource Brush.TextHint}"/>
+                                <TextBlock x:Name="LblInHole" Text="—"
+                                           FontSize="{StaticResource FontSize.Sm}"
+                                           Foreground="{StaticResource Brush.TextSecondary}"/>
+                            </StackPanel>
                         </StackPanel>
                     </StackPanel>
 
                     <!-- Primary actions -->
-                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
                         <Button x:Name="BtnGenerateBracket" Style="{StaticResource Style.Button.Dialog.Primary}"
                                 Content="Generate bracket" Click="BtnGenerateBracket_Click"
                                 Padding="20,12" Margin="0,0,8,0" IsEnabled="False"/>

--- a/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml
@@ -1,0 +1,376 @@
+<Window x:Class="RCDragManagerProd.WPF.Windows.RaceConsoleWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:conv="clr-namespace:RCDragManagerProd.WPF"
+        Title="Race Console — RC Drag Manager"
+        Width="1180" Height="760"
+        MinWidth="980" MinHeight="620"
+        WindowStartupLocation="CenterScreen"
+        WindowStyle="None"
+        ResizeMode="CanResizeWithGrip"
+        Background="{StaticResource Brush.Background}"
+        FontFamily="Segoe UI">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="38" CornerRadius="0"
+                      GlassFrameThickness="0" ResizeBorderThickness="5"
+                      UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Window.Resources>
+        <conv:BoolToVisibilityConverter x:Key="BoolToVis"/>
+        <conv:InverseBoolToVisibilityConverter x:Key="InvBoolToVis"/>
+
+        <!-- Pairings row: header or match -->
+        <DataTemplate x:Key="PairingRowTemplate">
+            <Grid>
+                <!-- Round header -->
+                <Border Background="{StaticResource Brush.Chrome}"
+                        Padding="10,5" Margin="0,2"
+                        Visibility="{Binding IsHeader, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="{Binding HeaderText}"
+                               FontSize="{StaticResource FontSize.Xs}"
+                               FontWeight="Medium" FontStyle="Italic"
+                               Foreground="{StaticResource Brush.TextSecondary}"/>
+                </Border>
+                <!-- Match row -->
+                <Grid Margin="4,3"
+                      Visibility="{Binding IsHeader, Converter={StaticResource InvBoolToVis}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="42"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="{Binding MatchLabel}"
+                               FontSize="{StaticResource FontSize.Xs}"
+                               Foreground="{StaticResource Brush.TextHint}"
+                               VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="1" Text="{Binding Driver1}"
+                               FontSize="{StaticResource FontSize.Sm}"
+                               Foreground="{StaticResource Brush.TextPrimary}"
+                               VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="2" Text="{Binding Driver2}"
+                               FontSize="{StaticResource FontSize.Sm}"
+                               Foreground="{StaticResource Brush.TextPrimary}"
+                               VerticalAlignment="Center"/>
+                </Grid>
+            </Grid>
+        </DataTemplate>
+
+        <!-- Winners row: header or result -->
+        <DataTemplate x:Key="WinnerRowTemplate">
+            <Grid>
+                <Border Background="{StaticResource Brush.Chrome}"
+                        Padding="10,5" Margin="0,2"
+                        Visibility="{Binding IsHeader, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="{Binding HeaderText}"
+                               FontSize="{StaticResource FontSize.Xs}"
+                               FontWeight="Medium" FontStyle="Italic"
+                               Foreground="{StaticResource Brush.TextSecondary}"/>
+                </Border>
+                <Grid Margin="4,3"
+                      Visibility="{Binding IsHeader, Converter={StaticResource InvBoolToVis}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="42"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="{Binding MatchLabel}"
+                               FontSize="{StaticResource FontSize.Xs}"
+                               Foreground="{StaticResource Brush.TextHint}"
+                               VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="1" Text="{Binding Winner}"
+                               FontSize="{StaticResource FontSize.Sm}"
+                               Foreground="{StaticResource Brush.TextPrimary}"
+                               VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="2" Text="{Binding Loser}"
+                               FontSize="{StaticResource FontSize.Sm}"
+                               Foreground="{StaticResource Brush.TextMuted}"
+                               VerticalAlignment="Center"/>
+                </Grid>
+            </Grid>
+        </DataTemplate>
+    </Window.Resources>
+
+    <Border Background="{StaticResource Brush.Background}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="38"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title bar -->
+            <Grid Grid.Row="0" Background="{StaticResource Brush.Chrome}">
+                <TextBlock Text="Race console"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           FontSize="12" Foreground="{StaticResource Brush.TextHint}"
+                           FontWeight="Medium"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                            VerticalAlignment="Center" Margin="0,0,14,0">
+                    <Button Style="{StaticResource Style.WinCtrl.Minimize}" Click="BtnMinimize_Click" Margin="0,0,7,0"/>
+                    <Button Style="{StaticResource Style.WinCtrl.Maximize}" Click="BtnMaximize_Click" Margin="0,0,7,0"/>
+                    <Button Style="{StaticResource Style.WinCtrl.Close}" Click="BtnClose_Click"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Header: event title + save/close -->
+            <Border Grid.Row="1"
+                    Background="{StaticResource Brush.Surface}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,0,0,1"
+                    Padding="20,14">
+                <Grid>
+                    <TextBlock x:Name="LblEventTitle"
+                               FontSize="{StaticResource FontSize.Xl}"
+                               FontWeight="Medium"
+                               Foreground="{StaticResource Brush.TextPrimary}"
+                               VerticalAlignment="Center"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Style="{StaticResource Style.Button.Toolbar}"
+                                Content="Save progress" Click="BtnSaveProgress_Click" Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource Style.Button.Toolbar.Danger}"
+                                Content="Close race" Click="BtnCloseRace_Click"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- Body: drivers | bracket | winners+rail -->
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="270"/>
+                    <ColumnDefinition Width="1"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="1"/>
+                    <ColumnDefinition Width="320"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Drivers -->
+                <Grid Grid.Column="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <Border Grid.Row="0" Padding="16,10,16,8"
+                            BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,0,0,1">
+                        <TextBlock Text="Drivers" FontSize="{StaticResource FontSize.Xs}"
+                                   FontWeight="Medium" Foreground="{StaticResource Brush.TextHint}"/>
+                    </Border>
+
+                    <!-- Add driver row -->
+                    <StackPanel Grid.Row="1" Margin="12,10" x:Name="AddDriverPanel">
+                        <TextBox x:Name="TxtName" Style="{StaticResource Style.TextBox}"
+                                 Height="28" VerticalContentAlignment="Center"
+                                 Margin="0,0,0,6" Tag="Driver name"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="8"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Grid.Column="0" x:Name="TxtTime" Style="{StaticResource Style.TextBox}"
+                                     Height="28" VerticalContentAlignment="Center" Tag="Qual time"/>
+                            <Button Grid.Column="2" Style="{StaticResource Style.Button.Toolbar}"
+                                    Content="Add" Click="BtnAddDriver_Click" Width="56"/>
+                        </Grid>
+                    </StackPanel>
+
+                    <DataGrid Grid.Row="2" x:Name="DgDrivers"
+                              AutoGenerateColumns="False" CanUserAddRows="False"
+                              CanUserDeleteRows="False" CanUserReorderColumns="False"
+                              CanUserResizeRows="False" IsReadOnly="True" SelectionMode="Single"
+                              HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                              HorizontalGridLinesBrush="{StaticResource Brush.BorderSubtle}"
+                              Background="{StaticResource Brush.Background}"
+                              RowBackground="{StaticResource Brush.Background}"
+                              AlternatingRowBackground="{StaticResource Brush.Surface}"
+                              Foreground="{StaticResource Brush.TextPrimary}"
+                              FontSize="{StaticResource FontSize.Sm}"
+                              BorderThickness="0" RowHeight="30"
+                              MouseDoubleClick="DgDrivers_DoubleClick">
+                        <DataGrid.ColumnHeaderStyle>
+                            <Style TargetType="DataGridColumnHeader">
+                                <Setter Property="Background" Value="{StaticResource Brush.Chrome}"/>
+                                <Setter Property="Foreground" Value="{StaticResource Brush.TextHint}"/>
+                                <Setter Property="FontSize" Value="{StaticResource FontSize.Xs}"/>
+                                <Setter Property="Padding" Value="12,0"/>
+                                <Setter Property="Height" Value="28"/>
+                                <Setter Property="BorderBrush" Value="{StaticResource Brush.BorderSubtle}"/>
+                                <Setter Property="BorderThickness" Value="0,0,1,1"/>
+                            </Style>
+                        </DataGrid.ColumnHeaderStyle>
+                        <DataGrid.CellStyle>
+                            <Style TargetType="DataGridCell">
+                                <Setter Property="Padding" Value="12,0"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                                <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="DataGridCell">
+                                            <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                                                <ContentPresenter VerticalAlignment="Center"/>
+                                            </Border>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                                <Style.Triggers>
+                                    <Trigger Property="IsSelected" Value="True">
+                                        <Setter Property="Background" Value="{StaticResource Brush.Primary}"/>
+                                        <Setter Property="Foreground" Value="White"/>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </DataGrid.CellStyle>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Driver"  Binding="{Binding Name}"       Width="*"/>
+                            <DataGridTextColumn Header="Qual"    Binding="{Binding QualText}"   Width="60"/>
+                            <DataGridTextColumn Header="Dial-in" Binding="{Binding DialInText}" Width="65"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <!-- Driver action buttons -->
+                    <Border Grid.Row="3" Padding="12,10"
+                            BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,1,0,0">
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{StaticResource Style.Button.Toolbar}"
+                                    Content="Edit" Click="BtnEditDriver_Click" Margin="0,0,6,0"/>
+                            <Button Style="{StaticResource Style.Button.Toolbar}"
+                                    Content="Qual time" Click="BtnSetQual_Click" Margin="0,0,6,0"/>
+                            <Button Style="{StaticResource Style.Button.Toolbar}"
+                                    Content="Dial-in" Click="BtnSetDialIn_Click"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+
+                <Border Grid.Column="1" Background="{StaticResource Brush.BorderSubtle}"/>
+
+                <!-- Bracket -->
+                <Grid Grid.Column="2">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0" Padding="16,10,16,8"
+                            BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,0,0,1">
+                        <TextBlock Text="Bracket" FontSize="{StaticResource FontSize.Xs}"
+                                   FontWeight="Medium" Foreground="{StaticResource Brush.TextHint}"/>
+                    </Border>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="10,6">
+                        <ItemsControl x:Name="IcPairings" ItemTemplate="{StaticResource PairingRowTemplate}"/>
+                    </ScrollViewer>
+                </Grid>
+
+                <Border Grid.Column="3" Background="{StaticResource Brush.BorderSubtle}"/>
+
+                <!-- Winners + rail -->
+                <Grid Grid.Column="4" Background="{StaticResource Brush.Surface}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0" Padding="16,10,16,8"
+                            BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,0,0,1">
+                        <TextBlock Text="Winners" FontSize="{StaticResource FontSize.Xs}"
+                                   FontWeight="Medium" Foreground="{StaticResource Brush.TextHint}"/>
+                    </Border>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="10,6">
+                        <ItemsControl x:Name="IcWinners" ItemTemplate="{StaticResource WinnerRowTemplate}"/>
+                    </ScrollViewer>
+
+                    <!-- Rail -->
+                    <Border Grid.Row="2" Padding="12,12"
+                            BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,1,0,0">
+                        <StackPanel>
+                            <UniformGrid Columns="2" Margin="0,0,0,6">
+                                <Button x:Name="BtnEditResult" Style="{StaticResource Style.Button.Toolbar}"
+                                        Content="Edit result" Click="BtnEditResult_Click" Margin="0,0,3,0"/>
+                                <Button x:Name="BtnStandings" Style="{StaticResource Style.Button.Toolbar}"
+                                        Content="Standings" Click="BtnStandings_Click" Margin="3,0,0,0"
+                                        IsEnabled="False"/>
+                            </UniformGrid>
+                            <UniformGrid Columns="2">
+                                <Button x:Name="BtnBuybacks" Style="{StaticResource Style.Button.Toolbar}"
+                                        Content="Open buybacks" Click="BtnBuybacks_Click" Margin="0,0,3,0"
+                                        IsEnabled="False"/>
+                                <Button x:Name="BtnReset" Style="{StaticResource Style.Button.Toolbar.Danger}"
+                                        Content="Reset" Click="BtnReset_Click" Margin="3,0,0,0"/>
+                            </UniformGrid>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Grid>
+
+            <!-- Race queue bar -->
+            <Border Grid.Row="3"
+                    Background="{StaticResource Brush.Chrome}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,1,0,0"
+                    Padding="20,14">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Now racing + winner buttons -->
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock x:Name="LblNowRacing" Text="No active match"
+                                   FontSize="{StaticResource FontSize.Xs}"
+                                   FontWeight="Medium"
+                                   Foreground="{StaticResource Brush.TextHint}"
+                                   Margin="0,0,0,8"/>
+                        <StackPanel Orientation="Horizontal">
+                            <Button x:Name="BtnWinner1" Style="{StaticResource Style.Button.Winner}"
+                                    Content="—" Click="BtnWinner1_Click"
+                                    MouseRightButtonUp="BtnWinner1_RightClick"
+                                    Width="240" Margin="0,0,10,0" IsEnabled="False"/>
+                            <TextBlock Text="vs" VerticalAlignment="Center"
+                                       Foreground="{StaticResource Brush.TextHint}"
+                                       FontSize="{StaticResource FontSize.Sm}" Margin="0,0,10,0"/>
+                            <Button x:Name="BtnWinner2" Style="{StaticResource Style.Button.Winner}"
+                                    Content="—" Click="BtnWinner2_Click"
+                                    MouseRightButtonUp="BtnWinner2_RightClick"
+                                    Width="240" IsEnabled="False"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- Queue -->
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="24,0">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                            <TextBlock Text="On deck" Width="60"
+                                       FontSize="{StaticResource FontSize.Xs}"
+                                       Foreground="{StaticResource Brush.TextHint}"/>
+                            <TextBlock x:Name="LblOnDeck" Text="—"
+                                       FontSize="{StaticResource FontSize.Sm}"
+                                       Foreground="{StaticResource Brush.TextSecondary}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="In the hole" Width="60"
+                                       FontSize="{StaticResource FontSize.Xs}"
+                                       Foreground="{StaticResource Brush.TextHint}"/>
+                            <TextBlock x:Name="LblInHole" Text="—"
+                                       FontSize="{StaticResource FontSize.Sm}"
+                                       Foreground="{StaticResource Brush.TextSecondary}"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- Primary actions -->
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button x:Name="BtnGenerateBracket" Style="{StaticResource Style.Button.Dialog.Primary}"
+                                Content="Generate bracket" Click="BtnGenerateBracket_Click"
+                                Padding="20,12" Margin="0,0,8,0" IsEnabled="False"/>
+                        <Button x:Name="BtnNextRound" Style="{StaticResource Style.Button.Dialog.Secondary}"
+                                Content="Next round" Click="BtnNextRound_Click"
+                                Padding="20,12" IsEnabled="False"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml
@@ -248,12 +248,11 @@
 
                 <Border Grid.Column="1" Background="{StaticResource Brush.BorderSubtle}"/>
 
-                <!-- Bracket + current-match winner buttons -->
+                <!-- Bracket -->
                 <Grid Grid.Column="2">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Border Grid.Row="0" Padding="16,10,16,8"
                             BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,0,0,1">
@@ -263,38 +262,6 @@
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="10,6">
                         <ItemsControl x:Name="IcPairings" ItemTemplate="{StaticResource PairingRowTemplate}"/>
                     </ScrollViewer>
-
-                    <!-- Current match: now-racing label + the two winner buttons -->
-                    <Border Grid.Row="2" Padding="14,12"
-                            Background="{StaticResource Brush.Surface}"
-                            BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,1,0,0">
-                        <StackPanel>
-                            <TextBlock x:Name="LblNowRacing" Text="No active match"
-                                       FontSize="{StaticResource FontSize.Xs}" FontWeight="Medium"
-                                       Foreground="{StaticResource Brush.TextHint}"
-                                       HorizontalAlignment="Center" Margin="0,0,0,8"/>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Button Grid.Column="0" x:Name="BtnWinner1"
-                                        Style="{StaticResource Style.Button.Winner}"
-                                        Content="—" Click="BtnWinner1_Click"
-                                        MouseRightButtonUp="BtnWinner1_RightClick"
-                                        IsEnabled="False"/>
-                                <TextBlock Grid.Column="1" Text="vs" VerticalAlignment="Center"
-                                           Foreground="{StaticResource Brush.TextHint}"
-                                           FontSize="{StaticResource FontSize.Sm}" Margin="12,0"/>
-                                <Button Grid.Column="2" x:Name="BtnWinner2"
-                                        Style="{StaticResource Style.Button.Winner}"
-                                        Content="—" Click="BtnWinner2_Click"
-                                        MouseRightButtonUp="BtnWinner2_RightClick"
-                                        IsEnabled="False"/>
-                            </Grid>
-                        </StackPanel>
-                    </Border>
                 </Grid>
 
                 <Border Grid.Column="3" Background="{StaticResource Brush.BorderSubtle}"/>
@@ -338,48 +305,79 @@
                 </Grid>
             </Grid>
 
-            <!-- Action bar: queue + primary actions -->
+            <!-- Action bar — columns mirror the body so the winner buttons sit
+                 exactly under the bracket, queue under drivers, actions under winners. -->
             <Border Grid.Row="3"
                     Background="{StaticResource Brush.Chrome}"
                     BorderBrush="{StaticResource Brush.BorderSubtle}"
                     BorderThickness="0,1,0,0"
-                    Padding="20,12">
+                    Padding="0,12">
                 <Grid>
                     <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="270"/>
+                        <ColumnDefinition Width="1"/>
                         <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="1"/>
+                        <ColumnDefinition Width="320"/>
                     </Grid.ColumnDefinitions>
 
-                    <!-- Queue -->
-                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-                        <StackPanel Margin="0,0,28,0">
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                                <TextBlock Text="On deck" Width="64"
-                                           FontSize="{StaticResource FontSize.Xs}"
-                                           Foreground="{StaticResource Brush.TextHint}"/>
-                                <TextBlock x:Name="LblOnDeck" Text="—"
-                                           FontSize="{StaticResource FontSize.Sm}"
-                                           Foreground="{StaticResource Brush.TextSecondary}"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="In the hole" Width="64"
-                                           FontSize="{StaticResource FontSize.Xs}"
-                                           Foreground="{StaticResource Brush.TextHint}"/>
-                                <TextBlock x:Name="LblInHole" Text="—"
-                                           FontSize="{StaticResource FontSize.Sm}"
-                                           Foreground="{StaticResource Brush.TextSecondary}"/>
-                            </StackPanel>
+                    <!-- Under Drivers: queue -->
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="16,0">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                            <TextBlock Text="On deck" Width="64"
+                                       FontSize="{StaticResource FontSize.Xs}"
+                                       Foreground="{StaticResource Brush.TextHint}"/>
+                            <TextBlock x:Name="LblOnDeck" Text="—"
+                                       FontSize="{StaticResource FontSize.Sm}"
+                                       Foreground="{StaticResource Brush.TextSecondary}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="In the hole" Width="64"
+                                       FontSize="{StaticResource FontSize.Xs}"
+                                       Foreground="{StaticResource Brush.TextHint}"/>
+                            <TextBlock x:Name="LblInHole" Text="—"
+                                       FontSize="{StaticResource FontSize.Sm}"
+                                       Foreground="{StaticResource Brush.TextSecondary}"/>
                         </StackPanel>
                     </StackPanel>
 
-                    <!-- Primary actions -->
-                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                    <!-- Under Bracket: now-racing + winner buttons, edges aligned to the column -->
+                    <StackPanel Grid.Column="2" VerticalAlignment="Center" Margin="10,0">
+                        <TextBlock x:Name="LblNowRacing" Text="No active match"
+                                   FontSize="{StaticResource FontSize.Xs}" FontWeight="Medium"
+                                   Foreground="{StaticResource Brush.TextHint}"
+                                   HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Button Grid.Column="0" x:Name="BtnWinner1"
+                                    Style="{StaticResource Style.Button.Winner}"
+                                    Content="—" Click="BtnWinner1_Click"
+                                    MouseRightButtonUp="BtnWinner1_RightClick"
+                                    IsEnabled="False"/>
+                            <TextBlock Grid.Column="1" Text="vs" VerticalAlignment="Center"
+                                       Foreground="{StaticResource Brush.TextHint}"
+                                       FontSize="{StaticResource FontSize.Sm}" Margin="12,0"/>
+                            <Button Grid.Column="2" x:Name="BtnWinner2"
+                                    Style="{StaticResource Style.Button.Winner}"
+                                    Content="—" Click="BtnWinner2_Click"
+                                    MouseRightButtonUp="BtnWinner2_RightClick"
+                                    IsEnabled="False"/>
+                        </Grid>
+                    </StackPanel>
+
+                    <!-- Under Winners: primary actions -->
+                    <StackPanel Grid.Column="4" VerticalAlignment="Center" Margin="16,0"
+                                Orientation="Horizontal" HorizontalAlignment="Right">
                         <Button x:Name="BtnGenerateBracket" Style="{StaticResource Style.Button.Dialog.Primary}"
                                 Content="Generate bracket" Click="BtnGenerateBracket_Click"
-                                Padding="20,12" Margin="0,0,8,0" IsEnabled="False"/>
+                                Padding="18,12" Margin="0,0,8,0" IsEnabled="False"/>
                         <Button x:Name="BtnNextRound" Style="{StaticResource Style.Button.Dialog.Secondary}"
                                 Content="Next round" Click="BtnNextRound_Click"
-                                Padding="20,12" IsEnabled="False"/>
+                                Padding="18,12" IsEnabled="False"/>
                     </StackPanel>
                 </Grid>
             </Border>

--- a/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml.cs
@@ -1,0 +1,597 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Logging;
+using RCDragManagerProd.RaceEngines;
+using RCDragManagerProd.Repositories;
+using RCDragManagerProd.ViewModels;
+using RCDragManagerProd.WPF.Dialogs;
+using RCDragManagerProd.WPF.ViewModels;
+
+namespace RCDragManagerProd.WPF.Windows
+{
+    /// <summary>
+    /// Single-class race console. Binds to a RaceController + RaceConsoleService and
+    /// renders the bracket, winners, queue and winner buttons. Form → Service → Engine;
+    /// this view holds no race logic of its own.
+    /// </summary>
+    public partial class RaceConsoleWindow : Window, IRaceSessionStore
+    {
+        private readonly RaceController _controller;
+        private readonly RaceConsoleService _raceConsole;
+        private readonly SessionRosterService _rosterService = new SessionRosterService();
+        private readonly RaceSessionRepository _sessionRepo;
+        private readonly RaceSession _session;
+        private List<Driver> _drivers = new List<Driver>();
+        private MatchButtons? _currentButtons;
+
+        public RaceConsoleWindow(RaceController controller, string connectionString)
+        {
+            _controller = controller ?? throw new ArgumentNullException(nameof(controller));
+            InitializeComponent();
+
+            _sessionRepo = new RaceSessionRepository(connectionString);
+            _raceConsole = new RaceConsoleService(_controller, this, new DriverRepository(connectionString));
+            _session = _controller.Session;
+
+            LblEventTitle.Text = _raceConsole.GetState().EventTitle;
+
+            if (_session?.DriverEntries != null && _session.DriverEntries.Count > 0)
+            {
+                _drivers = _session.DriverEntries
+                    .Select(e => new Driver { Id = e.DriverID, Name = e.DriverName, QualTime = e.QualifyingTime })
+                    .ToList();
+                RefreshDriverGrid();
+                BtnGenerateBracket.IsEnabled = true;
+            }
+
+            _controller.BracketRedrawn += OnBracketRedrawn;
+            _controller.NextMatchReady += OnNextMatchReady;
+            _controller.WinnersUpdated += OnWinnersUpdated;
+            _controller.CanAdvanceChanged += OnCanAdvanceChanged;
+            _controller.CanOfferBuybackChanged += OnCanOfferBuybackChanged;
+            _controller.CanStartFinalsChanged += OnCanStartFinalsChanged;
+            _controller.TournamentCompleted += OnTournamentCompleted;
+
+            _controller.StartDialInPolling();
+            Closed += (_, __) => Unsubscribe();
+        }
+
+        private void Unsubscribe()
+        {
+            try
+            {
+                _controller.BracketRedrawn -= OnBracketRedrawn;
+                _controller.NextMatchReady -= OnNextMatchReady;
+                _controller.WinnersUpdated -= OnWinnersUpdated;
+                _controller.CanAdvanceChanged -= OnCanAdvanceChanged;
+                _controller.CanOfferBuybackChanged -= OnCanOfferBuybackChanged;
+                _controller.CanStartFinalsChanged -= OnCanStartFinalsChanged;
+                _controller.TournamentCompleted -= OnTournamentCompleted;
+            }
+            catch { }
+            _controller.StopDialInPolling();
+        }
+
+        void IRaceSessionStore.Persist()
+        {
+            if (_session != null) _sessionRepo.SaveSession(_session);
+        }
+
+        private void Run(Action a)
+        {
+            if (Dispatcher.CheckAccess()) a();
+            else Dispatcher.Invoke(a);
+        }
+
+        // ── Controller events ─────────────────────────────────────────────────
+
+        private void OnBracketRedrawn(IReadOnlyList<PairingRow> rows) => Run(() =>
+        {
+            var list = new List<PairingDisplayRow>();
+            string lastHeader = null;
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var row in rows ?? new List<PairingRow>())
+            {
+                if (row == null) continue;
+                if (row.IsHeader)
+                {
+                    var label = RoundLabels.Normalize(row.RoundLabel);
+                    if (string.Equals(label, lastHeader, StringComparison.OrdinalIgnoreCase)) continue;
+                    lastHeader = label;
+                    list.Add(new PairingDisplayRow { IsHeader = true, HeaderText = label });
+                    continue;
+                }
+
+                string key = row.MatchId > 0
+                    ? $"{row.RoundLabel}|{row.MatchId}"
+                    : $"{row.RoundLabel}|{row.Driver1}|{row.Driver2}";
+                if (!seen.Add(key)) continue;
+
+                bool bye1 = IsBye(row.Driver1);
+                bool bye2 = IsBye(row.Driver2);
+                list.Add(new PairingDisplayRow
+                {
+                    MatchLabel = !string.IsNullOrEmpty(row.MatchNumber) ? row.MatchNumber
+                               : (row.MatchId > 0 ? $"M{row.MatchId}" : "-"),
+                    Driver1 = bye1 ? "BYE" : row.Driver1,
+                    Driver2 = bye2 ? "BYE" : row.Driver2,
+                    Bye1 = bye1, Bye2 = bye2
+                });
+            }
+
+            IcPairings.ItemsSource = list;
+        });
+
+        private void OnNextMatchReady(PairingRow row) => Run(() =>
+        {
+            if (row == null)
+            {
+                _currentButtons = null;
+                SetWinnerButton(BtnWinner1, "—", false);
+                SetWinnerButton(BtnWinner2, "—", false);
+                LblNowRacing.Text = "No active match";
+                UpdateQueue();
+                return;
+            }
+
+            var mb = _raceConsole.GetMatchButtons(row.MatchId);
+            _currentButtons = mb;
+
+            if (mb == null)
+            {
+                SetWinnerButton(BtnWinner1, "—", false);
+                SetWinnerButton(BtnWinner2, "—", false);
+                return;
+            }
+
+            var b = mb.Value;
+            SetWinnerButton(BtnWinner1, b.LeftName + FormatDialIn(b.LeftDialIn), !b.LeftIsBye);
+            SetWinnerButton(BtnWinner2, b.RightName + FormatDialIn(b.RightDialIn), !b.RightIsBye);
+            if (b.LeftIsBye) BtnWinner1.Content = "BYE";
+            if (b.RightIsBye) BtnWinner2.Content = "BYE";
+
+            LblNowRacing.Text = $"Now racing — {RoundLabels.Normalize(row.RoundLabel)}";
+            UpdateQueue();
+        });
+
+        private void OnWinnersUpdated(IReadOnlyList<WinnerRow> rows) => Run(() =>
+        {
+            var list = new List<WinnerDisplayRow>();
+            string header = null;
+            int n = 1;
+            foreach (var w in rows ?? new List<WinnerRow>())
+            {
+                if (!string.Equals(header, w.RoundLabel, StringComparison.OrdinalIgnoreCase))
+                {
+                    header = w.RoundLabel ?? "";
+                    list.Add(new WinnerDisplayRow { IsHeader = true, HeaderText = RoundLabels.Normalize(header) });
+                }
+                list.Add(new WinnerDisplayRow
+                {
+                    MatchLabel = $"M{n++}",
+                    Winner = w.Winner ?? "",
+                    Loser = w.Loser ?? "",
+                    MatchId = w.MatchId
+                });
+            }
+            IcWinners.ItemsSource = list;
+        });
+
+        private void OnCanAdvanceChanged(bool can) => Run(() =>
+        {
+            BtnNextRound.IsEnabled = can;
+            if (can) _controller.UnlockDialIn();
+        });
+
+        private void OnCanOfferBuybackChanged(bool enabled) => Run(() =>
+        {
+            BtnBuybacks.IsEnabled = enabled;
+            BtnStandings.IsEnabled = enabled;
+            if (enabled)
+                MessageBox.Show("Round-Robin complete.\nClick 'Open buybacks' to add drivers to the Losers Bracket.",
+                    "Buyback phase ready", MessageBoxButton.OK, MessageBoxImage.Information);
+        });
+
+        private bool _finalsPopupShown;
+        private void OnCanStartFinalsChanged(bool enabled) => Run(() =>
+        {
+            BtnGenerateBracket.IsEnabled = enabled;
+            if (enabled)
+            {
+                BtnGenerateBracket.Content = "Start finals";
+                if (!_finalsPopupShown)
+                {
+                    _finalsPopupShown = true;
+                    MessageBox.Show("Losers Bracket complete.\nClick 'Start finals' to run the Finals.",
+                        "Finals ready", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+            }
+            else _finalsPopupShown = false;
+        });
+
+        private void OnTournamentCompleted(RaceController.RaceSummary summary) => Run(() =>
+        {
+            var winner = summary.Winner?.Name ?? "N/A";
+            var runnerUp = summary.RunnerUp?.Name ?? "N/A";
+            MessageBox.Show(
+                $"Event: {summary.EventName}\nWinner: {winner}\nRunner-up: {runnerUp}\nMatches: {summary.TotalMatches}",
+                "Event complete", MessageBoxButton.OK, MessageBoxImage.Information);
+            _raceConsole.RecordTournamentCompletion(summary, _drivers);
+        });
+
+        // ── Rendering helpers ─────────────────────────────────────────────────
+
+        private void UpdateQueue()
+        {
+            var upcoming = _controller.PeekUpcomingMatches(3)
+                .Where(m => _currentButtons == null || m.MatchId != _currentButtons.Value.MatchId)
+                .Take(2).ToList();
+
+            LblOnDeck.Text = QueueText(upcoming.Count > 0 ? upcoming[0] : null);
+            LblInHole.Text = QueueText(upcoming.Count > 1 ? upcoming[1] : null);
+        }
+
+        private string QueueText(EngineMatch m)
+        {
+            if (m == null) return "—";
+            var mb = _raceConsole.GetMatchButtons(m.MatchId);
+            if (mb == null) return "—";
+            return $"{mb.Value.LeftName}  vs  {mb.Value.RightName}";
+        }
+
+        private void RefreshDriverGrid()
+        {
+            DgDrivers.ItemsSource = _drivers
+                .Select(d => new ConsoleDriverRow
+                {
+                    DriverId = d.Id,
+                    Name = d.Name,
+                    QualText = d.QualTime.HasValue ? d.QualTime.Value.ToString("0.000") : "—",
+                    DialInText = FormatDialInPlain(_controller.GetDriverDialIn(d.Id))
+                })
+                .ToList();
+        }
+
+        private void SetWinnerButton(System.Windows.Controls.Button btn, string text, bool enabled)
+        {
+            btn.Content = text;
+            btn.IsEnabled = enabled;
+        }
+
+        private static bool IsBye(string name) =>
+            string.IsNullOrWhiteSpace(name) || string.Equals(name.Trim(), "BYE", StringComparison.OrdinalIgnoreCase);
+
+        private static string FormatDialIn(double? d) => d.HasValue ? $"  [{d.Value:0.000}]" : "";
+        private static string FormatDialInPlain(double? d) => d.HasValue ? d.Value.ToString("0.000") : "—";
+
+        // ── Title bar ─────────────────────────────────────────────────────────
+
+        private void BtnMinimize_Click(object sender, RoutedEventArgs e) => WindowState = WindowState.Minimized;
+        private void BtnMaximize_Click(object sender, RoutedEventArgs e) =>
+            WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+        private void BtnClose_Click(object sender, RoutedEventArgs e) => Close();
+
+        // ── Driver actions ────────────────────────────────────────────────────
+
+        private void BtnAddDriver_Click(object sender, RoutedEventArgs e)
+        {
+            if (_controller.HasBracketStarted)
+            {
+                MessageBox.Show("This race has already started — drivers can't be added to the active race.",
+                    "Race in progress", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            string name = (TxtName.Text ?? "").Trim();
+            string timeText = (TxtTime.Text ?? "").Trim();
+            string error = _rosterService.Validate(name, timeText);
+            if (error != null)
+            {
+                MessageBox.Show(error, "Add driver", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            double? qual = _rosterService.ParseQualTime(timeText);
+            var existing = _drivers.FirstOrDefault(d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (existing != null)
+            {
+                if (qual.HasValue) existing.QualTime = qual.Value;
+            }
+            else
+            {
+                _drivers.Add(_rosterService.BuildNewDriver(name, qual, _drivers));
+            }
+
+            RefreshDriverGrid();
+            TxtName.Clear();
+            TxtTime.Clear();
+            BtnGenerateBracket.IsEnabled = _drivers.Count >= 2;
+        }
+
+        private void BtnEditDriver_Click(object sender, RoutedEventArgs e)
+        {
+            if (_controller.HasBracketStarted)
+            {
+                MessageBox.Show("This race has already started — driver identity is fixed.",
+                    "Race in progress", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+            var row = DgDrivers.SelectedItem as ConsoleDriverRow;
+            if (row == null) return;
+            var driver = _drivers.FirstOrDefault(d => d.Id == row.DriverId);
+            if (driver == null) return;
+
+            var dlg = new AddEditDriverDialog(driver.Name, "") { Owner = this };
+            if (dlg.ShowDialog() == true)
+            {
+                driver.Name = dlg.DriverName;
+                RefreshDriverGrid();
+            }
+        }
+
+        private void BtnSetQual_Click(object sender, RoutedEventArgs e)
+        {
+            var row = DgDrivers.SelectedItem as ConsoleDriverRow;
+            if (row == null) { MessageBox.Show("Select a driver.", "Set qual time"); return; }
+            var driver = _drivers.FirstOrDefault(d => d.Id == row.DriverId);
+            if (driver == null) return;
+
+            var dlg = new SetQualTimeDialog(driver.Name, driver.QualTime) { Owner = this };
+            if (dlg.ShowDialog() == true)
+            {
+                driver.QualTime = dlg.QualTime;
+                RefreshDriverGrid();
+            }
+        }
+
+        private void BtnSetDialIn_Click(object sender, RoutedEventArgs e)
+        {
+            var row = DgDrivers.SelectedItem as ConsoleDriverRow;
+            if (row == null) { MessageBox.Show("Select a driver.", "Set dial-in"); return; }
+            EditDialIn(row.DriverId, row.Name);
+        }
+
+        private void DgDrivers_DoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DgDrivers.SelectedItem is ConsoleDriverRow row) EditDialIn(row.DriverId, row.Name);
+        }
+
+        private void EditDialIn(int driverId, string name)
+        {
+            if (_controller.DialInLocked)
+            {
+                var proceed = MessageBox.Show(
+                    $"This round is in progress.\n\nEdit {name}'s dial-in anyway? It won't affect pairs that already raced.",
+                    "Round in progress", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                if (proceed != MessageBoxResult.Yes) return;
+            }
+
+            double? current = _controller.GetDriverDialIn(driverId);
+            var dlg = new DialInDialog(name, current) { Owner = this };
+            if (dlg.ShowDialog() != true) return;
+
+            _controller.UpdateDriverDialIn(driverId, dlg.Cleared ? (double?)null : dlg.DialIn);
+            RefreshDriverGrid();
+            RefreshWinnerButtonDialIns();
+        }
+
+        private void RefreshWinnerButtonDialIns()
+        {
+            if (_currentButtons == null) return;
+            var mb = _raceConsole.GetMatchButtons(_currentButtons.Value.MatchId);
+            if (mb == null) return;
+            _currentButtons = mb;
+            var b = mb.Value;
+            if (!b.LeftIsBye) BtnWinner1.Content = b.LeftName + FormatDialIn(b.LeftDialIn);
+            if (!b.RightIsBye) BtnWinner2.Content = b.RightName + FormatDialIn(b.RightDialIn);
+        }
+
+        // ── Winner buttons ────────────────────────────────────────────────────
+
+        private void BtnWinner1_Click(object sender, RoutedEventArgs e) => SubmitWinner(true);
+        private void BtnWinner2_Click(object sender, RoutedEventArgs e) => SubmitWinner(false);
+
+        private void SubmitWinner(bool leftClicked)
+        {
+            if (_currentButtons == null) return;
+            int matchId = _currentButtons.Value.MatchId;
+            var submission = _raceConsole.SubmitWinnerFromButton(matchId, leftClicked);
+            if (!submission.Accepted)
+            {
+                Logger.Log($"[WPF][WINNER] Submit not accepted for M{matchId}.");
+                return;
+            }
+
+            var winner = _controller.GetWinner(matchId);
+            var loser = _controller.GetLoser(matchId);
+            if (winner != null && loser != null &&
+                !IsBye(winner.Name) && !IsBye(loser.Name))
+            {
+                _raceConsole_PersistStats(winner, loser, matchId);
+            }
+        }
+
+        private void _raceConsole_PersistStats(Driver winner, Driver loser, int matchId)
+        {
+            // Mirror Form1: persist match stats; bump events-won on the Final.
+            var match = _controller.GetMatch(matchId);
+            _controller.PersistMatchStats(winner, loser, App.ConnectionString);
+            var round = match?.RoundLabel ?? "";
+            if (string.Equals(round, "F", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(round, "Final", StringComparison.OrdinalIgnoreCase))
+                _controller.PersistEventWon(winner, App.ConnectionString);
+        }
+
+        private void BtnWinner1_RightClick(object sender, MouseButtonEventArgs e) => EditButtonDialIn(true);
+        private void BtnWinner2_RightClick(object sender, MouseButtonEventArgs e) => EditButtonDialIn(false);
+
+        private void EditButtonDialIn(bool left)
+        {
+            if (_currentButtons == null) return;
+            var b = _currentButtons.Value;
+            string name = left ? b.LeftName : b.RightName;
+            int id = left ? b.LeftDriverId : b.RightDriverId;
+            if (id <= 0 || IsBye(name)) return;
+            EditDialIn(id, name);
+        }
+
+        // ── Primary actions ───────────────────────────────────────────────────
+
+        private void BtnGenerateBracket_Click(object sender, RoutedEventArgs e)
+        {
+            var raceType = _controller.Session?.RaceType ?? _session?.RaceType;
+            var action = _raceConsole.ExecutePrimaryAction(_drivers, raceType);
+            BtnGenerateBracket.IsEnabled = false;
+            if (action == RaceConsolePrimaryAction.StartLosersBracket)
+                BtnBuybacks.IsEnabled = false;
+        }
+
+        private void BtnNextRound_Click(object sender, RoutedEventArgs e)
+        {
+            if (!BtnNextRound.IsEnabled) return;
+            BtnNextRound.IsEnabled = false;
+            try { _raceConsole.AdvanceRound(); }
+            catch (Exception ex)
+            {
+                Logger.Log($"[WPF][CONSOLE] AdvanceRound failed: {ex}");
+                MessageBox.Show("Failed to advance the round. Check the log.", "Advance round",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void BtnReset_Click(object sender, RoutedEventArgs e)
+        {
+            if (_controller.HasBracketStarted)
+            {
+                var confirmed = MessageBox.Show(
+                    "Reset this active race? This clears bracket progress, winners and round state. This cannot be undone.",
+                    "Reset active race", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                if (confirmed != MessageBoxResult.Yes) return;
+                if (_session != null) { try { _raceConsole.SaveProgress(); } catch { } }
+            }
+
+            _controller.Reset();
+            IcPairings.ItemsSource = null;
+            IcWinners.ItemsSource = null;
+            UpdateQueue();
+            BtnGenerateBracket.IsEnabled = _drivers.Count >= 2;
+            BtnGenerateBracket.Content = "Generate bracket";
+            BtnNextRound.IsEnabled = false;
+            BtnStandings.IsEnabled = false;
+            BtnBuybacks.IsEnabled = false;
+        }
+
+        private void BtnStandings_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_raceConsole.TryShowStandings())
+                MessageBox.Show("Standings aren't available yet — they appear after Round Robin completes.",
+                    "Standings not ready", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void BtnBuybacks_Click(object sender, RoutedEventArgs e)
+        {
+            var eligible = _raceConsole.GetEligibleBuybacks();
+            if (eligible == null || eligible.Count < 2)
+            {
+                MessageBox.Show("Not enough eligible drivers for a Losers Bracket.", "No entries",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var dlg = new BuybackDialog(eligible.ToList()) { Owner = this };
+            if (dlg.ShowDialog() != true) return;
+
+            switch (_raceConsole.ApplyBuybackSelection(dlg.SelectedDrivers))
+            {
+                case BuybackSelectionOutcome.Invalid:
+                    MessageBox.Show("At least one driver must be selected.", "Invalid selection",
+                        MessageBoxButton.OK, MessageBoxImage.Warning);
+                    break;
+                case BuybackSelectionOutcome.SingleToFinals:
+                    break;
+                case BuybackSelectionOutcome.Stored:
+                    BtnGenerateBracket.IsEnabled = true;
+                    BtnGenerateBracket.Content = "Start losers bracket";
+                    BtnBuybacks.Content = "Edit buybacks";
+                    break;
+            }
+        }
+
+        private void BtnEditResult_Click(object sender, RoutedEventArgs e)
+        {
+            if (!(IcWinners.ItemsSource is IEnumerable<WinnerDisplayRow>)) return;
+            // Selection: the winners list is an ItemsControl; use a simple pick via the
+            // currently-focused row is not available, so ask the user to use the bracket.
+            var selectable = (IcWinners.ItemsSource as IEnumerable<WinnerDisplayRow>)
+                .Where(r => !r.IsHeader && r.MatchId > 0).ToList();
+            if (selectable.Count == 0)
+            {
+                MessageBox.Show("No results to edit yet.", "Edit result",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var pick = new EditResultPickWindow(selectable) { Owner = this };
+            if (pick.ShowDialog() != true || pick.SelectedMatchId <= 0) return;
+            int matchId = pick.SelectedMatchId;
+
+            switch (_raceConsole.ValidateEditable(matchId))
+            {
+                case EditResultStatus.MatchNotFound:
+                    MessageBox.Show("Match not found.", "Edit result"); return;
+                case EditResultStatus.NoResultYet:
+                    MessageBox.Show("That match has not run yet.", "Edit result"); return;
+                case EditResultStatus.NotInActiveRound:
+                    MessageBox.Show("You can only change results for the active round.", "Edit result"); return;
+            }
+
+            var match = _controller.GetMatch(matchId);
+            var d1 = match.Driver1?.Name ?? "BYE";
+            var d2 = match.Driver2?.Name ?? "BYE";
+            var dlg = new EditResultDialog(matchId, match.RoundLabel, d1, d2,
+                                           IsBye(d1), IsBye(d2)) { Owner = this };
+            if (dlg.ShowDialog() != true || dlg.Choice == 0) return;
+
+            bool setFirst = dlg.Choice == 1;
+            if (!_raceConsole.ApplyEditResult(matchId, setFirst))
+                MessageBox.Show("Edit rejected. Only active-round matches can change and BYE can't win.",
+                    "Edit result", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        // ── Save / close ──────────────────────────────────────────────────────
+
+        private void BtnSaveProgress_Click(object sender, RoutedEventArgs e)
+        {
+            if (_session == null)
+            {
+                MessageBox.Show("Quick session has no saved file to update.", "Nothing to save");
+                return;
+            }
+            _raceConsole.SaveProgress();
+            MessageBox.Show("Race progress saved. You can resume this race later.", "Progress saved",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void BtnCloseRace_Click(object sender, RoutedEventArgs e)
+        {
+            var confirmed = MessageBox.Show(
+                "Close this race? Make sure progress is saved if you want to resume it later.",
+                "Close race", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (confirmed != MessageBoxResult.Yes) return;
+
+            if (_session != null)
+            {
+                _raceConsole.CloseRace();
+                _raceConsole.RecomputeEventsWon(_drivers);
+            }
+            Close();
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml.cs
@@ -49,6 +49,7 @@ namespace RCDragManagerProd.WPF.Windows
                 RefreshDriverGrid();
                 BtnGenerateBracket.IsEnabled = true;
             }
+            UpdatePrimaryButtons();
 
             _controller.BracketRedrawn += OnBracketRedrawn;
             _controller.NextMatchReady += OnNextMatchReady;
@@ -188,6 +189,7 @@ namespace RCDragManagerProd.WPF.Windows
         {
             BtnNextRound.IsEnabled = can;
             if (can) _controller.UnlockDialIn();
+            UpdatePrimaryButtons();
         });
 
         private void OnCanOfferBuybackChanged(bool enabled) => Run(() =>
@@ -214,6 +216,7 @@ namespace RCDragManagerProd.WPF.Windows
                 }
             }
             else _finalsPopupShown = false;
+            UpdatePrimaryButtons();
         });
 
         private void OnTournamentCompleted(RaceController.RaceSummary summary) => Run(() =>
@@ -244,6 +247,17 @@ namespace RCDragManagerProd.WPF.Windows
             var mb = _raceConsole.GetMatchButtons(m.MatchId);
             if (mb == null) return "—";
             return $"{mb.Value.LeftName}  vs  {mb.Value.RightName}";
+        }
+
+        // The "what to push next" button is orange (primary); the other is grey.
+        // Next round takes priority once a round is ready to advance.
+        private void UpdatePrimaryButtons()
+        {
+            var primary = (Style)FindResource("Style.Button.Dialog.Primary");
+            var secondary = (Style)FindResource("Style.Button.Dialog.Secondary");
+            bool nextActive = BtnNextRound.IsEnabled;
+            BtnNextRound.Style = nextActive ? primary : secondary;
+            BtnGenerateBracket.Style = (!nextActive && BtnGenerateBracket.IsEnabled) ? primary : secondary;
         }
 
         private void RefreshDriverGrid()
@@ -313,6 +327,7 @@ namespace RCDragManagerProd.WPF.Windows
             TxtName.Clear();
             TxtTime.Clear();
             BtnGenerateBracket.IsEnabled = _drivers.Count >= 2;
+            UpdatePrimaryButtons();
         }
 
         private void BtnEditDriver_Click(object sender, RoutedEventArgs e)
@@ -451,6 +466,7 @@ namespace RCDragManagerProd.WPF.Windows
             BtnGenerateBracket.IsEnabled = false;
             if (action == RaceConsolePrimaryAction.StartLosersBracket)
                 BtnBuybacks.IsEnabled = false;
+            UpdatePrimaryButtons();
         }
 
         private void BtnNextRound_Click(object sender, RoutedEventArgs e)
@@ -486,6 +502,7 @@ namespace RCDragManagerProd.WPF.Windows
             BtnNextRound.IsEnabled = false;
             BtnStandings.IsEnabled = false;
             BtnBuybacks.IsEnabled = false;
+            UpdatePrimaryButtons();
         }
 
         private void BtnStandings_Click(object sender, RoutedEventArgs e)
@@ -520,6 +537,7 @@ namespace RCDragManagerProd.WPF.Windows
                     BtnGenerateBracket.IsEnabled = true;
                     BtnGenerateBracket.Content = "Start losers bracket";
                     BtnBuybacks.Content = "Edit buybacks";
+                    UpdatePrimaryButtons();
                     break;
             }
         }

--- a/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
@@ -32,6 +32,36 @@ namespace RCDragManagerProd.AppServices
         public RaceConsoleViewModel GetState() => RaceConsoleViewModelBuilder.Build(_controller);
 
         /// <summary>
+        /// Lane-correct winner-button info for a match: the left/right names (after lane swap),
+        /// their dial-ins, and whether each side is a BYE. Returns null when the match is unknown.
+        /// Lets a view (WinForms or WPF) label the two winner buttons without owning the internal
+        /// lane-adjustment logic; pass the resulting left/right click straight to
+        /// <see cref="SubmitWinnerFromButton"/> as uiFirstOption (true = left).
+        /// </summary>
+        public MatchButtons? GetMatchButtons(int matchId)
+        {
+            var m = _controller.GetMatch(matchId);
+            if (m == null) return null;
+
+            _controller.GetLaneAdjustedNames(m, out string left, out string right);
+
+            bool swapped = left != (m.Driver1?.Name ?? "BYE");
+            int leftId  = (swapped ? m.Driver2 : m.Driver1)?.Id ?? 0;
+            int rightId = (swapped ? m.Driver1 : m.Driver2)?.Id ?? 0;
+
+            return new MatchButtons(
+                matchId,
+                left, right,
+                leftId  > 0 ? _controller.GetDriverDialIn(leftId)  : null,
+                rightId > 0 ? _controller.GetDriverDialIn(rightId) : null,
+                leftId, rightId,
+                IsByeName(left), IsByeName(right));
+        }
+
+        private static bool IsByeName(string name) =>
+            string.Equals((name ?? "").Trim(), "BYE", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Runs the phase-appropriate primary Build/Start action and reports which one ran.
         /// This is the decision that used to live inline in the console's Build/Start button
         /// handler: Finals pending → start Finals; Losers Bracket pending → start it;
@@ -278,6 +308,36 @@ namespace RCDragManagerProd.AppServices
         public static readonly WinnerSubmission Rejected = new WinnerSubmission(false, false);
 
         public static WinnerSubmission Accept(bool engineFirstOption) => new WinnerSubmission(true, engineFirstOption);
+    }
+
+    /// <summary>Lane-correct winner-button info from <see cref="RaceConsoleService.GetMatchButtons"/>.</summary>
+    public readonly struct MatchButtons
+    {
+        public MatchButtons(int matchId, string leftName, string rightName,
+                            double? leftDialIn, double? rightDialIn,
+                            int leftDriverId, int rightDriverId,
+                            bool leftIsBye, bool rightIsBye)
+        {
+            MatchId = matchId;
+            LeftName = leftName;
+            RightName = rightName;
+            LeftDialIn = leftDialIn;
+            RightDialIn = rightDialIn;
+            LeftDriverId = leftDriverId;
+            RightDriverId = rightDriverId;
+            LeftIsBye = leftIsBye;
+            RightIsBye = rightIsBye;
+        }
+
+        public int MatchId { get; }
+        public string LeftName { get; }
+        public string RightName { get; }
+        public double? LeftDialIn { get; }
+        public double? RightDialIn { get; }
+        public int LeftDriverId { get; }
+        public int RightDriverId { get; }
+        public bool LeftIsBye { get; }
+        public bool RightIsBye { get; }
     }
 
     /// <summary>Result of <see cref="RaceConsoleService.ValidateEditable"/>.</summary>


### PR DESCRIPTION
## Summary

The app's core screen — the single-class race console, ported to WPF and wired to the real `RaceController` + `RaceConsoleService` (Form → Service → Engine; the view holds no race logic).

This is **stage 1** of screen #4. The multi-class tab wrapper that hosts one console per class is **stage 2** (next PR).

### RaceConsoleWindow
- **Drivers panel** — add (name + qual), edit, set qual time, set dial-in; double-click a row to edit dial-in.
- **Bracket** — live full bracket with round headers + BYE styling, rendered from `BracketRedrawn`.
- **Winners** — results list with round headers, from `WinnersUpdated`.
- **Race queue** — current match label + on-deck / in-the-hole, two big winner buttons showing dial-ins, BYE sides disabled. Right-click a winner button to edit that driver's dial-in.
- **Primary actions** — Generate bracket / Start losers bracket / Start finals (phase-driven), Next round, Reset, Standings, Open buybacks, Save progress, Close race.
- Subscribes to all 7 controller events with dispatcher marshaling.

### Dialogs (dark, themed)
`DialInDialog`, `EditResultDialog`, `EditResultPickWindow`, `BuybackDialog`. Standings reuse the existing scrollable dialog service.

### Core-project change (additive)
`RaceConsoleService.GetMatchButtons(matchId)` — a UI-neutral, lane-correct accessor returning the left/right names, dial-ins and BYE flags for a match, so a view can label the two winner buttons without owning the internal lane-adjustment logic. This matches the service's stated goal of driving "a future WPF view".

### Temporary launch
Start new event / Load now open the console on the event's **first class session** so it's testable end-to-end. The multi-class wrapper replaces this in stage 2.

## Test plan

- [ ] Create an event (Round Robin, a handful of drivers) → console opens
- [ ] Generate bracket → bracket + first match + queue populate
- [ ] Pick winners → winners list grows, next match advances, BYE sides disabled
- [ ] Next round enables when the round completes → advances
- [ ] Right-click a winner button → edit dial-in, button text updates
- [ ] After RR: Standings + Open buybacks enable; buybacks → losers bracket → finals
- [ ] Edit result on an active-round match
- [ ] Save progress (resumable) and Load it back; Close race
- [ ] No white strips; dark scrollbars

> Note: this is the largest screen and can only be fully validated by running a real tournament — hands-on testing welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)