### PR TITLE
fix(live): show all classes on live site as soon as event starts

### DIFF
--- a/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
@@ -99,6 +99,16 @@ namespace RCDragManagerProd.WPF.Windows
                 try { c.RestoreFromSave(); }
                 catch (Exception ex) { Logger.Log($"[WPF][RESUME] {ex}"); }
             }
+
+            // Announce every class to the live site as soon as the event opens, so all
+            // classes are visible immediately — classes without a bracket yet show as
+            // "waiting" rather than being absent until their first round is generated.
+            foreach (var c in _controllers)
+            {
+                try { c.BroadcastLiveSnapshot("EventStarted"); }
+                catch (Exception ex) { Logger.Log($"[WPF][LIVE][INIT] {ex}"); }
+            }
+
             UpdateAllTabStates();
         }
 

--- a/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/RaceConsoleWindow.xaml.cs
@@ -16,6 +16,14 @@ namespace RCDragManagerProd.WPF.Windows
             _view = new RaceConsoleView(controller, connectionString);
             ViewHost.Child = _view;
             Closed += (_, __) => _view.Teardown();
+
+            // Show the event on the live site as soon as the console opens, even before
+            // a bracket is generated (mirrors the multi-class window behaviour).
+            Loaded += (_, __) =>
+            {
+                try { controller.BroadcastLiveSnapshot("EventStarted"); }
+                catch { /* live broadcast is best-effort */ }
+            };
         }
 
         private void BtnMinimize_Click(object sender, RoutedEventArgs e) => WindowState = WindowState.Minimized;

--- a/src/RCDragManagerProd/AppServices/MultiClassSetupService.cs
+++ b/src/RCDragManagerProd/AppServices/MultiClassSetupService.cs
@@ -155,12 +155,21 @@ namespace RCDragManagerProd.AppServices
                 EventDate    = date.Date
             };
 
+            // All classes in a multi-class event share one EventId. The live server
+            // buckets classes by EventName but treats a push whose EventId differs
+            // from the last one it saw as a *new session* and clears the whole bucket
+            // (all sibling classes). Giving every class the same EventId keeps them
+            // together on the live site, while a genuinely new event still gets a
+            // fresh shared id that correctly clears stale state.
+            var sharedEventId = Guid.NewGuid();
+
             foreach (var cc in classesList)
             {
                 bool isRR = string.Equals(cc.RaceType, RaceTypes.RoundRobin, StringComparison.OrdinalIgnoreCase);
 
                 var session = new RaceSession
                 {
+                    EventId           = sharedEventId,
                     EventName         = multiEvent.EventName,
                     EventDate         = multiEvent.EventDate,
                     RaceType          = cc.RaceType ?? RaceTypes.RoundRobin,

--- a/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
@@ -110,6 +110,66 @@ namespace RCDragManagerProd.Controllers
             };
         }
 
