### PR TITLE
feat(wpf): add "send race to back of round" for more time

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerDeferMatchTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerDeferMatchTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Tests.Helpers;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// "Push to end of round" — sending the current race to the back of its round when a
+/// racer needs more time. Live-session ordering only; engines are never reordered.
+/// </summary>
+[TestClass]
+public class RaceControllerDeferMatchTests
+{
+    [TestMethod]
+    public void PushToEndOfRound_MovesCurrentMatchToBack_AndPromotesTheNextOne()
+    {
+        var controller = NewRandomEight();
+
+        var before = MatchIds(controller);
+        Assert.AreEqual(4, before.Count, "8-driver random R1 should have 4 matches");
+        var wasCurrent = before[0];
+
+        controller.PushCurrentMatchToEndOfRound();
+
+        var after = MatchIds(controller);
+        CollectionAssert.AreEquivalent(before, after, "no matches gained or lost");
+        Assert.AreEqual(wasCurrent, after[after.Count - 1], "pushed match is now last");
+        Assert.AreEqual(before[1], after[0], "the next match becomes current");
+    }
+
+    [TestMethod]
+    public void PushToEndOfRound_Twice_SecondPushGoesBehindTheFirst()
+    {
+        var controller = NewRandomEight();
+        var before = MatchIds(controller); // [a, b, c, d]
+
+        controller.PushCurrentMatchToEndOfRound(); // a → back: [b, c, d, a]
+        controller.PushCurrentMatchToEndOfRound(); // b → back: [c, d, a, b]
+
+        var after = MatchIds(controller);
+        Assert.AreEqual(before[2], after[0]); // c
+        Assert.AreEqual(before[3], after[1]); // d
+        Assert.AreEqual(before[0], after[2]); // a
+        Assert.AreEqual(before[1], after[3]); // b
+    }
+
+    [TestMethod]
+    public void PushToEndOfRound_IsNoOp_WhenOnlyOneMatchRemains()
+    {
+        var controller = NewRandomEight();
+
+        // Resolve all but the last match in the round.
+        var matches = controller.PeekUpcomingMatches(10).ToList();
+        for (int i = 0; i < matches.Count - 1; i++)
+            controller.SubmitWinner(matches[i].MatchId, firstOption: matches[i].Driver1 != null);
+
+        var remaining = controller.PeekUpcomingMatches(10).ToList();
+        Assert.AreEqual(1, remaining.Count);
+        var onlyId = remaining[0].MatchId;
+
+        controller.PushCurrentMatchToEndOfRound(); // nothing to run ahead of it → no-op
+
+        var after = controller.PeekUpcomingMatches(10).ToList();
+        Assert.AreEqual(1, after.Count);
+        Assert.AreEqual(onlyId, after[0].MatchId);
+    }
+
+    [TestMethod]
+    public void CanDeferChanged_TrueWithTwoPlusMatches_FalseWhenOneLeft()
+    {
+        var session = CreateSession("Random");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+
+        var signals = new List<bool>();
+        controller.CanDeferChanged += v => signals.Add(v);
+
+        controller.GenerateBracket("Random", TestDriverFactory.CreateRoundRobinPack(8));
+        Assert.IsTrue(signals.LastOrDefault(), "4 unraced matches → push is actionable");
+
+        var matches = controller.PeekUpcomingMatches(10).ToList();
+        for (int i = 0; i < matches.Count - 1; i++)
+            controller.SubmitWinner(matches[i].MatchId, firstOption: matches[i].Driver1 != null);
+
+        Assert.IsFalse(signals.LastOrDefault(), "one match left → push no longer actionable");
+    }
+
+    [TestMethod]
+    public void AdvanceRound_ClearsDeferral_NextRoundIsNaturalOrder()
+    {
+        var controller = NewRandomEight();
+
+        controller.PushCurrentMatchToEndOfRound(); // defer something in R1
+
+        // Resolve the whole round and advance.
+        foreach (var m in controller.PeekUpcomingMatches(10).ToList())
+            controller.SubmitWinner(m.MatchId, firstOption: m.Driver1 != null);
+        controller.AdvanceRound();
+
+        Assert.AreEqual("R2", controller.GetActiveRoundLabel());
+        var r2 = MatchIds(controller);
+        var sorted = r2.OrderBy(id => id).ToList();
+        CollectionAssert.AreEqual(sorted, r2, "deferral does not carry into the next round");
+    }
+
+    private static RaceController NewRandomEight()
+    {
+        var session = CreateSession("Random");
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Random", TestDriverFactory.CreateRoundRobinPack(8));
+        Assert.AreEqual("R1", controller.GetActiveRoundLabel());
+        return controller;
+    }
+
+    private static List<int> MatchIds(RaceController controller) =>
+        controller.PeekUpcomingMatches(10).Select(m => m.MatchId).ToList();
+
+    private static RaceSession CreateSession(string raceType) => new RaceSession
+    {
+        EventName = "QA Defer Flow",
+        EventDate = new DateTime(2026, 3, 11, 8, 0, 0),
+        RaceType = raceType,
+        ClassType = "Heads Up"
+    };
+}

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml
@@ -316,6 +316,10 @@
                                 Content="—" Click="BtnWinner2_Click"
                                 MouseRightButtonUp="BtnWinner2_RightClick" IsEnabled="False"/>
                     </Grid>
