### PR TITLE
[codex] Preserve race data and snapshot results

### DIFF
--- a/src/RCDragManagerProd.Tests/MultiClassFeatureTests.cs
+++ b/src/RCDragManagerProd.Tests/MultiClassFeatureTests.cs
@@ -132,15 +132,22 @@ namespace RCDragManagerProd.Tests
         }
 
         [TestMethod]
-        public void SaveTwice_CreatesTwoRows()
+        public void SaveTwice_UpdatesExistingRow()
         {
             var evt = BuildSampleEvent(classCount: 1);
 
             _repo.SaveEvent(evt);
-            _repo.SaveEvent(evt); // second save — append-only, creates new row
+            var firstId = evt.Id;
+            evt.EventName = "Updated Event";
+            _repo.SaveEvent(evt);
 
             var all = _repo.GetAllEvents();
-            Assert.AreEqual(2, all.Count);
+            var loaded = _repo.LoadEvent(firstId);
+
+            Assert.AreEqual(1, all.Count);
+            Assert.AreEqual(firstId, evt.Id);
+            Assert.AreEqual(firstId, loaded.Id);
+            Assert.AreEqual("Updated Event", loaded.EventName);
         }
 
         [TestMethod]

--- a/src/RCDragManagerProd.Tests/RaceSessionRepositoryTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceSessionRepositoryTests.cs
@@ -91,6 +91,97 @@ public class RaceSessionRepositoryTests
         Assert.IsFalse(summariesAfterDelete.Any(s => s.Id == savedId));
     }
 
+    [TestMethod]
+    public void SaveSession_WhenAlreadyPersisted_UpdatesExistingRow()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repository = new RaceSessionRepository(db.ConnectionString);
+
+        var session = CreateSession(
+            "QA Update Session",
+            new DateTime(2026, 3, 2, 9, 0, 0),
+            "Pro Ladder");
+
+        var firstId = repository.SaveSession(session);
+        session.EventName = "QA Updated Session";
+        session.DriverEntries[0].DialIn = 4.125;
+
+        var secondId = repository.SaveSession(session);
+        var all = repository.GetAllSessions();
+        var loaded = repository.LoadSession(firstId);
+
+        Assert.AreEqual(firstId, secondId);
+        Assert.AreEqual(1, all.Count, "Saving an existing session must not insert a stale duplicate");
+        Assert.AreEqual("QA Updated Session", loaded.EventName);
+        Assert.AreEqual(4.125, loaded.DriverEntries[0].DialIn);
+        Assert.AreEqual(firstId, loaded.Id);
+    }
+
+    [TestMethod]
+    public void ControllerSaveSession_PreservesDialInsAndEntryMetadata()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repository = new RaceSessionRepository(db.ConnectionString);
+
+        var session = CreateSession(
+            "QA Dial-In Preservation",
+            new DateTime(2026, 3, 2, 10, 0, 0),
+            "Pro Ladder");
+        for (int i = 0; i < session.DriverEntries.Count; i++)
+            session.DriverEntries[i].DialIn = 4.000 + (i * 0.100);
+
+        var controller = new RCDragManagerProd.Controllers.RaceController(
+            session,
+            new NoOpStandingsDialogService());
+        controller.GenerateBracket("Pro Ladder", session.Drivers);
+        controller.UpdateDriverDialIn(session.Drivers[1].Id, 4.555);
+        controller.SaveProgress();
+
+        var id = repository.SaveSession(session);
+        var loaded = repository.LoadSession(id);
+
+        Assert.AreEqual(4.000, loaded.DriverEntries[0].DialIn);
+        Assert.AreEqual(4.555, loaded.DriverEntries[1].DialIn);
+        Assert.AreEqual(4.200, loaded.DriverEntries[2].DialIn);
+        Assert.AreEqual(4.300, loaded.DriverEntries[3].DialIn);
+        Assert.AreEqual(500, loaded.DriverEntries[0].CarID);
+        Assert.AreEqual("Car 1", loaded.DriverEntries[0].CarName);
+        Assert.AreEqual(1, loaded.DriverEntries[0].Seed);
+    }
+
+    [TestMethod]
+    public void ControllerSaveSession_PersistsProLadderResultSnapshot()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repository = new RaceSessionRepository(db.ConnectionString);
+
+        var session = CreateSession(
+            "QA Result Snapshot",
+            new DateTime(2026, 3, 2, 11, 0, 0),
+            "Pro Ladder");
+        var controller = new RCDragManagerProd.Controllers.RaceController(
+            session,
+            new NoOpStandingsDialogService());
+        controller.GenerateBracket("Pro Ladder", session.Drivers);
+
+        var first = controller.PeekUpcomingMatches(10).First();
+        controller.SubmitWinner(first.MatchId, firstOption: true);
+        controller.SaveProgress();
+
+        var id = repository.SaveSession(session);
+        var loaded = repository.LoadSession(id);
+        var phase = loaded.ResultsArchive.Phases
+            .Single(p => p.Phase == "Pro Ladder");
+        var savedMatch = phase.Matches.Single(m => m.MatchId == first.MatchId);
+
+        Assert.AreEqual(session.Drivers[0].Id, savedMatch.WinnerDriverId);
+        Assert.AreEqual(session.Drivers[0].Name, savedMatch.WinnerName);
+        Assert.IsTrue(phase.Matches.Count >= 3);
+    }
+
     private static RaceSession CreateSession(string eventName, DateTime eventDate, string raceType)
     {
         var drivers = TestDriverFactory.CreateRoundRobinPack(4);

--- a/src/RCDragManagerProd/Controllers/RaceController.Persistence.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Persistence.cs
@@ -76,18 +76,34 @@ namespace RCDragManagerProd.Controllers
 
                 if (_drivers != null)
                 {
-                    _session.DriverEntries.Clear();
-                    foreach (var d in _drivers)
+                    lock (_dialInLock)
                     {
-                        _session.DriverEntries.Add(new RaceSessionDriverEntry
+                        var existingByDriverId = (_session.DriverEntries ?? new List<RaceSessionDriverEntry>())
+                            .Where(e => e != null)
+                            .GroupBy(e => e.DriverID)
+                            .ToDictionary(g => g.Key, g => g.First());
+
+                        var synchronizedEntries = new List<RaceSessionDriverEntry>(_drivers.Count);
+                        foreach (var d in _drivers)
                         {
-                            DriverID = d.Id,
-                            DriverName = d.Name,
-                            QualifyingTime = d.QualTime
-                        });
+                            if (d == null) continue;
+
+                            if (!existingByDriverId.TryGetValue(d.Id, out var entry))
+                                entry = new RaceSessionDriverEntry { DriverID = d.Id };
+
+                            // The controller owns identity/qualifying time. The session
+                            // entry owns race metadata such as DialIn, car, class and seed,
+                            // so reuse the entry instead of destructively rebuilding it.
+                            entry.DriverName = d.Name;
+                            entry.QualifyingTime = d.QualTime;
+                            synchronizedEntries.Add(entry);
+                        }
+
+                        _session.DriverEntries = synchronizedEntries;
                     }
                 }
 
