### PR TITLE
chore(installer): package the WPF app for the v2.0.0 release

### DIFF
--- a/Installer/RCDragManager.iss
+++ b/Installer/RCDragManager.iss
@@ -1,7 +1,7 @@
 #define MyAppName        "RC Drag Manager"
 #define MyAppPublisher   "Stewart McMillan"
 #define MyAppURL         "https://github.com/stewmac570/RC-Drag-Manager"
-#define MyAppExeName     "RCDragManagerProd.exe"
+#define MyAppExeName     "RCDragManagerProd.WPF.exe"
 #define MyCompanyAppData "RC_Drag_Manager"
 #define MyAppId          "{{A41B3B69-3B2F-4C2F-9D0A-3A2C3F1F8F8B}}"
 

--- a/Installer/build-installer.ps1
+++ b/Installer/build-installer.ps1
@@ -52,13 +52,15 @@ function Get-ISCCPath {
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent $scriptDir
-$projectPath = Join-Path $repoRoot "src\RCDragManagerProd\RCDragManagerProd.csproj"
-$releaseDir = Join-Path $repoRoot "src\RCDragManagerProd\bin\Release"
+# v2.0.0: the shipped app is the WPF UI. Build the WPF project (it pulls in the
+# engine project via ProjectReference) and package its net48 Release output.
+$projectPath = Join-Path $repoRoot "src\RCDragManagerProd.WPF\RCDragManagerProd.WPF.csproj"
+$releaseDir = Join-Path $repoRoot "src\RCDragManagerProd.WPF\bin\Release\net48"
 $payloadDir = Join-Path $scriptDir "Payload"
 $outputDir = Join-Path $scriptDir "output"
 $issPath = Join-Path $scriptDir "RCDragManager.iss"
 $payloadReadme = Join-Path $payloadDir "README.txt"
-$exePath = Join-Path $releaseDir "RCDragManagerProd.exe"
+$exePath = Join-Path $releaseDir "RCDragManagerProd.WPF.exe"
 
 Write-Step "Locating build tools"
 $msbuildPath = Get-MSBuildPath
@@ -76,12 +78,20 @@ if (Test-Path $outputDir) {
 New-Item -ItemType Directory -Path $payloadDir | Out-Null
 New-Item -ItemType Directory -Path $outputDir | Out-Null
 
+# Clear the WPF Release output so stale files are never packaged.
+if (Test-Path $releaseDir) {
+    Remove-Item $releaseDir -Recurse -Force
+}
+
 Write-Step "Building Release output"
+# -restore is required: the WPF project is SDK-style and needs its NuGet
+# PackageReferences restored before Build (no separate Clean target, which would
+# drop the restore assets).
 if ($msbuildPath -eq "dotnet msbuild") {
-    & dotnet msbuild $projectPath /t:Clean,Build /p:Configuration=Release /p:Platform="AnyCPU" /nologo /verbosity:minimal
+    & dotnet msbuild $projectPath -restore /t:Build /p:Configuration=Release /p:Platform="AnyCPU" /nologo /verbosity:minimal
 }
 else {
-    & $msbuildPath $projectPath /t:Clean,Build /p:Configuration=Release /p:Platform="AnyCPU" /nologo /verbosity:minimal
+    & $msbuildPath $projectPath -restore /t:Build /p:Configuration=Release /p:Platform="AnyCPU" /nologo /verbosity:minimal
 }
 
 if (-not (Test-Path $exePath)) {

--- a/src/RCDragManagerProd.WPF/RCDragManagerProd.WPF.csproj
+++ b/src/RCDragManagerProd.WPF/RCDragManagerProd.WPF.csproj
@@ -8,6 +8,9 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>disable</Nullable>
     <ApplicationIcon />
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Make the installer ship the **WPF app** for the v2.0.0 release. It was still building the legacy WinForms project and launching `RCDragManagerProd.exe`.

## Changes

- **`Installer/build-installer.ps1`** — builds `src\RCDragManagerProd.WPF` (pulls in the engine via `ProjectReference`) and packages its `bin\Release\net48` output. Added `-restore` (the WPF project is SDK-style) and a release-dir clean so stale files are never bundled.
- **`Installer/RCDragManager.iss`** — launches `RCDragManagerProd.WPF.exe`.
- **WPF csproj** — version set to `2.0.0` (was defaulting to `1.0.0.0`), so the setup is named/versioned correctly.

## Verified

`Installer/build-installer.ps1` runs clean and produces `RC-Drag-Manager-Setup-2.0.0.0.exe` containing the WPF exe + its live-broadcast config, the engine, SQLite native interop (x86/x64), and assets.

This is the installer that will be attached to the v2.0.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