+        /// <summary>
+        /// Pushes the current live state if a bracket exists, otherwise a roster-only
+        /// "initial" state so the class still appears on the live site before any bracket
+        /// is generated. Called when the race window opens so every class of an event is
+        /// visible the moment the event starts, regardless of which classes have brackets.
+        /// </summary>
+        public void BroadcastLiveSnapshot(string reason)
+        {
+            if (_engine != null)
+                QueueLiveUpdate(reason);
+            else
+                BroadcastInitialState(reason);
+        }
+
+        /// <summary>
+        /// Sends a minimal state for this class (event/class identity, no matches) so the
+        /// class shows up on the live site before its bracket is generated. Built from the
+        /// session alone because the engine does not exist until the first bracket.
+        /// </summary>
+        private void BroadcastInitialState(string reason)
+        {
+            try
+            {
+                if (!AppSettings.LiveBroadcastEnabled)
+                {
+                    Logger.Log("[LIVE][SKIP] reason=" + reason + " disabled=true");
+                    return;
+                }
+                if (_session == null || _session.EventDate == default)
+                {
+                    Logger.Log("[LIVE][SKIP] reason=" + reason + " initialState session/date invalid");
+                    return;
+                }
+
+                var eventName = string.IsNullOrWhiteSpace(_session.EventName) ? "Quick Session" : _session.EventName;
+                var dto = new LiveRaceUpdateDto
+                {
+                    EventId      = _session.EventId.ToString("N"),
+                    EventName    = eventName,
+                    EventDate    = _session.EventDate.ToString("yyyy-MM-dd"),
+                    ClassType    = _session.ClassType,
+                    RaceType     = _session.RaceType,
+                    CurrentRound = string.Empty,
+                    NextUp       = string.Empty,
+                    Matches      = new List<LiveMatchDto>(),
+                    Winners      = new List<LiveWinnerDto>(),
+                    RRStandings  = null,
+                    DialInLocked = false
+                };
+
+                Logger.Log("[LIVE][BUILD] reason=" + reason + " initialState class=" +
+                           (string.IsNullOrWhiteSpace(dto.ClassType) ? "(none)" : dto.ClassType));
+                _ = _liveApiClient.SendAsync(dto);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("[LIVE][SKIP] reason=" + reason + " initialState exception=" + ex.Message);
+            }
+        }
+
         private void QueueLiveUpdate(string reason)
         {
             try

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -171,8 +171,12 @@ namespace RCDragManagerProd.Controllers
 
             _winners.Clear();
             PushFullRefresh();
-            var resetEventName = string.IsNullOrWhiteSpace(_session.EventName) ? "Quick Session" : _session.EventName;
-            _ = _liveApiClient.ResetAsync(_session.EventId.ToString("N"), _session.ClassType, resetEventName);
+            // NOTE: no live /api/reset here. Reset is event-wide on the server (it clears
+            // every class in the event bucket), so resetting on each class's bracket
+            // generation wiped sibling classes off the live site. The QueueLiveUpdate
+            // below fully overwrites this class's state on the server (matches + cleared
+            // winners), so a per-class reset is unnecessary; stale state from a previous
+            // event run is cleared by the server's new-session guard (shared EventId).
             QueueLiveUpdate("GenerateBracket");
         }
 


### PR DESCRIPTION
## Problem

On the live scoreboard, a multi-class event only ever showed **one class** (the last one touched) — e.g. three classes in the desktop app (pro / random / robin) but a single ROBIN tab on the site.

Two server-side clobber paths, both triggered from the desktop, were wiping sibling classes:

1. **GenerateBracket fired an event-wide reset.** It called `/api/reset`, and the server's `ClearEvent` clears the *entire* event bucket (all classes); then only the just-generated class got re-pushed.
2. **Each class had its own random `EventId`.** The server treats a push whose `EventId` differs from the last one it saw as a new session and clears the whole bucket — so every per-class push erased its siblings.

On top of that, a class wasn't broadcast at all until its first bracket was generated, so it couldn't appear "as soon as the event starts".

## Fix (desktop-only — no live-server redeploy needed)

- **Shared `EventId` across all classes in an event** (`MultiClassSetupService.StartEvent`) so the server groups them. A genuinely new event still gets a fresh id that correctly clears stale state.
- **Removed the per-bracket event-wide reset** (`RaceController.RoundFlow.Core`). The per-class update already fully overwrites that class's state, so the reset was redundant and was the thing erasing siblings.
- **Broadcast every class when the race window opens** (`RaceController.BroadcastLiveSnapshot` / `BroadcastInitialState`, wired from `MultiClassRaceWindow` and `RaceConsoleWindow`). Classes without a bracket yet render as "No bracket data available yet" instead of being absent.

The server and frontend already render an empty class gracefully, so no changes were needed in the live-server repo.

## Testing

- Full solution builds clean (Debug, all 3 projects).
- Test suite: 226 pass; the 50 failures are a pre-existing command-line `vstest` binding-redirect issue (`System.Threading.Tasks.Extensions`) unrelated to this change — they pass in VS Test Explorer.
- Manual: start a fresh multi-class event → all classes appear as tabs on the site immediately, and stay visible as each bracket is generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