+                CaptureCurrentResultSnapshot();
                 CaptureResumeSnapshot();
 
                 Logger.Log($"[SAVE] results={list.Count}, rounds={_session.SavedRevealedRounds.Count}, type='{_session.RaceType}'");

--- a/src/RCDragManagerProd/Controllers/RaceController.ResultSnapshots.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.ResultSnapshots.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.RaceEngines;
+
+namespace RCDragManagerProd.Controllers
+{
+    public partial class RaceController
+    {
+        private void CaptureCurrentResultSnapshot()
+        {
+            if (_session == null || _engine == null) return;
+
+            string phase;
+            if (string.Equals(_session.RaceType, RaceTypes.Finals, StringComparison.OrdinalIgnoreCase))
+                phase = RaceTypes.Finals;
+            else if (_inLosersPhase ||
+                     string.Equals(_session.RaceType, RaceTypes.LosersBracket, StringComparison.OrdinalIgnoreCase))
+                phase = RaceTypes.LosersBracket;
+            else if (_engine is RoundRobinEngineAdapter)
+                phase = RaceTypes.RoundRobin;
+            else
+                phase = string.IsNullOrWhiteSpace(_session.OriginalRaceType)
+                    ? (_session.RaceType ?? "Main")
+                    : _session.OriginalRaceType;
+
+            CapturePhaseSnapshot(phase, EngineGetMatches(_engine));
+        }
+
+        private void CaptureRoundRobinResultSnapshot(RoundRobinEngineAdapter rr)
+        {
+            if (rr == null) return;
+
+            var matches = EngineGetMatches(rr).ToList();
+            CapturePhaseSnapshot(RaceTypes.RoundRobin, matches);
+
+            var standings = rr.GetStandings();
+            var losses = matches
+                .Where(m => m.HasResult)
+                .Select(m => _matchResult.GetLoser(m.MatchId))
+                .Where(d => d != null)
+                .GroupBy(d => d.Id)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            EnsureResultsArchive();
+            _session.ResultsArchive.RoundRobinStandings = standings
+                .Select((row, index) => new RoundRobinStandingSnapshot
+                {
+                    Rank = index + 1,
+                    DriverId = row.Driver.Id,
+                    DriverName = row.Driver.Name,
+                    Wins = row.Wins,
+                    Losses = losses.TryGetValue(row.Driver.Id, out var count) ? count : 0
+                })
+                .ToList();
+        }
+
+        private void CapturePhaseSnapshot(string phase, IEnumerable<EngineMatch> matches)
+        {
+            if (_session == null || matches == null || string.IsNullOrWhiteSpace(phase)) return;
+
+            EnsureResultsArchive();
+            var entryById = (_session.DriverEntries ?? new List<RaceSessionDriverEntry>())
+                .Where(e => e != null)
+                .GroupBy(e => e.DriverID)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            var snapshot = new RacePhaseResultSnapshot
+            {
+                Phase = phase,
+                CapturedAt = DateTime.Now,
+                Matches = matches
+                    .OrderBy(m => RoundLabels.CompareKey(m.RoundLabel ?? string.Empty))
+                    .ThenBy(m => m.MatchId)
+                    .Select(m =>
+                    {
+                        var winner = m.HasResult ? _matchResult.GetWinner(m.MatchId) : null;
+                        var loser = m.HasResult ? _matchResult.GetLoser(m.MatchId) : null;
+                        return new RaceResultMatchSnapshot
+                        {
+                            MatchId = m.MatchId,
+                            RoundLabel = m.RoundLabel,
+                            Driver1Id = m.Driver1?.Id,
+                            Driver1Name = m.Driver1?.Name ?? "BYE",
+                            Driver2Id = m.Driver2?.Id,
+                            Driver2Name = m.Driver2?.Name ?? "BYE",
+                            Driver1Seed = SeedFor(m.Driver1, entryById),
+                            Driver2Seed = SeedFor(m.Driver2, entryById),
+                            FromMatch1 = m.FromMatch1,
+                            FromMatch2 = m.FromMatch2,
+                            WinnerDriverId = winner?.Id,
+                            WinnerName = winner?.Name,
+                            LoserDriverId = loser?.Id,
+                            LoserName = loser?.Name
+                        };
+                    })
+                    .ToList()
+            };
+
+            int existingIndex = _session.ResultsArchive.Phases.FindIndex(p =>
+                string.Equals(p?.Phase, phase, StringComparison.OrdinalIgnoreCase));
+            if (existingIndex >= 0)
+                _session.ResultsArchive.Phases[existingIndex] = snapshot;
+            else
+                _session.ResultsArchive.Phases.Add(snapshot);
+        }
+
+        private void CaptureCompletedResult(Driver champion, Driver runnerUp, DateTime completedAt)
+        {
+            EnsureResultsArchive();
+            _session.ResultsArchive.ChampionDriverId = champion?.Id;
+            _session.ResultsArchive.ChampionName = champion?.Name;
+            _session.ResultsArchive.RunnerUpDriverId = runnerUp?.Id;
+            _session.ResultsArchive.RunnerUpName = runnerUp?.Name;
+            _session.ResultsArchive.CompletedAt = completedAt;
+        }
+
+        private void EnsureResultsArchive()
+        {
+            if (_session.ResultsArchive == null)
+                _session.ResultsArchive = new RaceResultsArchive();
+            if (_session.ResultsArchive.Phases == null)
+                _session.ResultsArchive.Phases = new List<RacePhaseResultSnapshot>();
+            if (_session.ResultsArchive.RoundRobinStandings == null)
+                _session.ResultsArchive.RoundRobinStandings = new List<RoundRobinStandingSnapshot>();
+        }
+
+        private static int? SeedFor(
+            Driver driver,
+            IReadOnlyDictionary<int, RaceSessionDriverEntry> entryById)
+        {
+            if (driver == null) return null;
+            return entryById.TryGetValue(driver.Id, out var entry) ? entry.Seed : null;
+        }
+    }
+}

