### PR TITLE
[codex] Add ladder and saved race results views

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceResultsPresentationBuilderTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceResultsPresentationBuilderTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+
+namespace RCDragManagerProd.Tests;
+
+[TestClass]
+public class RaceResultsPresentationBuilderTests
+{
+    [TestMethod]
+    public void Build_SeparatesLadderRoundsAndBuildsResultList()
+    {
+        var session = new RaceSession
+        {
+            EventName = "Club Finals",
+            ResultsArchive = new RaceResultsArchive
+            {
+                Phases = new List<RacePhaseResultSnapshot>
+                {
+                    new RacePhaseResultSnapshot
+                    {
+                        Phase = RaceTypes.Finals,
+                        Matches = new List<RaceResultMatchSnapshot>
+                        {
+                            Match(1, "SF", "Ava", "Drew", "Ava", "Drew"),
+                            Match(2, "SF", "Blake", "Casey", "Casey", "Blake"),
+                            Match(3, "F", "Ava", "Casey", "Ava", "Casey")
+                        }
+                    }
+                },
+                ChampionName = "Ava",
+                RunnerUpName = "Casey"
+            }
+        };
+
+        var view = RaceResultsPresentationBuilder.Build(session);
+
+        Assert.IsTrue(view.HasResults);
+        Assert.AreEqual("Champion: Ava  •  Runner-up: Casey", view.Summary);
+        Assert.AreEqual(1, view.Phases.Count);
+        Assert.AreEqual(2, view.Phases[0].Rounds.Count);
+        Assert.AreEqual("Semi-Final", view.Phases[0].Rounds[0].RoundLabel);
+        Assert.AreEqual("Final", view.Phases[0].Rounds[1].RoundLabel);
+        Assert.AreEqual(3, view.ResultRows.Count);
+    }
+
+    [TestMethod]
+    public void Build_IncludesRoundRobinStandings()
+    {
+        var session = new RaceSession
+        {
+            ResultsArchive = new RaceResultsArchive
+            {
+                RoundRobinStandings = new List<RoundRobinStandingSnapshot>
+                {
+                    new RoundRobinStandingSnapshot { Rank = 2, DriverName = "Blake", Wins = 2, Losses = 1 },
+                    new RoundRobinStandingSnapshot { Rank = 1, DriverName = "Ava", Wins = 3, Losses = 0 }
+                }
+            }
+        };
+
+        var view = RaceResultsPresentationBuilder.Build(session);
+
+        Assert.IsTrue(view.HasResults);
+        Assert.IsTrue(view.HasRoundRobinStandings);
+        Assert.AreEqual("Ava", view.Standings[0].Driver);
+    }
+
+    private static RaceResultMatchSnapshot Match(
+        int id, string round, string d1, string d2, string winner, string loser) =>
+        new RaceResultMatchSnapshot
+        {
+            MatchId = id,
+            RoundLabel = round,
+            Driver1Name = d1,
+            Driver2Name = d2,
+            WinnerName = winner,
+            LoserName = loser
+        };
+}

