### PR TITLE
[codex] Fix dial-in editing after race reset

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerResetTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerResetTests.cs
@@ -210,6 +210,45 @@ public class RaceControllerResetTests
             "_rrStandingsCardCache must be null after Reset()");
     }
 
+    [TestMethod]
+    public void DialIn_IsUnlockedAfterReset_WhenPreviousRoundLockedIt()
+    {
+        var controller = new RaceController(NewSession());
+        controller.LockDialIn();
+        Assert.IsTrue(controller.DialInLocked, "Precondition: dial-in must be locked");
+
+        controller.Reset();
+
+        Assert.IsFalse(controller.DialInLocked,
+            "Reset must return the console to setup mode where dial-ins can be edited");
+    }
+
+    [TestMethod]
+    public void SavedResultDisplayState_IsClearedAfterReset()
+    {
+        var session = NewSession();
+        session.Resume = new ResumeSnapshot { CurrentPhase = "Main" };
+        session.SavedResults.Add(new MatchResultSave
+        {
+            MatchId = 1,
+            WinnerDriverId = 1,
+            LoserDriverId = 2
+        });
+        session.SavedRevealedRounds.Add("SF");
+        session.ResultsArchive.Phases.Add(new RacePhaseResultSnapshot
+        {
+            Phase = "Pro Ladder"
+        });
+
+        var controller = new RaceController(session);
+        controller.Reset();
+
+        Assert.IsNull(session.Resume);
+        Assert.AreEqual(0, session.SavedResults.Count);
+        Assert.AreEqual(0, session.SavedRevealedRounds.Count);
+        Assert.AreEqual(0, session.ResultsArchive.Phases.Count);
+    }
+
     // ── Second GenerateBracket() starts cleanly ───────────────────────────────
 
     [TestMethod]

--- a/src/RCDragManagerProd.Tests/SessionRosterServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/SessionRosterServiceTests.cs
@@ -99,4 +99,55 @@ public class SessionRosterServiceTests
         var driver = _svc.BuildNewDriver("Eve", 3.92, new List<Driver>());
         Assert.AreEqual(3.92, driver.QualTime);
     }
+
+    [TestMethod]
+    public void SyncSession_AddsNewDriverSoDialInCanBeStored()
+    {
+        var session = new RaceSession();
+        var roster = new List<Driver>
+        {
+            new Driver { Id = 1, Name = "Existing" },
+            new Driver { Id = 2, Name = "Added after reset" }
+        };
+
+        _svc.SyncSession(session, roster);
+        var controller = new Controllers.RaceController(session);
+        controller.UpdateDriverDialIn(2, 2.850);
+
+        Assert.AreEqual(2, session.DriverEntries.Count);
+        Assert.AreEqual(2.850, session.DriverEntries.Single(e => e.DriverID == 2).DialIn);
+    }
+
+    [TestMethod]
+    public void SyncSession_PreservesExistingDialInAndCarMetadata()
+    {
+        var session = new RaceSession
+        {
+            DriverEntries = new List<RaceSessionDriverEntry>
+            {
+                new RaceSessionDriverEntry
+                {
+                    DriverID = 7,
+                    DriverName = "Old name",
+                    DialIn = 3.125,
+                    CarID = 44,
+                    CarName = "Blue car",
+                    Seed = 2
+                }
+            }
+        };
+
+        _svc.SyncSession(session, new List<Driver>
+        {
+            new Driver { Id = 7, Name = "New name", QualTime = 3.010 }
+        });
+
+        var entry = session.DriverEntries.Single();
+        Assert.AreEqual("New name", entry.DriverName);
+        Assert.AreEqual(3.010, entry.QualifyingTime);
+        Assert.AreEqual(3.125, entry.DialIn);
+        Assert.AreEqual(44, entry.CarID);
+        Assert.AreEqual("Blue car", entry.CarName);
+        Assert.AreEqual(2, entry.Seed);
+    }
 }

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
@@ -350,6 +350,7 @@ namespace RCDragManagerProd.WPF.Views
                 _drivers.Add(_rosterService.BuildNewDriver(name, qual, _drivers));
             }
 
+            SyncSessionRoster();
             RefreshDriverGrid();
             TxtName.Clear();
             TxtTime.Clear();