--- a/src/RCDragManagerProd/Controllers/RaceController.Results.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Results.cs
@@ -69,6 +69,7 @@ namespace RCDragManagerProd.Controllers
                 Loser = loser?.Name ?? "BYE"
             });
 
+            CaptureCurrentResultSnapshot();
             WinnersUpdated?.Invoke(_winners);
 
             // advance UI/state first
@@ -181,6 +182,7 @@ namespace RCDragManagerProd.Controllers
 
             Logger.Log($"[CTRL][EDIT] Override: M{matchId} ({match.RoundLabel}) ? {newWinner.Name} over {(newLoser?.Name ?? "BYE")}.");
 
+            CaptureCurrentResultSnapshot();
             WinnersUpdated?.Invoke(_winners);
             PushNextMatch();
             PushAdvanceState();

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -406,6 +406,7 @@ namespace RCDragManagerProd.Controllers
                         Logger.Log($"[RR][QMDRA] COMPLETE ? Advancing ALL drivers to finals. RankedCount={rankedAll.Count}, SessionDrivers={totalDrivers}");
                         Logger.Log("[RR][QMDRA] Finals seed order: " + (rankedAll.Count == 0 ? "(none)" : string.Join(", ", rankedAll.Select(d => d.Name))));
 
+                        CaptureRoundRobinResultSnapshot(rr);
                         InjectFinalsAllAdvance(rankedAll);
                         return;
                     }