+                    <Button x:Name="BtnMoreTime" Style="{StaticResource Style.Button.Toolbar}"
+                            Content="More time — send to back of round"
+                            Click="BtnMoreTime_Click" IsEnabled="False"
+                            HorizontalAlignment="Center" Margin="0,8,0,0"/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="4" VerticalAlignment="Center" Margin="16,0"

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
@@ -75,6 +75,7 @@ namespace RCDragManagerProd.WPF.Views
             _controller.NextMatchReady += OnNextMatchReady;
             _controller.WinnersUpdated += OnWinnersUpdated;
             _controller.CanAdvanceChanged += OnCanAdvanceChanged;
+            _controller.CanDeferChanged += OnCanDeferChanged;
             _controller.CanOfferBuybackChanged += OnCanOfferBuybackChanged;
             _controller.CanStartFinalsChanged += OnCanStartFinalsChanged;
             _controller.TournamentCompleted += OnTournamentCompleted;
@@ -92,6 +93,7 @@ namespace RCDragManagerProd.WPF.Views
                 _controller.NextMatchReady -= OnNextMatchReady;
                 _controller.WinnersUpdated -= OnWinnersUpdated;
                 _controller.CanAdvanceChanged -= OnCanAdvanceChanged;
+                _controller.CanDeferChanged -= OnCanDeferChanged;
                 _controller.CanOfferBuybackChanged -= OnCanOfferBuybackChanged;
                 _controller.CanStartFinalsChanged -= OnCanStartFinalsChanged;
                 _controller.TournamentCompleted -= OnTournamentCompleted;
@@ -218,6 +220,8 @@ namespace RCDragManagerProd.WPF.Views
             if (can) _controller.UnlockDialIn();
             UpdatePrimaryButtons();
         });
+
+        private void OnCanDeferChanged(bool can) => Run(() => BtnMoreTime.IsEnabled = can);
 
         private void OnCanOfferBuybackChanged(bool enabled) => Run(() =>
         {
@@ -490,6 +494,16 @@ namespace RCDragManagerProd.WPF.Views
             if (action == RaceConsolePrimaryAction.StartLosersBracket)
                 BtnBuybacks.IsEnabled = false;
             UpdatePrimaryButtons();
+        }
+
+        private void BtnMoreTime_Click(object sender, RoutedEventArgs e)
+        {
+            try { _raceConsole.PushCurrentMatchToEndOfRound(); }
+            catch (Exception ex)
+            {
+                Logger.Log($"[WPF][CONSOLE] PushCurrentMatchToEndOfRound failed: {ex}");
+                MessageDialog.Error(Host, "Couldn't move that race. Check the log.", "More time");
+            }
         }
 
         private void BtnNextRound_Click(object sender, RoutedEventArgs e)

--- a/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
@@ -168,6 +168,13 @@ namespace RCDragManagerProd.AppServices
         }
 
         /// <summary>