--- a/src/RCDragManagerProd.WPF/Dialogs/RaceResultsWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/RaceResultsWindow.xaml
@@ -1,0 +1,156 @@
+<Window x:Class="RCDragManagerProd.WPF.Dialogs.RaceResultsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Race results"
+        Width="1040" Height="720" MinWidth="760" MinHeight="520"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ResizeMode="CanResizeWithGrip"
+        KeyDown="Window_KeyDown"
+        Background="{StaticResource Brush.Background}"
+        FontFamily="Segoe UI"
+        ShowInTaskbar="False">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="38" GlassFrameThickness="0"
+                      ResizeBorderThickness="5" UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Window.Resources>
+        <DataTemplate x:Key="MatchCardTemplate">
+            <Border Width="210" MinHeight="94" Margin="0,0,0,10" Padding="12,10"
+                    Background="{StaticResource Brush.Surface}"
+                    BorderBrush="{StaticResource Brush.Border}" BorderThickness="1"
+                    CornerRadius="{StaticResource Radius.Panel}">
+                <StackPanel>
+                    <TextBlock Text="{Binding MatchLabel}"
+                               Foreground="{StaticResource Brush.TextHint}"
+                               FontSize="{StaticResource FontSize.Xs}"/>
+                    <TextBlock Text="{Binding Driver1}" Margin="0,6,0,2"
+                               Foreground="{StaticResource Brush.TextPrimary}"
+                               FontSize="{StaticResource FontSize.Md}" FontWeight="Medium"/>
+                    <TextBlock Text="{Binding Driver2}"
+                               Foreground="{StaticResource Brush.TextSecondary}"
+                               FontSize="{StaticResource FontSize.Md}"/>
+                    <TextBlock Text="{Binding Winner}" Margin="0,8,0,0"
+                               Foreground="{StaticResource Brush.Success}"
+                               FontSize="{StaticResource FontSize.Sm}"/>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="RoundColumnTemplate">
+            <StackPanel Width="230" Margin="0,0,22,0">
+                <TextBlock Text="{Binding RoundLabel}" Margin="0,0,0,10"
+                           Foreground="{StaticResource Brush.Primary}"
+                           FontSize="{StaticResource FontSize.Lg}" FontWeight="SemiBold"/>
+                <ItemsControl ItemsSource="{Binding Matches}"
+                              ItemTemplate="{StaticResource MatchCardTemplate}"/>
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="PhaseLadderTemplate">
+            <StackPanel Margin="0,0,0,24">
+                <TextBlock Text="{Binding Phase}" Margin="0,0,0,14"
+                           Foreground="{StaticResource Brush.TextPrimary}"
+                           FontSize="{StaticResource FontSize.Xl}" FontWeight="SemiBold"/>
+                <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Disabled">
+                    <ItemsControl ItemsSource="{Binding Rounds}"
+                                  ItemTemplate="{StaticResource RoundColumnTemplate}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </ScrollViewer>
+            </StackPanel>
+        </DataTemplate>
+    </Window.Resources>
+
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="38"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <Grid Grid.Row="0" Background="{StaticResource Brush.Chrome}">
+                <TextBlock Text="Race results"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           FontSize="12" Foreground="{StaticResource Brush.TextHint}" FontWeight="Medium"/>
+                <Button Style="{StaticResource Style.WinCtrl.Close}"
+                        HorizontalAlignment="Right" VerticalAlignment="Center"
+                        Margin="0,0,14,0" Click="BtnClose_Click"/>
+            </Grid>
+
+            <Border Grid.Row="1" Padding="24,16"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,0,0,1">
+                <StackPanel>
+                    <TextBlock Text="{Binding EventName}"
+                               Foreground="{StaticResource Brush.TextPrimary}"
+                               FontSize="{StaticResource FontSize.Xxl}" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Summary}" Margin="0,5,0,0"
+                               Foreground="{StaticResource Brush.TextSecondary}"
+                               FontSize="{StaticResource FontSize.Md}"/>
+                </StackPanel>
+            </Border>
+
+            <TabControl Grid.Row="2" Margin="18,12"
+                        Background="{StaticResource Brush.Background}"
+                        Foreground="{StaticResource Brush.TextPrimary}">
+                <TabItem Header="Ladder">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="12,18">
+                        <ItemsControl ItemsSource="{Binding Phases}"
+                                      ItemTemplate="{StaticResource PhaseLadderTemplate}"/>
+                    </ScrollViewer>
+                </TabItem>
+
+                <TabItem Header="Results list">
+                    <DataGrid ItemsSource="{Binding ResultRows}" AutoGenerateColumns="False"
+                              IsReadOnly="True" CanUserAddRows="False" Margin="8,14"
+                              Background="{StaticResource Brush.Background}"
+                              Foreground="{StaticResource Brush.TextPrimary}"
+                              RowBackground="{StaticResource Brush.Background}"
+                              AlternatingRowBackground="{StaticResource Brush.Surface}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Phase" Binding="{Binding Phase}" Width="150"/>
+                            <DataGridTextColumn Header="Round" Binding="{Binding Round}" Width="100"/>
+                            <DataGridTextColumn Header="Match" Binding="{Binding Match}" Width="65"/>
+                            <DataGridTextColumn Header="Pairing" Binding="{Binding Pairing}" Width="*"/>
+                            <DataGridTextColumn Header="Winner" Binding="{Binding Winner}" Width="160"/>
+                            <DataGridTextColumn Header="Loser" Binding="{Binding Loser}" Width="160"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </TabItem>
+
+                <TabItem Header="Round Robin standings"
+                         IsEnabled="{Binding HasRoundRobinStandings}">
+                    <DataGrid ItemsSource="{Binding Standings}" AutoGenerateColumns="False"
+                              IsReadOnly="True" CanUserAddRows="False" Margin="8,14"
+                              Background="{StaticResource Brush.Background}"
+                              Foreground="{StaticResource Brush.TextPrimary}"
+                              RowBackground="{StaticResource Brush.Background}"
+                              AlternatingRowBackground="{StaticResource Brush.Surface}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Rank" Binding="{Binding Rank}" Width="80"/>
+                            <DataGridTextColumn Header="Driver" Binding="{Binding Driver}" Width="*"/>
+                            <DataGridTextColumn Header="Wins" Binding="{Binding Wins}" Width="100"/>
+                            <DataGridTextColumn Header="Losses" Binding="{Binding Losses}" Width="100"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </TabItem>
+            </TabControl>
+
+            <Border Grid.Row="3" Padding="24,12"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,1,0,0">
+                <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                        Content="Close" HorizontalAlignment="Right" Click="BtnClose_Click"/>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Dialogs/RaceResultsWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/RaceResultsWindow.xaml.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+using System.Windows.Input;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Domain;
+
+namespace RCDragManagerProd.WPF.Dialogs
+{
+    public partial class RaceResultsWindow : Window
+    {
+        public RaceResultsWindow(RaceSession session)
+        {
+            InitializeComponent();
+            WindowSizing.RoundCorners(this);
+            DataContext = RaceResultsPresentationBuilder.Build(session);
+        }
+
+        private void BtnClose_Click(object sender, RoutedEventArgs e) => Close();
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape) Close();
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml
@@ -242,11 +242,14 @@
                 <Border Grid.Row="2" Padding="12,12"
                         BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,1,0,0">
                     <StackPanel>
-                        <UniformGrid Columns="2" Margin="0,0,0,6">
+                        <UniformGrid Columns="3" Margin="0,0,0,6">
                             <Button x:Name="BtnEditResult" Style="{StaticResource Style.Button.Toolbar}"
                                     Content="Edit result" Click="BtnEditResult_Click" Margin="0,0,3,0"/>
                             <Button x:Name="BtnStandings" Style="{StaticResource Style.Button.Toolbar}"
-                                    Content="Standings" Click="BtnStandings_Click" Margin="3,0,0,0" IsEnabled="False"/>
+                                    Content="Standings" Click="BtnStandings_Click" Margin="3,0" IsEnabled="False"/>
+                            <Button x:Name="BtnRaceResults" Style="{StaticResource Style.Button.Toolbar}"
+                                    Content="Results" Click="BtnRaceResults_Click" Margin="3,0,0,0"
+                                    IsEnabled="False"/>
                         </UniformGrid>
                         <UniformGrid Columns="2">
                             <Button x:Name="BtnBuybacks" Style="{StaticResource Style.Button.Toolbar}"

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
@@ -70,6 +70,7 @@ namespace RCDragManagerProd.WPF.Views
                 BtnGenerateBracket.IsEnabled = true;
             }
             UpdatePrimaryButtons();