@@ -434,6 +435,7 @@ namespace RCDragManagerProd.Controllers
 
                     _rrMatchesSnapshot = EngineGetMatches(_engine).ToList();
                     _rrRoundOrderSnapshot = EngineGetRoundOrder(_engine).ToList();
+                    CaptureRoundRobinResultSnapshot(rr);
 
                     // Popup scorecard + keep detailed log
                     try
@@ -556,6 +558,8 @@ namespace RCDragManagerProd.Controllers
                         MatchResults = _matchResult.GetAllResults()
                     };
 
+                    CaptureCurrentResultSnapshot();
+                    CaptureCompletedResult(winner, runnerUp, summary.CompletedAt);
                     Logger.Log($"?? Tournament complete � Winner: {winner?.Name}, Runner-Up: {runnerUp?.Name}");
                     _tournamentClosed = true;
 

--- a/src/RCDragManagerProd/Domain/RaceResults.cs
+++ b/src/RCDragManagerProd/Domain/RaceResults.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace RCDragManagerProd.Domain
+{
+    /// <summary>
+    /// Durable historical results for a race. Unlike ResumeSnapshot, this model is
+    /// presentation-oriented and remains useful after the race is closed.
+    /// </summary>
+    public sealed class RaceResultsArchive
+    {
+        public List<RacePhaseResultSnapshot> Phases { get; set; } = new List<RacePhaseResultSnapshot>();
+        public List<RoundRobinStandingSnapshot> RoundRobinStandings { get; set; } =
+            new List<RoundRobinStandingSnapshot>();
+        public int? ChampionDriverId { get; set; }
+        public string ChampionName { get; set; }
+        public int? RunnerUpDriverId { get; set; }
+        public string RunnerUpName { get; set; }
+        public DateTime? CompletedAt { get; set; }
+    }
+
+    public sealed class RacePhaseResultSnapshot
+    {
+        public string Phase { get; set; }
+        public DateTime CapturedAt { get; set; }
+        public List<RaceResultMatchSnapshot> Matches { get; set; } =
+            new List<RaceResultMatchSnapshot>();
+    }
+
+    public sealed class RaceResultMatchSnapshot
+    {
+        public int MatchId { get; set; }
+        public string RoundLabel { get; set; }
+        public int? Driver1Id { get; set; }
+        public string Driver1Name { get; set; }
+        public int? Driver2Id { get; set; }
+        public string Driver2Name { get; set; }
+        public int? Driver1Seed { get; set; }
+        public int? Driver2Seed { get; set; }
+        public int? FromMatch1 { get; set; }
+        public int? FromMatch2 { get; set; }
+        public int? WinnerDriverId { get; set; }
+        public string WinnerName { get; set; }
+        public int? LoserDriverId { get; set; }
+        public string LoserName { get; set; }
+    }
+
+    public sealed class RoundRobinStandingSnapshot
+    {
+        public int Rank { get; set; }
+        public int DriverId { get; set; }
+        public string DriverName { get; set; }
+        public int Wins { get; set; }
+        public int Losses { get; set; }
+    }
+}

