### PR TITLE
fix(race): keep the class's race type after a race reset

### DIFF
--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -41,6 +41,11 @@ namespace RCDragManagerProd.Controllers
 
             // normalize + default to RR if empty
             var rt = (raceType ?? _session?.RaceType ?? string.Empty).Trim();
+            // Reset() blanks _session.RaceType, so a reset+regenerate arrives here
+            // with no race type. Fall back to the class's original mode before
+            // defaulting, otherwise every reset silently became a Round Robin.
+            if (string.IsNullOrWhiteSpace(rt))
+                rt = (_session?.OriginalRaceType ?? string.Empty).Trim();
             if (string.IsNullOrWhiteSpace(rt))
             {
                 rt = RaceTypes.RoundRobin;


### PR DESCRIPTION
## Problem

Picking a non-RR race type (e.g. Pro Ladder), generating the bracket, then **Reset** → regenerate produced a **Round Robin** bracket instead of the picked type.

## Cause

`Reset()` blanks `_session.RaceType` (an existing reset test asserts this), so the regenerate reached `GenerateBracket` with no race type and hit the Round Robin default fallback.

## Fix

`GenerateBracket` now falls back to `_session.OriginalRaceType` — the class's starting mode, which `Reset()` preserves — before defaulting to Round Robin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)