+        /// Pushes the current (next-up) race to the back of its round — used when a racer
+        /// needs more time. No-op when fewer than two races remain in the round. The order
+        /// is live-session only and is not persisted with the session.
+        /// </summary>
+        public void PushCurrentMatchToEndOfRound() => _controller.PushCurrentMatchToEndOfRound();
+
+        /// <summary>
         /// Whether a match's result can be edited: it must exist, already have a result, and be
         /// in the active round. Backs the validation the console's "Edit Match Result" handler
         /// did before opening the winner picker.

--- a/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs
@@ -36,9 +36,8 @@ namespace RCDragManagerProd.Controllers
             if (string.IsNullOrWhiteSpace(currentRound))
                 currentRound = _revealedRounds.LastOrDefault();
 
-            var nextMatch = EngineGetMatches(_engine)
-                .Where(m => _revealedRounds.Contains(m.RoundLabel) && !m.HasResult)
-                .OrderBy(m => m.MatchId)
+            var nextMatch = ApplyRaceOrder(
+                    EngineGetMatches(_engine).Where(m => _revealedRounds.Contains(m.RoundLabel) && !m.HasResult))
                 .FirstOrDefault();
 
             string nextUp = string.Empty;

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -175,6 +175,7 @@ namespace RCDragManagerProd.Controllers
             }
 
             _winners.Clear();
+            ClearDeferrals();
             PushFullRefresh();
             // NOTE: no live /api/reset here. Reset is event-wide on the server (it clears
             // every class in the event bucket), so resetting on each class's bracket
@@ -209,6 +210,9 @@ namespace RCDragManagerProd.Controllers
                 CanAdvanceChanged?.Invoke(false);
                 return;
             }
