### PR TITLE
feat(wpf): distinct window edges — contrast border + rounded corners/shadow

### DIFF
--- a/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassConfigDialog.xaml
@@ -17,7 +17,8 @@
                       UseAeroCaptionButtons="False"/>
     </WindowChrome.WindowChrome>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>

--- a/src/RCDragManagerProd.WPF/Dialogs/MessageDialog.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/MessageDialog.xaml.cs
@@ -15,6 +15,7 @@ namespace RCDragManagerProd.WPF.Dialogs
         private MessageDialog(Window owner, Kind kind, string title, string message, bool destructive)
         {
             InitializeComponent();
+            WindowSizing.RoundCorners(this);
             Owner = owner ?? ActiveOwner();
             if (Owner == null) WindowStartupLocation = WindowStartupLocation.CenterScreen;
 

--- a/src/RCDragManagerProd.WPF/Dialogs/TextSummaryWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/TextSummaryWindow.xaml
@@ -16,7 +16,8 @@
                       ResizeBorderThickness="5" UseAeroCaptionButtons="False"/>
     </WindowChrome.WindowChrome>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>

--- a/src/RCDragManagerProd.WPF/Dialogs/TextSummaryWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/TextSummaryWindow.xaml.cs
@@ -8,6 +8,7 @@ namespace RCDragManagerProd.WPF.Dialogs
         public TextSummaryWindow(string title, string body)
         {
             InitializeComponent();
+            WindowSizing.RoundCorners(this);
             Title = title;
             LblTitle.Text = title;
             TxtBody.Text = body;

--- a/src/RCDragManagerProd.WPF/Resources/Theme.xaml
+++ b/src/RCDragManagerProd.WPF/Resources/Theme.xaml
@@ -29,6 +29,7 @@
     <SolidColorBrush x:Key="Brush.Border"         Color="{DynamicResource C.Border}"/>
     <SolidColorBrush x:Key="Brush.BorderSubtle"   Color="{DynamicResource C.BorderSubtle}"/>
     <SolidColorBrush x:Key="Brush.BorderEmphasis" Color="{DynamicResource C.BorderEmphasis}"/>
+    <SolidColorBrush x:Key="Brush.WindowEdge"     Color="{DynamicResource C.WindowEdge}"/>
 
     <!-- Corner radii -->
     <CornerRadius x:Key="Radius.Card">10</CornerRadius>

--- a/src/RCDragManagerProd.WPF/ThemeManager.cs
+++ b/src/RCDragManagerProd.WPF/ThemeManager.cs
@@ -46,6 +46,7 @@ namespace RCDragManagerProd.WPF
                 ["C.Border"]         = ("#17FFFFFF", "#14000000"),
                 ["C.BorderSubtle"]   = ("#0FFFFFFF", "#0A000000"),
                 ["C.BorderEmphasis"] = ("#252525", "#D0CEC9"),
+                ["C.WindowEdge"]     = ("#3C3C3C", "#C7C4BE"),
             };
 
         public static AppTheme FromSetting() =>

--- a/src/RCDragManagerProd.WPF/WindowSizing.cs
+++ b/src/RCDragManagerProd.WPF/WindowSizing.cs
@@ -27,11 +27,41 @@ namespace RCDragManagerProd.WPF
 
                 var hwnd = new WindowInteropHelper(w).Handle;
                 HwndSource.FromHwnd(hwnd)?.AddHook(WndProc);
+                RoundCornersHwnd(hwnd);
             }
 
             if (w.IsLoaded) Apply();
             else w.SourceInitialized += (_, __) => Apply();
         }
+
+        /// <summary>Rounds the window corners (and lets DWM cast its drop shadow) on
+        /// Windows 11. No-op on older Windows. For dialogs that don't call FitToScreen.</summary>
+        public static void RoundCorners(Window w)
+        {
+            void Apply()
+            {
+                RoundCornersHwnd(new WindowInteropHelper(w).Handle);
+            }
+            if (w.IsLoaded) Apply();
+            else w.SourceInitialized += (_, __) => Apply();
+        }
+
+        private const int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
+        private const int DWMWCP_ROUND = 2;
+
+        private static void RoundCornersHwnd(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero) return;
+            try
+            {
+                int pref = DWMWCP_ROUND;
+                DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref pref, sizeof(int));
+            }
+            catch { /* pre-Win11 — ignore */ }
+        }
+
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int value, int size);
 
         // ── Constrain maximize to the monitor work area ─────────────────────────
 