+            UpdateRaceResultsButton();
 
             _controller.BracketRedrawn += OnBracketRedrawn;
             _controller.NextMatchReady += OnNextMatchReady;
@@ -212,6 +213,7 @@ namespace RCDragManagerProd.WPF.Views
                 });
             }
             IcWinners.ItemsSource = list;
+            UpdateRaceResultsButton();
         });
 
         private void OnCanAdvanceChanged(bool can) => Run(() =>
@@ -546,6 +548,24 @@ namespace RCDragManagerProd.WPF.Views
             if (!_raceConsole.TryShowStandings())
                 MessageDialog.Info(Host, "Standings aren't available yet — they appear after Round Robin completes.",
                     "Standings not ready");
+        }
+
+        private void BtnRaceResults_Click(object sender, RoutedEventArgs e)
+        {
+            var presentation = RaceResultsPresentationBuilder.Build(_session);
+            if (!presentation.HasResults)
+            {
+                MessageDialog.Info(Host, "No race results have been recorded yet.", "Race results");
+                return;
+            }
+
+            new RaceResultsWindow(_session) { Owner = Host }.ShowDialog();
+        }
+
+        private void UpdateRaceResultsButton()
+        {
+            if (BtnRaceResults != null)
+                BtnRaceResults.IsEnabled = RaceResultsPresentationBuilder.Build(_session).HasResults;
         }
 
         private void BtnBuybacks_Click(object sender, RoutedEventArgs e)