+
+            // Push-to-back ordering is scoped to a single round — drop it as we move on.
+            ClearDeferrals();
 
             if (_activeRound != null)
             {
@@ -275,15 +279,13 @@ namespace RCDragManagerProd.Controllers
         public void PushNextMatch()
         {
             EnsureReady();
+            PushDeferState();
 
             // In RR active-round mode, only the active round can supply the next match.
-            // In all other modes, use _revealedRounds as before.
-            var next = EngineGetMatches(_engine)
-                              .Where(m => (_activeRound != null
-                                               ? string.Equals(m.RoundLabel, _activeRound, StringComparison.OrdinalIgnoreCase)
-                                               : _revealedRounds.Contains(m.RoundLabel))
-                                          && !m.HasResult)
-                              .OrderBy(m => m.MatchId)
+            // In all other modes, use _revealedRounds as before. ApplyRaceOrder honours
+            // any "push to end of round" the operator has applied.
+            var next = ApplyRaceOrder(
+                              EngineGetMatches(_engine).Where(m => InActiveRaceScope(m) && !m.HasResult))
                               .FirstOrDefault();
 
             if (next == null)

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Defer.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Defer.cs
@@ -1,0 +1,107 @@
+// RaceController.RoundFlow.Defer.cs
+//
+// "Push to end of round" — when a racer needs more time, the Race Director can send
+// the current (next-up) match to the back of its round so the others run first.
+//
+// This is a controller-level ordering concern only: engines are never reordered
+// (they stay on the no-touch list). A per-round list of deferred match ids acts as a
+// secondary sort key applied wherever the within-round race order is read
+// (PushNextMatch, PeekUpcomingMatches, BuildCurrentBracketRows, the live "next up").
+//
+// Live-session only: the order is intentionally NOT persisted. A Save + reload
+// returns matches to their natural MatchId order.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using RCDragManagerProd.RaceEngines;
+using RCDragManagerProd.Logging;
+
+namespace RCDragManagerProd.Controllers
+{
+    public partial class RaceController
+    {
+        // Match ids the operator has pushed to the back of the current round, in the
+        // order they were pushed (first pushed = first among the deferred tail).
+        private readonly List<int> _deferredMatchIds = new List<int>();
+
+        /// <summary>Fires with true when the current round still has 2+ unraced matches
+        /// (so "push to end of round" can do something), false otherwise.</summary>
+        public event Action<bool> CanDeferChanged;
+
+        /// <summary>True when the match this round currently determines is racing in the
+        /// active round scope (RR active round, or any revealed round otherwise).</summary>
+        private bool InActiveRaceScope(EngineMatch m) =>
+            _activeRound != null
+                ? string.Equals(m.RoundLabel, _activeRound, StringComparison.OrdinalIgnoreCase)
+                : _revealedRounds.Contains(m.RoundLabel);
+
+        /// <summary>Applies the operator's "push to end of round" ordering: non-deferred
+        /// matches first (in MatchId order), then deferred matches in the order they were
+        /// pushed back. Stable, so callers that already filtered keep their other ordering.</summary>
+        internal IEnumerable<EngineMatch> ApplyRaceOrder(IEnumerable<EngineMatch> matches)
+        {
+            return matches
+                .OrderBy(m => _deferredMatchIds.Contains(m.MatchId) ? 1 : 0)
+                .ThenBy(m =>
+                {
+                    int i = _deferredMatchIds.IndexOf(m.MatchId);
+                    return i < 0 ? 0 : i;
+                })
+                .ThenBy(m => m.MatchId);
+        }
+
+        /// <summary>Sends the current (next-up) match to the back of its round. No-op when
+        /// fewer than two unraced matches remain (nothing to run ahead of it).</summary>
+        public void PushCurrentMatchToEndOfRound()
+        {
+            if (_engine == null)
+            {
+                Logger.Log("[CTRL][DEFER] PushCurrentMatchToEndOfRound ignored — no engine.");
+                return;
+            }
+
+            var unresolved = ApplyRaceOrder(
+                    EngineGetMatches(_engine).Where(m => InActiveRaceScope(m) && !m.HasResult))
+                .ToList();
+
+            if (unresolved.Count < 2)
+            {
+                Logger.Log("[CTRL][DEFER] PushCurrentMatchToEndOfRound ignored — fewer than 2 races left in round.");
+                return;
+            }
+
+            var current = unresolved[0];
+            _deferredMatchIds.Remove(current.MatchId); // re-add at the tail if already deferred
+            _deferredMatchIds.Add(current.MatchId);
+
+            Logger.Log($"[CTRL][DEFER] Pushed M{current.MatchId} ({current.RoundLabel}) to end of round. " +
+                       $"DeferOrder=[{string.Join(",", _deferredMatchIds)}]");
+
+            BracketRedrawn?.Invoke(BuildCurrentBracketRows());
+            PushNextMatch();              // re-points "Next Up" + refreshes CanDefer
+            QueueLiveUpdate("PushToEndOfRound");
+        }
+
+        /// <summary>Recomputes whether "push to end of round" is currently actionable.</summary>
+        internal void PushDeferState()
+        {
+            bool canDefer = false;
+            if (_engine != null)
+            {
+                int unresolved = EngineGetMatches(_engine).Count(m => InActiveRaceScope(m) && !m.HasResult);
+                canDefer = unresolved >= 2;
+            }
+            CanDeferChanged?.Invoke(canDefer);
+        }
+
+        /// <summary>Drops all push-to-back ordering. Called when the round advances or the
+        /// bracket is (re)generated/reset — deferrals are scoped to a single live round.</summary>
+        internal void ClearDeferrals()
+        {
+            if (_deferredMatchIds.Count == 0) return;
+            _deferredMatchIds.Clear();
+            Logger.Log("[CTRL][DEFER] Cleared deferrals.");
+        }
+    }
+}

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.View.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.View.cs
@@ -134,7 +134,7 @@ namespace RCDragManagerProd.Controllers
 
                     rows.Add(new PairingRow { IsHeader = true, RoundLabel = normalizedRound });
 
-                    foreach (var m in mList.Where(x => string.Equals(RoundLabels.Normalize(x.RoundLabel), normalizedRound, StringComparison.OrdinalIgnoreCase)))
+                    foreach (var m in ApplyRaceOrder(mList.Where(x => string.Equals(RoundLabels.Normalize(x.RoundLabel), normalizedRound, StringComparison.OrdinalIgnoreCase))))
                     {
                         string leftName;
                         string rightName;
@@ -222,12 +222,8 @@ namespace RCDragManagerProd.Controllers
                 if (_engine == null || count <= 0) return Array.Empty<EngineMatch>();
 
                 // In RR active-round mode, show upcoming matches for the active round only.
-                var list = EngineGetMatches(_engine)
-                                  .Where(m => (_activeRound != null
-                                                   ? string.Equals(m.RoundLabel, _activeRound, StringComparison.OrdinalIgnoreCase)
-                                                   : _revealedRounds.Contains(m.RoundLabel))
-                                              && !m.HasResult)
-                                  .OrderBy(m => m.MatchId)
+                var list = ApplyRaceOrder(
+                                  EngineGetMatches(_engine).Where(m => InActiveRaceScope(m) && !m.HasResult))
                                   .Take(count)
                                   .ToList();
 

--- a/src/RCDragManagerProd/Controllers/RaceController.Session.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Session.cs
@@ -25,6 +25,7 @@ namespace RCDragManagerProd.Controllers
             _revealedRounds.Clear();
             _activeRound = null;
             _winners.Clear();
+            ClearDeferrals();
 
             _matchResult.Clear();
             _rrMatchesSnapshot = null;
@@ -43,6 +44,7 @@ namespace RCDragManagerProd.Controllers
             NextMatchReady?.Invoke(null);
             CanAdvanceChanged?.Invoke(false);
             CanPickWinnerChanged?.Invoke(false);
+            CanDeferChanged?.Invoke(false);
 
             Logger.Log("[RESET] Controller cleared — ready for new class.");
         }

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Controllers\RaceController.SaveClose.cs" />
     <Compile Include="Controllers\RaceController.Results.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Core.cs" />
+    <Compile Include="Controllers\RaceController.RoundFlow.Defer.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Finals.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Losers.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.View.cs" />


### PR DESCRIPTION
## What & why

When a racer needs more time, the Race Director can now push the **current race to the end of its round** so the other pairings run first. One button, repeatable (press again to push the next one back too).

Per the agreed scope: **one-way send-to-back**, **live-session only** (the order is intentionally not persisted — a save + reload returns to natural order).

## How it works (within the architecture)

Ordering stays a controller concern — **engines are never reordered** (they're on the no-touch list).

- New `RaceController.RoundFlow.Defer.cs`: a per-round deferred-match-id list + `ApplyRaceOrder()` (non-deferred first by MatchId, then deferred in push order).
- Every within-round order read now routes through it: `PushNextMatch`, `PeekUpcomingMatches`, `BuildCurrentBracketRows`, and the live "Next Up" — so the console, the on-deck/in-the-hole rail, and the phone scoreboard stay consistent.
- `PushCurrentMatchToEndOfRound()` is a no-op when fewer than two races remain; a new `CanDeferChanged` event disables the button in that case.
- Deferrals clear on round advance / regenerate / reset (they're scoped to one live round).
- Works across all modes (Pro Ladder, Round Robin, Random, Losers Bracket, Finals) and in multi-class tabs.

UI: a "More time — send to back of round" button under the winner buttons → `RaceConsoleService` → controller. The view only forwards actions and reacts to events (no logic), per the rules.

## Tests

`RaceControllerDeferMatchTests` (5, all passing): move-to-back, repeated-push order, single-match no-op, `CanDeferChanged` toggling, and clear-on-advance. Solution builds clean.

> Note: running the full suite via raw `vstest.console` shows 50 pre-existing failures, all the same `System.Threading.Tasks.Extensions` binding-redirect load error in serialization paths (unrelated to this change); they pass in VS Test Explorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