@@ -374,6 +375,7 @@ namespace RCDragManagerProd.WPF.Views
             if (dlg.ShowDialog() == true)
             {
                 driver.Name = dlg.DriverName;
+                SyncSessionRoster();
                 RefreshDriverGrid();
             }
         }
@@ -389,8 +391,15 @@ namespace RCDragManagerProd.WPF.Views
             if (dlg.ShowDialog() == true)
             {
                 driver.QualTime = dlg.QualTime;
+                SyncSessionRoster();
                 RefreshDriverGrid();
             }
+        }
+
+        private void SyncSessionRoster()
+        {
+            if (_session == null) return;
+            _rosterService.SyncSession(_session, _drivers);
         }
 
         private void BtnSetDialIn_Click(object sender, RoutedEventArgs e)

--- a/src/RCDragManagerProd/AppServices/SessionRosterService.cs
+++ b/src/RCDragManagerProd/AppServices/SessionRosterService.cs
@@ -52,5 +52,33 @@ namespace RCDragManagerProd.AppServices
             int newId = (roster == null || roster.Count == 0) ? 1 : roster.Max(d => d.Id) + 1;
             return new Driver { Id = newId, Name = name, QualTime = qualTime };
         }
+
+        /// <summary>
+        /// Synchronizes the editable console roster into the session while preserving
+        /// race-entry metadata such as dial-in, car, class and seed.
+        /// </summary>
+        public void SyncSession(RaceSession session, IReadOnlyCollection<Driver> roster)
+        {
+            if (session == null) throw new ArgumentNullException(nameof(session));
+
+            var drivers = (roster ?? Array.Empty<Driver>())
+                .Where(d => d != null)
+                .ToList();
+            var existing = (session.DriverEntries ?? new List<RaceSessionDriverEntry>())
+                .Where(e => e != null)
+                .GroupBy(e => e.DriverID)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            session.DriverEntries = drivers.Select(d =>
+            {
+                if (!existing.TryGetValue(d.Id, out var entry))
+                    entry = new RaceSessionDriverEntry { DriverID = d.Id };
+                entry.DriverName = d.Name;
+                entry.QualifyingTime = d.QualTime;
+                return entry;
+            }).ToList();
+
+            session.Drivers = new List<Driver>(drivers);
+        }
     }
 }

--- a/src/RCDragManagerProd/Controllers/RaceController.Session.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Session.cs
@@ -35,9 +35,19 @@ namespace RCDragManagerProd.Controllers
             _rrStandingsCardCache = null;
             _rrLoggedRounds.Clear();
 
+            // Reset returns the console to pre-bracket setup. A lock from the
+            // previous round must not block dial-in entry for the new race.
+            UnlockDialIn();
             laneFairness.Reset();
 
-            if (_session != null) _session.RaceType = string.Empty;
+            if (_session != null)
+            {
+                _session.RaceType = string.Empty;
+                _session.Resume = null;
+                _session.SavedResults?.Clear();
+                _session.SavedRevealedRounds?.Clear();
+                _session.ResultsArchive = new RaceResultsArchive();
+            }
 
             BracketRedrawn?.Invoke(Array.Empty<PairingRow>());
             WinnersUpdated?.Invoke(Array.Empty<WinnerRow>());


### PR DESCRIPTION
## Problem

After resetting a race, selecting a newly added driver and setting their dial-in incorrectly showed “Round in progress.” Even after proceeding, a newly added driver was only present in the WPF grid and not in `RaceSession.DriverEntries`, so the entered dial-in had nowhere to be stored.

## Root causes

1. `RaceController.Reset()` did not clear `_dialInLocked`.
2. The WPF add/edit roster flow did not synchronize newly added drivers back into the session model.
3. Reset left stale resume/result-display state from the previous run.

## What changed

- Reset now unlocks dial-in editing.
- Reset clears stale resume, revealed-round, saved-result, and results-archive state.
- Add/edit/qualifying-time changes synchronize the WPF roster into the session.
- Synchronization preserves existing dial-ins, car metadata, class, and seed values.
- Added regression tests for:
  - locked dial-in followed by Reset;
  - Reset clearing old result-display state;
  - adding a driver after Reset and storing a dial-in;
  - preserving existing driver-entry metadata during roster synchronization.

## Validation

- Full test suite: 290 passed, 11 existing intentional skips, 0 failed.
- WPF Release build succeeded.
- Debug build could not overwrite the executable because the app was actively running under Visual Studio; Release output verified compilation independently.