### PR TITLE
fix(wpf): live-broadcast config + result/completion logging (from test-log review)

### DIFF
--- a/src/RCDragManagerProd.WPF/App.config
+++ b/src/RCDragManagerProd.WPF/App.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+	</startup>
+
+	<!-- Live-broadcast settings are read via ConfigurationManager.AppSettings by
+	     LiveApiClient, so they must live in the running exe's config. Mirrors the
+	     WinForms project's App.config so live broadcast works from the WPF app. -->
+	<appSettings>
+		<add key="LiveUpdateEnabled" value="true" />
+		<add key="LiveUpdateUrl" value="https://stewmacrc.com/api/update" />
+		<add key="ApiKey" value="86561451-e7cf-4c01-87f1-0ae7e34e26d0" />
+	</appSettings>
+</configuration>

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
@@ -252,6 +252,7 @@ namespace RCDragManagerProd.WPF.Views
 
             var winner = summary.Winner?.Name ?? "N/A";
             var runnerUp = summary.RunnerUp?.Name ?? "N/A";
+            Logger.Log($"[RESULT][EVENT] '{summary.EventName}' complete — winner={winner}, runner-up={runnerUp}, matches={summary.TotalMatches}");
             MessageDialog.Info(Host,
                 $"Event: {summary.EventName}\nWinner: {winner}\nRunner-up: {runnerUp}\nMatches: {summary.TotalMatches}",
                 "Event complete");
@@ -444,11 +445,14 @@ namespace RCDragManagerProd.WPF.Views
                 return;
             }
 
+            var winner = _controller.GetWinner(matchId);
+            var loser = _controller.GetLoser(matchId);
+            var round = _controller.GetMatch(matchId)?.RoundLabel ?? "?";
+            Logger.Log($"[RESULT] M{matchId} ({round}): {winner?.Name ?? "?"} defeated {loser?.Name ?? "BYE"}");
+
             // In hosted mode the multi-class window records win/loss stats on completion.
             if (IsHostedMode) return;
 
-            var winner = _controller.GetWinner(matchId);
-            var loser = _controller.GetLoser(matchId);
             if (winner != null && loser != null && !IsBye(winner.Name) && !IsBye(loser.Name))
                 PersistStats(winner, loser, matchId);
         }

--- a/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
@@ -164,6 +164,7 @@ namespace RCDragManagerProd.WPF.Windows
             catch (Exception ex) { Logger.Log($"[WPF][MultiClass][STATS] {ex}"); }
 
             var className = _multiEvent.ClassSessions[classIndex].ClassType;
+            Logger.Log($"[RESULT][CLASS] '{className}' complete — winner={summary.Winner?.Name ?? "N/A"}, runner-up={summary.RunnerUp?.Name ?? "N/A"}");
             MessageDialog.Info(this,
                 $"Class: {className}\nWinner: {summary.Winner?.Name ?? "N/A"}\nRunner-up: {summary.RunnerUp?.Name ?? "N/A"}",
                 "Class complete");
@@ -172,7 +173,10 @@ namespace RCDragManagerProd.WPF.Windows
             UpdateAllTabStates();
 
             if (_completed.Count == _controllers.Count)
+            {
+                Logger.Log($"[RESULT][EVENT] '{_multiEvent.EventName}' complete — all {_controllers.Count} classes finished");
                 ShowCombinedSummary();
+            }
         }
 
         private void ShowCombinedSummary()


### PR DESCRIPTION
## Summary

Two findings from reviewing a full end-to-end test run's log.

### 1. Live broadcast couldn't authenticate (bug)
The run logged `[LIVE][FAIL] Missing config key ApiKey.` **51 times**. `LiveApiClient` reads credentials via `ConfigurationManager.AppSettings["ApiKey"]` / `["LiveUpdateUrl"]` — from the running exe's `.config`. Those keys only existed in the WinForms project's `App.config`; the WPF project (now the shipped app) had **no `App.config`**, so they were null.

Fix: added `App.config` to `RCDragManagerProd.WPF` mirroring the WinForms live-broadcast keys. Verified the build emits `RCDragManagerProd.WPF.exe.config` containing them.

### 2. Logging parity (polish)
The WPF console wasn't emitting the `[RESULT] …` and completion log lines the old WinForms console did, so the log showed `[RESULT]` count = 0 even though winners advanced. Added back:
- `[RESULT] M{id} ({round}): {winner} defeated {loser}` on each winner submit
- `[RESULT][CLASS]` / `[RESULT][EVENT]` on class and event completion (standalone + multi-class)

> The rest of the run was clean — a full multi-class event (brackets → rounds → losers bracket → finals → standings → stats recompute → saves) logged zero errors, exceptions, or rejects.

## Test plan

- [ ] Run an event with Live Broadcast enabled → no `[LIVE][FAIL] Missing config key ApiKey`; updates reach stewmacrc.com
- [ ] Log now shows `[RESULT] …` per match and `[RESULT][EVENT]` on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)