--- a/src/RCDragManagerProd/Domain/RaceSession.cs
+++ b/src/RCDragManagerProd/Domain/RaceSession.cs
@@ -26,6 +26,10 @@ namespace RCDragManagerProd.Domain
         // Null on pre-feature saves or before a bracket is generated.
         public ResumeSnapshot Resume { get; set; }
 
+        // Durable display/reporting history. This is separate from Resume because
+        // completed races still need their RR standings and elimination ladders.
+        public RaceResultsArchive ResultsArchive { get; set; } = new RaceResultsArchive();
+
         // True once the operator has CLOSED the race (event finished / done with the
         // console). Distinct from a Save Progress checkpoint, which leaves the race open
         // and resumable. See issue #255 (Save Progress vs Close Race) and #294 (resume).

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Controllers\RaceController.Resume.cs" />
     <Compile Include="Controllers\RaceController.SaveClose.cs" />
     <Compile Include="Controllers\RaceController.Results.cs" />
+    <Compile Include="Controllers\RaceController.ResultSnapshots.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Core.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Defer.cs" />
     <Compile Include="Controllers\RaceController.RoundFlow.Finals.cs" />
@@ -305,6 +306,7 @@
     <Compile Include="RaceEngines\RandomEngineAdapter.cs" />
     <Compile Include="RaceEngines\RoundRobinEngineAdapter.cs" />
     <Compile Include="Domain\RaceSession.cs" />
+    <Compile Include="Domain\RaceResults.cs" />
     <Compile Include="Domain\ResumeSnapshot.cs" />
     <Compile Include="Repositories\RaceSessionRepository.cs" />
     <Compile Include="UI\Forms\Common\RaceDialogs.cs" />

--- a/src/RCDragManagerProd/Repositories/MultiClassEventRepository.cs
+++ b/src/RCDragManagerProd/Repositories/MultiClassEventRepository.cs
@@ -51,19 +51,13 @@ namespace RCDragManagerProd.Repositories
         public void SaveEvent(MultiClassEvent evt)
         {
             if (evt == null) throw new ArgumentNullException(nameof(evt));
-            Logger.Log("[DB][MultiClassEventRepo] SaveEvent()");
+            Logger.Log($"[DB][MultiClassEventRepo] SaveEvent(id={evt.Id})");
 
             string eventName = evt.EventName ?? "(event)";
             DateTime eventDate = evt.EventDate != default ? evt.EventDate : DateTime.Now;
             int classCount = evt.ClassSessions?.Count ?? 0;
 
-            string json = JsonSerializer.Serialize(evt, new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                WriteIndented = false
-            });
-
-            const string sql = @"
+            const string insertSql = @"
 INSERT INTO MultiClassEvents (EventName, EventDate, ClassCount, EventData)
 VALUES (@EventName, @EventDate, @ClassCount, @EventData);
 SELECT last_insert_rowid();";
@@ -74,16 +68,16 @@ SELECT last_insert_rowid();";
                 Logger.Log("[TX] BEGIN SaveEvent");
                 try
                 {
-                    using (var cmd = new SQLiteCommand(sql, cn, tx))
+                    if (evt.Id <= 0)
                     {
-                        cmd.Parameters.AddWithValue("@EventName", eventName);
-                        cmd.Parameters.AddWithValue("@EventDate", eventDate.ToString("yyyy-MM-dd HH:mm:ss"));
-                        cmd.Parameters.AddWithValue("@ClassCount", classCount);
-                        cmd.Parameters.AddWithValue("@EventData", json ?? "{}");
-
-                        evt.Id = Convert.ToInt32(cmd.ExecuteScalar());
+                        using (var cmd = new SQLiteCommand(insertSql, cn, tx))
+                        {
+                            AddSaveParameters(cmd, eventName, eventDate, classCount, Serialize(evt));
+                            evt.Id = Convert.ToInt32(cmd.ExecuteScalar());
+                        }
                     }
 
+                    UpdateExistingEvent(cn, tx, evt, eventName, eventDate, classCount);
                     tx.Commit();
                     Logger.Log("[TX] COMMIT SaveEvent");
                 }
@@ -97,6 +91,53 @@ SELECT last_insert_rowid();";
 
             Logger.Log($"[DB][MultiClassEventRepo] SaveEvent → Id={evt.Id}");
         }