--- a/src/RCDragManagerProd/AppServices/RaceResultsPresentationBuilder.cs
+++ b/src/RCDragManagerProd/AppServices/RaceResultsPresentationBuilder.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.ViewModels;
+
+namespace RCDragManagerProd.AppServices
+{
+    public static class RaceResultsPresentationBuilder
+    {
+        public static RaceResultsPresentation Build(RaceSession session)
+        {
+            var result = new RaceResultsPresentation
+            {
+                EventName = string.IsNullOrWhiteSpace(session?.EventName) ? "Race results" : session.EventName
+            };
+
+            var archive = session?.ResultsArchive;
+            if (archive == null)
+            {
+                result.Summary = "No saved race results are available.";
+                return result;
+            }
+
+            result.Summary = BuildSummary(archive);
+
+            foreach (var phase in (archive.Phases ?? new List<RacePhaseResultSnapshot>())
+                         .Where(p => p != null && p.Matches != null && p.Matches.Count > 0))
+            {
+                var phaseView = new RaceResultsPhaseView { Phase = DisplayPhase(phase.Phase) };
+                foreach (var roundGroup in phase.Matches
+                             .OrderBy(m => RoundLabels.CompareKey(m.RoundLabel ?? string.Empty))
+                             .ThenBy(m => m.MatchId)
+                             .GroupBy(m => RoundLabels.Normalize(m.RoundLabel ?? string.Empty)))
+                {
+                    var round = new RaceResultsRoundView { RoundLabel = DisplayRound(roundGroup.Key) };
+                    foreach (var match in roundGroup)
+                    {
+                        round.Matches.Add(new RaceResultsMatchCard
+                        {
+                            MatchLabel = $"M{match.MatchId}",
+                            Driver1 = SeededName(match.Driver1Seed, match.Driver1Name),
+                            Driver2 = SeededName(match.Driver2Seed, match.Driver2Name),
+                            Winner = string.IsNullOrWhiteSpace(match.WinnerName)
+                                ? "Pending"
+                                : $"Winner: {match.WinnerName}",
+                            IsComplete = !string.IsNullOrWhiteSpace(match.WinnerName)
+                        });
+
+                        result.ResultRows.Add(new RaceResultsListRow
+                        {
+                            Phase = DisplayPhase(phase.Phase),
+                            Round = DisplayRound(roundGroup.Key),
+                            Match = $"M{match.MatchId}",
+                            Pairing = $"{match.Driver1Name ?? "BYE"} vs {match.Driver2Name ?? "BYE"}",
+                            Winner = match.WinnerName ?? "Pending",
+                            Loser = match.LoserName ?? ""
+                        });
+                    }
+                    phaseView.Rounds.Add(round);
+                }
+                result.Phases.Add(phaseView);
+            }
+
+            result.Standings = (archive.RoundRobinStandings ?? new List<RoundRobinStandingSnapshot>())
+                .OrderBy(s => s.Rank)
+                .Select(s => new RaceResultsStandingRow
+                {
+                    Rank = s.Rank,
+                    Driver = s.DriverName,
+                    Wins = s.Wins,
+                    Losses = s.Losses
+                })
+                .ToList();
+
+            result.HasRoundRobinStandings = result.Standings.Count > 0;
+            result.HasResults = result.Phases.Count > 0 || result.HasRoundRobinStandings;
+            if (!result.HasResults && string.IsNullOrWhiteSpace(result.Summary))
+                result.Summary = "No saved race results are available.";
+            return result;
+        }
+
+        private static string BuildSummary(RaceResultsArchive archive)
+        {
+            if (!string.IsNullOrWhiteSpace(archive.ChampionName))
+            {
+                var runner = string.IsNullOrWhiteSpace(archive.RunnerUpName)
+                    ? ""
+                    : $"  •  Runner-up: {archive.RunnerUpName}";
+                return $"Champion: {archive.ChampionName}{runner}";
+            }
+            return "Race in progress — saved results shown below.";
+        }
+
+        private static string SeededName(int? seed, string name)
+        {
+            var display = string.IsNullOrWhiteSpace(name) ? "BYE" : name;
+            return seed.HasValue ? $"{seed.Value}. {display}" : display;
+        }
+
+        private static string DisplayPhase(string phase)
+        {
+            if (string.Equals(phase, RaceTypes.Finals, StringComparison.OrdinalIgnoreCase))
+                return "Finals — Pro Ladder";
+            return string.IsNullOrWhiteSpace(phase) ? "Race" : phase;
+        }
+
+        private static string DisplayRound(string round)
+        {
+            var normalized = RoundLabels.Normalize(round);
+            if (string.Equals(normalized, "SF", StringComparison.OrdinalIgnoreCase))
+                return "Semi-Final";
+            if (string.Equals(normalized, "F", StringComparison.OrdinalIgnoreCase))
+                return "Final";
+            if (string.Equals(normalized, "LB-F", StringComparison.OrdinalIgnoreCase))
+                return "Losers Bracket Final";
+            if (normalized.StartsWith("RR", StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(normalized.Substring(2), out var rr))
+                return $"Round Robin {rr}";
+            if (normalized.StartsWith("LB-R", StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(normalized.Substring(4), out var lb))
+                return $"Losers Bracket Round {lb}";
+            if (normalized.StartsWith("R", StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(normalized.Substring(1), out var r))
+                return $"Round {r}";
+            return normalized;
+        }
+    }
+}

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -119,6 +119,7 @@
     <Compile Include="AppServices\RaceConsoleService.cs" />
     <Compile Include="AppServices\RaceConsoleViewModel.cs" />
     <Compile Include="AppServices\RaceConsoleViewModelBuilder.cs" />
+    <Compile Include="AppServices\RaceResultsPresentationBuilder.cs" />
     <Compile Include="Controllers\IStandingsDialogService.cs" />
     <Compile Include="Controllers\LaneFairnessManager.cs" />
     <Compile Include="Controllers\RaceController.DialIn.cs" />
@@ -335,6 +336,7 @@
     <Compile Include="ViewModels\MatchResultSave.cs" />
     <Compile Include="ViewModels\PairingRow.cs" />
     <Compile Include="ViewModels\WinnerRow.cs" />
+    <Compile Include="ViewModels\RaceResultsPresentation.cs" />
     <EmbeddedResource Include="UI\Forms\Drivers\DriverManagerForm.resx">
       <DependentUpon>DriverManagerForm.cs</DependentUpon>
       <SubType>Designer</SubType>

--- a/src/RCDragManagerProd/ViewModels/RaceResultsPresentation.cs
+++ b/src/RCDragManagerProd/ViewModels/RaceResultsPresentation.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+namespace RCDragManagerProd.ViewModels
+{
+    public sealed class RaceResultsPresentation
+    {
+        public string EventName { get; set; }
+        public string Summary { get; set; }
+        public bool HasResults { get; set; }
+        public bool HasRoundRobinStandings { get; set; }
+        public List<RaceResultsPhaseView> Phases { get; set; } = new List<RaceResultsPhaseView>();
+        public List<RaceResultsListRow> ResultRows { get; set; } = new List<RaceResultsListRow>();
+        public List<RaceResultsStandingRow> Standings { get; set; } = new List<RaceResultsStandingRow>();
+    }
+
+    public sealed class RaceResultsPhaseView
+    {
+        public string Phase { get; set; }
+        public List<RaceResultsRoundView> Rounds { get; set; } = new List<RaceResultsRoundView>();
+    }
+
+    public sealed class RaceResultsRoundView
+    {
+        public string RoundLabel { get; set; }
+        public List<RaceResultsMatchCard> Matches { get; set; } = new List<RaceResultsMatchCard>();
+    }
+
+    public sealed class RaceResultsMatchCard
+    {
+        public string MatchLabel { get; set; }
+        public string Driver1 { get; set; }
+        public string Driver2 { get; set; }
+        public string Winner { get; set; }
+        public bool IsComplete { get; set; }
+    }
+
+    public sealed class RaceResultsListRow
+    {
+        public string Phase { get; set; }
+        public string Round { get; set; }
+        public string Match { get; set; }
+        public string Winner { get; set; }
+        public string Loser { get; set; }
+        public string Pairing { get; set; }
+    }
+
+    public sealed class RaceResultsStandingRow
+    {
+        public int Rank { get; set; }
+        public string Driver { get; set; }
+        public int Wins { get; set; }
+        public int Losses { get; set; }
+    }
+}


### PR DESCRIPTION
## What changed

- Add a dedicated WPF Race Results window.
- Display elimination phases as horizontally arranged ladder columns grouped by round.
- Add a round-by-round results list showing phase, pairing, winner, and loser.
- Add a Round Robin standings tab with rank, wins, and losses.
- Add a Results button to the race console that enables when saved result data exists.
- Render from the persisted `ResultsArchive`, so the same view works during an event and after reopening a saved or closed race.
- Add a UI-independent presentation builder and regression tests for ladder grouping, friendly round labels, summaries, and RR standings.

## Operator impact

Race directors can now open one results screen and switch between:

- Ladder
- Results list
- Round Robin standings

Completed saved races retain and display the same results when reopened.

## Validation

- `dotnet test src/RCDragManagerProd.Tests/RCDragManagerProd.Tests.csproj --no-restore`
  - 286 passed, 11 existing intentional skips, 0 failed.
- `dotnet build src/RCDragManagerProd.WPF/RCDragManagerProd.WPF.csproj --no-restore`
  - Build succeeded with 0 warnings and 0 errors.

## Issues

Part of #359
Addresses #362
Continues testing coverage in #364