--- a/src/RCDragManagerProd.WPF/Windows/DriverManagerWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/DriverManagerWindow.xaml
@@ -16,7 +16,8 @@
                       UseAeroCaptionButtons="False"/>
     </WindowChrome.WindowChrome>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>

--- a/src/RCDragManagerProd.WPF/Windows/DriverStatsWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/DriverStatsWindow.xaml
@@ -17,7 +17,8 @@
                       UseAeroCaptionButtons="False"/>
     </WindowChrome.WindowChrome>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>

--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml
@@ -18,7 +18,8 @@
                       UseAeroCaptionButtons="False"/>
     </WindowChrome.WindowChrome>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>

--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
@@ -17,6 +17,7 @@ namespace RCDragManagerProd.WPF.Windows
         {
             _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
             InitializeComponent();
+            WindowSizing.RoundCorners(this);
 
             var driverRepo = new DriverRepository(connectionString);
             var sessionRepo = new RaceSessionRepository(connectionString);

--- a/src/RCDragManagerProd.WPF/Windows/LiveScoreboardWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LiveScoreboardWindow.xaml.cs
@@ -17,6 +17,7 @@ namespace RCDragManagerProd.WPF.Windows
         public LiveScoreboardWindow()
         {
             InitializeComponent();
+            WindowSizing.RoundCorners(this);
             UrlText.Text = LiveScoreboardUrl;
             QrImage.Source = BuildQrImage(LiveScoreboardUrl);
         }

--- a/src/RCDragManagerProd.WPF/Windows/LoadSessionWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/LoadSessionWindow.xaml
@@ -16,7 +16,8 @@
                       UseAeroCaptionButtons="False"/>
     </WindowChrome.WindowChrome>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>

--- a/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml
@@ -48,7 +48,8 @@
         </Style>
     </Window.Resources>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>

--- a/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml
@@ -16,7 +16,8 @@
                       UseAeroCaptionButtons="False"/>
     </WindowChrome.WindowChrome>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>

--- a/src/RCDragManagerProd.WPF/Windows/SettingsWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/SettingsWindow.xaml.cs
@@ -17,6 +17,7 @@ namespace RCDragManagerProd.WPF.Windows
         public SettingsWindow()
         {
             InitializeComponent();
+            WindowSizing.RoundCorners(this);
             _originalTheme = AppSettings.Theme;
             RbDark.IsChecked = !string.Equals(_originalTheme, "Light", StringComparison.OrdinalIgnoreCase);
             RbLight.IsChecked = string.Equals(_originalTheme, "Light", StringComparison.OrdinalIgnoreCase);

--- a/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml
@@ -16,7 +16,8 @@
                       UseAeroCaptionButtons="False"/>
     </WindowChrome.WindowChrome>
 
-    <Border Background="{StaticResource Brush.Background}">
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="38"/>


### PR DESCRIPTION
## Summary

Windows were blending into each other when stacked (a dark borderless window over the dark landing). This gives every window a clear edge so the top one reads as separate from what's behind.

- **Contrast edge border** — new themed `Brush.WindowEdge` (`#3C3C3C` dark / `#C7C4BE` light) applied as a 1px border on every window's root, replacing the near-invisible faint border.
- **Rounded corners + drop shadow** — `WindowSizing` now sets the Win11 DWM corner preference (`DWMWA_WINDOW_CORNER_PREFERENCE`), which rounds the borderless windows and lets DWM cast its standard drop shadow. Applied via `FitToScreen` (big windows) and a new `RoundCorners` helper (landing, settings, live scoreboard, summary, message dialog). No-op on pre-Win11.

## Test plan

- [x] Windows show a visible edge against the window behind  *(verified)*
- [x] Corners rounded with a drop shadow on Win11  *(verified)*
- [ ] Looks right in both dark and light themes
- [ ] Maximize still clamps to the work area (footers visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)