+
+        private static void UpdateExistingEvent(
+            SQLiteConnection cn,
+            SQLiteTransaction tx,
+            MultiClassEvent evt,
+            string eventName,
+            DateTime eventDate,
+            int classCount)
+        {
+            const string sql = @"
+UPDATE MultiClassEvents
+SET EventName = @EventName,
+    EventDate = @EventDate,
+    ClassCount = @ClassCount,
+    EventData = @EventData
+WHERE Id = @Id;";
+
+            using (var cmd = new SQLiteCommand(sql, cn, tx))
+            {
+                AddSaveParameters(cmd, eventName, eventDate, classCount, Serialize(evt));
+                cmd.Parameters.AddWithValue("@Id", evt.Id);
+                int affected = cmd.ExecuteNonQuery();
+                if (affected != 1)
+                    throw new InvalidOperationException(
+                        $"Expected to update MultiClassEvent Id={evt.Id}, but affected {affected} rows.");
+            }
+        }
+
+        private static void AddSaveParameters(
+            SQLiteCommand cmd,
+            string eventName,
+            DateTime eventDate,
+            int classCount,
+            string json)
+        {
+            cmd.Parameters.AddWithValue("@EventName", eventName);
+            cmd.Parameters.AddWithValue("@EventDate", eventDate.ToString("yyyy-MM-dd HH:mm:ss"));
+            cmd.Parameters.AddWithValue("@ClassCount", classCount);
+            cmd.Parameters.AddWithValue("@EventData", json ?? "{}");
+        }
+
+        private static string Serialize(MultiClassEvent evt) =>
+            JsonSerializer.Serialize(evt, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = false
+            });
 
         // ---------- LIST ----------
         public List<MultiClassEventSummary> GetAllEvents()
@@ -152,6 +193,7 @@ ORDER BY datetime(EventDate) DESC";
                 {
                     var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
                     var multiEvent = JsonSerializer.Deserialize<MultiClassEvent>(json, opts);
+                    if (multiEvent != null) multiEvent.Id = id;
                     Logger.Log("[DB][MultiClassEventRepo] LoadEvent → OK");
                     return multiEvent;
                 }

--- a/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
+++ b/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
@@ -56,25 +56,18 @@ namespace RCDragManagerProd.Repositories
         public int SaveSession(RaceSession session)
         {
             if (session == null) throw new ArgumentNullException(nameof(session));
-            Logger.Log("[DB][SessionRepo] SaveSession()");
+            Logger.Log($"[DB][SessionRepo] SaveSession(id={session.Id})");
 
             string eventName = session.EventName ?? "(event)";
             string classType = session.ClassType ?? "";
             string raceType = session.RaceType ?? "";
             DateTime eventDate = session.EventDate != default ? session.EventDate : DateTime.Now;
 
-            string json = JsonSerializer.Serialize(session, new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                WriteIndented = false
-            });
-
-            const string sql = @"
+            const string insertSql = @"
 INSERT INTO RaceSessions (EventName, EventDate, ClassType, RaceType, SessionData)
 VALUES (@EventName, @EventDate, @ClassType, @RaceType, @SessionData);
 SELECT last_insert_rowid();";
 
-            int newId;
             using (var cn = Open())
             {
                 using (var tx = cn.BeginTransaction())
@@ -82,17 +75,16 @@ SELECT last_insert_rowid();";
                     Logger.Log("[TX] BEGIN SaveSession");
                     try
                     {
-                        using (var cmd = new SQLiteCommand(sql, cn, tx))
+                        if (session.Id <= 0)
                         {
-                            cmd.Parameters.AddWithValue("@EventName", eventName);
-                            cmd.Parameters.AddWithValue("@EventDate", eventDate.ToString("yyyy-MM-dd HH:mm:ss"));
-                            cmd.Parameters.AddWithValue("@ClassType", classType);
-                            cmd.Parameters.AddWithValue("@RaceType", raceType);
-                            cmd.Parameters.AddWithValue("@SessionData", json ?? "{}");
-
-                            newId = Convert.ToInt32(cmd.ExecuteScalar());
+                            using (var cmd = new SQLiteCommand(insertSql, cn, tx))
+                            {
+                                AddSaveParameters(cmd, eventName, eventDate, classType, raceType, Serialize(session));
+                                session.Id = Convert.ToInt32(cmd.ExecuteScalar());
+                            }
                         }
 
+                        UpdateExistingSession(cn, tx, session, eventName, eventDate, classType, raceType);
                         tx.Commit();
                         Logger.Log("[TX] COMMIT SaveSession");
                     }
@@ -105,10 +97,60 @@ SELECT last_insert_rowid();";
                 }
             }
 
