### PR TITLE
chore(wpf): remove NPRC Australia line from landing header

### DIFF
--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml
@@ -63,11 +63,6 @@
                                        FontSize="{StaticResource FontSize.Xxl}"
                                        FontWeight="Medium"
                                        Foreground="{StaticResource Brush.TextPrimary}"/>
-                            <TextBlock Text="NPRC Australia"
-                                       FontSize="12" FontWeight="Medium"
-                                       Foreground="{StaticResource Brush.Primary}"
-                                       VerticalAlignment="Center"
-                                       Margin="12,0,0,0"/>
                         </StackPanel>
                         <TextBlock Text="Race director console"
                                    FontSize="{StaticResource FontSize.Xs}"


### PR DESCRIPTION
Removes the secondary **NPRC Australia** label next to the app title on the landing page. Header now reads just *RC Drag Manager* / *Race director console*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)