### PR TITLE
feat(wpf): Live Scoreboard window (QR for public site)

### DIFF
--- a/src/RCDragManagerProd.WPF/RCDragManagerProd.WPF.csproj
+++ b/src/RCDragManagerProd.WPF/RCDragManagerProd.WPF.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119.0" />
+    <PackageReference Include="QRCoder" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
@@ -100,8 +100,7 @@ namespace RCDragManagerProd.WPF.Windows
         }
 
         private void BtnLiveScoreboard_Click(object sender, RoutedEventArgs e) =>
-            MessageBox.Show("Live scoreboard — coming soon.", "RC Drag Manager",
-                MessageBoxButton.OK, MessageBoxImage.Information);
+            new LiveScoreboardWindow { Owner = this }.ShowDialog();
 
         private void BtnExit_Click(object sender, RoutedEventArgs e) =>
             Application.Current.Shutdown();

--- a/src/RCDragManagerProd.WPF/Windows/LiveScoreboardWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/LiveScoreboardWindow.xaml
@@ -1,0 +1,79 @@
+<Window x:Class="RCDragManagerProd.WPF.Windows.LiveScoreboardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Live Scoreboard — RC Drag Manager"
+        Width="440"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        KeyDown="Window_KeyDown"
+        Background="{StaticResource Brush.Background}"
+        FontFamily="Segoe UI">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="38" CornerRadius="0"
+                      GlassFrameThickness="0" ResizeBorderThickness="0"
+                      UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.Border}" BorderThickness="1">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="38"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title bar -->
+            <Grid Grid.Row="0" Background="{StaticResource Brush.Chrome}">
+                <TextBlock Text="Live scoreboard"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           FontSize="12" Foreground="{StaticResource Brush.TextHint}" FontWeight="Medium"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                            VerticalAlignment="Center" Margin="0,0,14,0">
+                    <Button Style="{StaticResource Style.WinCtrl.Close}" Click="BtnClose_Click"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Body -->
+            <StackPanel Grid.Row="1" Margin="28,22" HorizontalAlignment="Center">
+                <TextBlock Text="Public live scoreboard"
+                           FontSize="{StaticResource FontSize.Xl}" FontWeight="Medium"
+                           Foreground="{StaticResource Brush.TextPrimary}"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Scan to open on a phone, or open it here."
+                           FontSize="{StaticResource FontSize.Xs}"
+                           Foreground="{StaticResource Brush.TextMuted}"
+                           HorizontalAlignment="Center" Margin="0,4,0,18"/>
+
+                <!-- QR card (white for scan contrast) -->
+                <Border Background="White" CornerRadius="{StaticResource Radius.Card}"
+                        Padding="16" HorizontalAlignment="Center">
+                    <Image x:Name="QrImage" Width="280" Height="280"
+                           RenderOptions.BitmapScalingMode="NearestNeighbor"/>
+                </Border>
+
+                <TextBlock x:Name="UrlText"
+                           FontSize="{StaticResource FontSize.Md}" FontWeight="Medium"
+                           Foreground="{StaticResource Brush.Primary}"
+                           HorizontalAlignment="Center" Margin="0,16,0,0"/>
+            </StackPanel>
+
+            <!-- Footer -->
+            <Border Grid.Row="2"
+                    Background="{StaticResource Brush.Chrome}"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}"
+                    BorderThickness="0,1,0,0"
+                    Padding="24,14">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                            Content="Close" Click="BtnClose_Click" Margin="0,0,8,0"/>
+                    <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                            Content="Open live view ↗" Click="BtnOpenLiveView_Click"/>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Windows/LiveScoreboardWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LiveScoreboardWindow.xaml.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+using QRCoder;
+using RCDragManagerProd.Logging;
+
+namespace RCDragManagerProd.WPF.Windows
+{
+    public partial class LiveScoreboardWindow : Window
+    {
+        private const string LiveScoreboardUrl = "https://stewmacrc.com";
+
+        public LiveScoreboardWindow()
+        {
+            InitializeComponent();
+            UrlText.Text = LiveScoreboardUrl;
+            QrImage.Source = BuildQrImage(LiveScoreboardUrl);
+        }
+
+        // PngByteQRCode avoids a System.Drawing dependency — straight PNG bytes into a WPF image.
+        private static BitmapImage BuildQrImage(string url)
+        {
+            using (var generator = new QRCodeGenerator())
+            {
+                var data = generator.CreateQrCode(url, QRCodeGenerator.ECCLevel.M);
+                var png = new PngByteQRCode(data);
+                byte[] bytes = png.GetGraphic(20);
+
+                var img = new BitmapImage();
+                using (var ms = new MemoryStream(bytes))
+                {
+                    img.BeginInit();
+                    img.CacheOption = BitmapCacheOption.OnLoad;
+                    img.StreamSource = ms;
+                    img.EndInit();
+                }
+                img.Freeze();
+                return img;
+            }
+        }
+
+        private void BtnOpenLiveView_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo { FileName = LiveScoreboardUrl, UseShellExecute = true });
+                Logger.Log("[LIVE][OPEN] " + LiveScoreboardUrl);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("[LIVE][FAIL] " + ex.Message);
+                MessageBox.Show("Could not open live view.\n\n" + ex.Message, "Live view",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void BtnClose_Click(object sender, RoutedEventArgs e) => Close();
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape) Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires up the last landing sidebar stub — **Live scoreboard** — porting the WinForms `QRCodeDialog` to a dark WPF window.

- Shows a QR code for the public live scoreboard (`https://stewmacrc.com`) on a white card (scan contrast), with the URL beneath.
- **Open live view** opens the site in the browser; **Close** / Escape dismisses.
- QR generated via `QRCoder`'s `PngByteQRCode` → straight PNG bytes into a WPF `BitmapImage` (no `System.Drawing` dependency).
- Added `QRCoder` 1.6.0 package reference to the WPF project.
- Landing "Live scoreboard" button now opens it.

## Test plan

- [x] Landing → Live scoreboard → dark window with scannable QR + URL  *(verified live)*
- [ ] Scan QR on a phone → opens stewmacrc.com
- [ ] Open live view → launches the site in the browser
- [ ] Close / Escape dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)