-            session.Id = newId;
-            Logger.Log($"[DB][SessionRepo] SaveSession → Id={newId}");
-            return newId;
+            Logger.Log($"[DB][SessionRepo] SaveSession → Id={session.Id}");
+            return session.Id;
         }
+
+        private static void UpdateExistingSession(
+            SQLiteConnection cn,
+            SQLiteTransaction tx,
+            RaceSession session,
+            string eventName,
+            DateTime eventDate,
+            string classType,
+            string raceType)
+        {
+            const string sql = @"
+UPDATE RaceSessions
+SET EventName = @EventName,
+    EventDate = @EventDate,
+    ClassType = @ClassType,
+    RaceType = @RaceType,
+    SessionData = @SessionData
+WHERE Id = @Id;";
+
+            using (var cmd = new SQLiteCommand(sql, cn, tx))
+            {
+                AddSaveParameters(cmd, eventName, eventDate, classType, raceType, Serialize(session));
+                cmd.Parameters.AddWithValue("@Id", session.Id);
+                int affected = cmd.ExecuteNonQuery();
+                if (affected != 1)
+                    throw new InvalidOperationException(
+                        $"Expected to update RaceSession Id={session.Id}, but affected {affected} rows.");
+            }
+        }
+
+        private static void AddSaveParameters(
+            SQLiteCommand cmd,
+            string eventName,
+            DateTime eventDate,
+            string classType,
+            string raceType,
+            string json)
+        {
+            cmd.Parameters.AddWithValue("@EventName", eventName);
+            cmd.Parameters.AddWithValue("@EventDate", eventDate.ToString("yyyy-MM-dd HH:mm:ss"));
+            cmd.Parameters.AddWithValue("@ClassType", classType);
+            cmd.Parameters.AddWithValue("@RaceType", raceType);
+            cmd.Parameters.AddWithValue("@SessionData", json ?? "{}");
+        }
+
+        private static string Serialize(RaceSession session) =>
+            JsonSerializer.Serialize(session, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = false
+            });
 
         // ---------- LIST ----------
         public List<RaceSessionSummary> GetAllSessions()
@@ -166,6 +208,7 @@ ORDER BY datetime(EventDate) DESC";
                 {
                     var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
                     var session = JsonSerializer.Deserialize<RaceSession>(json, opts);
+                    if (session != null) session.Id = id;
                     Logger.Log("[DB][SessionRepo] LoadSession → OK");
                     return session;
                 }


### PR DESCRIPTION
## What changed

- Preserve every driver's dial-in and race-entry metadata when saving an active race.
- Update existing single-class sessions and multi-class events instead of inserting duplicate stale rows.
- Restore database IDs when loading legacy JSON so subsequent saves update the selected record.
- Add durable, phase-separated result snapshots for Pro Ladder, Round Robin, Losers Bracket, and Finals.
- Store final Round Robin standings plus champion and runner-up details.
- Add regression tests for dial-in preservation, update-in-place saves, and persisted Pro Ladder results.

## Why

At the race meeting, editing one driver's dial-in after the race started caused the other drivers' dial-ins to disappear. The save path cleared `DriverEntries` and rebuilt them without copying `DialIn` or the other entry metadata.

Repeated saves also inserted new rows, which could leave stale duplicate races in the saved-race list. Result history needed a durable model independent of the currently active engine, particularly because Round Robin and Finals can reuse match IDs.

## Impact

- Editing or saving one dial-in no longer destroys other drivers' values.
- Save Progress and Close Race keep updating the same saved race.
- Saved sessions now have the data foundation needed for the upcoming Ladder/List results UI.
- Existing session JSON remains backward-compatible.

## Validation

- `dotnet test src/RCDragManagerProd.Tests/RCDragManagerProd.Tests.csproj --no-restore`
- 284 passed, 11 existing intentional skips, 0 failed.

## Issues

Part of #359
Addresses #360
Addresses #361
Addresses #363
Testing foundation for #364

The WPF Ladder/List presentation remains in #362 and will be delivered separately.