### PR TITLE
[codex] Complete persisted race result coverage

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerRRStandardFlowTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerRRStandardFlowTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RCDragManagerProd.Controllers;
 using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
 using RCDragManagerProd.Tests.Helpers;
 
 namespace RCDragManagerProd.Tests;
@@ -222,6 +224,24 @@ public class RaceControllerRRStandardFlowTests
             $"All RR headers must precede all LB headers in bracket. Headers: [{string.Join(", ", finalHeaders)}]");
         Assert.IsTrue(firstLbIndex < firstSFOrFIdx,
             $"All LB headers must precede Finals headers (SF/F) in bracket. Headers: [{string.Join(", ", finalHeaders)}]");
+
+        // Historical result archive must survive the real SQLite save/load path.
+        controller.SaveSession();
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repository = new RaceSessionRepository(db.ConnectionString);
+        var savedId = repository.SaveSession(session);
+        var loaded = repository.LoadSession(savedId);
+
+        Assert.IsNotNull(loaded);
+        Assert.IsTrue(loaded.ResultsArchive.Phases.Any(p => p.Phase == RaceTypes.RoundRobin));
+        Assert.IsTrue(loaded.ResultsArchive.Phases.Any(p => p.Phase == RaceTypes.LosersBracket));
+        Assert.IsTrue(loaded.ResultsArchive.Phases.Any(p => p.Phase == RaceTypes.Finals));
+        Assert.AreEqual(drivers.Count, loaded.ResultsArchive.RoundRobinStandings.Count);
+        Assert.IsTrue(loaded.ResultsArchive.RoundRobinStandings.All(s => s.Points > 0));
+        Assert.IsTrue(loaded.ResultsArchive.RoundRobinStandings.All(s => s.OpponentStrength >= 0));
+        Assert.AreEqual(completion.Winner.Id, loaded.ResultsArchive.ChampionDriverId);
+        Assert.AreEqual(completion.RunnerUp.Id, loaded.ResultsArchive.RunnerUpDriverId);
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -231,5 +251,22 @@ public class RaceControllerRRStandardFlowTests
         var peek = controller.PeekUpcomingMatches(20).ToList();
         foreach (var match in peek)
             controller.SubmitWinner(match.MatchId, firstOption: true);
+    }
+
+    private sealed class TemporarySqliteDb : IDisposable
+    {
+        public TemporarySqliteDb() =>
+            DatabasePath = Path.Combine(
+                Path.GetTempPath(),
+                $"rcdragmanager-results-{Guid.NewGuid():N}.db");
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try { if (File.Exists(DatabasePath)) File.Delete(DatabasePath); }
+            catch { }
+        }
     }
 }

--- a/src/RCDragManagerProd.Tests/RaceResultsPresentationBuilderTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceResultsPresentationBuilderTests.cs
@@ -55,8 +55,16 @@ public class RaceResultsPresentationBuilderTests
             {
                 RoundRobinStandings = new List<RoundRobinStandingSnapshot>
                 {
-                    new RoundRobinStandingSnapshot { Rank = 2, DriverName = "Blake", Wins = 2, Losses = 1 },
-                    new RoundRobinStandingSnapshot { Rank = 1, DriverName = "Ava", Wins = 3, Losses = 0 }
+                    new RoundRobinStandingSnapshot
+                    {
+                        Rank = 2, DriverName = "Blake", Wins = 2, Losses = 1,
+                        Points = 9, OpponentStrength = 18
+                    },
+                    new RoundRobinStandingSnapshot
+                    {
+                        Rank = 1, DriverName = "Ava", Wins = 3, Losses = 0,
+                        Points = 12, OpponentStrength = 16
+                    }
                 }
             }
         };
@@ -66,6 +74,8 @@ public class RaceResultsPresentationBuilderTests
         Assert.IsTrue(view.HasResults);
         Assert.IsTrue(view.HasRoundRobinStandings);
         Assert.AreEqual("Ava", view.Standings[0].Driver);
+        Assert.AreEqual("12.00", view.Standings[0].Points);
+        Assert.AreEqual("16.00", view.Standings[0].OpponentStrength);
     }
 
     private static RaceResultMatchSnapshot Match(

--- a/src/RCDragManagerProd.Tests/RoundRobinStandingsTests.cs
+++ b/src/RCDragManagerProd.Tests/RoundRobinStandingsTests.cs
@@ -91,6 +91,7 @@ public class RoundRobinStandingsTests
         }
 
         var standings = adapter.GetStandings();
+        var detailed = adapter.GetRankedStandings();
         var topRanked = adapter.GetTopRankedDrivers(4);
 
         Assert.IsTrue(standings.Count > 0);
@@ -102,5 +103,8 @@ public class RoundRobinStandingsTests
 
         Assert.AreEqual(4, topRanked.Count);
         Assert.AreEqual(4, topRanked.Select(d => d.Id).Distinct().Count());
+        Assert.AreEqual(4, detailed.Count);
+        Assert.IsTrue(detailed.All(r => r.Points > 0));
+        Assert.IsTrue(detailed.All(r => r.Rank > 0));
     }
 }

--- a/src/RCDragManagerProd.WPF/Dialogs/RaceResultsWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/RaceResultsWindow.xaml
@@ -141,6 +141,9 @@
                             <DataGridTextColumn Header="Driver" Binding="{Binding Driver}" Width="*"/>
                             <DataGridTextColumn Header="Wins" Binding="{Binding Wins}" Width="100"/>
                             <DataGridTextColumn Header="Losses" Binding="{Binding Losses}" Width="100"/>
+                            <DataGridTextColumn Header="Points" Binding="{Binding Points}" Width="100"/>
+                            <DataGridTextColumn Header="Opponent strength"
+                                                Binding="{Binding OpponentStrength}" Width="150"/>
                         </DataGrid.Columns>
                     </DataGrid>
                 </TabItem>

--- a/src/RCDragManagerProd/AppServices/RaceResultsPresentationBuilder.cs
+++ b/src/RCDragManagerProd/AppServices/RaceResultsPresentationBuilder.cs
@@ -69,7 +69,9 @@ namespace RCDragManagerProd.AppServices
                     Rank = s.Rank,
                     Driver = s.DriverName,
                     Wins = s.Wins,
-                    Losses = s.Losses
+                    Losses = s.Losses,
+                    Points = s.Points.ToString("0.00"),
+                    OpponentStrength = s.OpponentStrength.ToString("0.00")
                 })
                 .ToList();
 

--- a/src/RCDragManagerProd/Controllers/RaceController.ResultSnapshots.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.ResultSnapshots.cs
@@ -35,23 +35,25 @@ namespace RCDragManagerProd.Controllers
             var matches = EngineGetMatches(rr).ToList();
             CapturePhaseSnapshot(RaceTypes.RoundRobin, matches);
 
-            var standings = rr.GetStandings();
-            var losses = matches
-                .Where(m => m.HasResult)
-                .Select(m => _matchResult.GetLoser(m.MatchId))
+            var standings = rr.GetRankedStandings();
+            var driverById = (_session.Drivers ?? new List<Driver>())
                 .Where(d => d != null)
                 .GroupBy(d => d.Id)
-                .ToDictionary(g => g.Key, g => g.Count());
+                .ToDictionary(g => g.Key, g => g.First());
 
             EnsureResultsArchive();
             _session.ResultsArchive.RoundRobinStandings = standings
-                .Select((row, index) => new RoundRobinStandingSnapshot
+                .Select(row => new RoundRobinStandingSnapshot
                 {
-                    Rank = index + 1,
-                    DriverId = row.Driver.Id,
-                    DriverName = row.Driver.Name,
+                    Rank = row.Rank,
+                    DriverId = row.DriverId,
+                    DriverName = driverById.TryGetValue(row.DriverId, out var driver)
+                        ? driver.Name
+                        : row.DriverId.ToString(),
                     Wins = row.Wins,
-                    Losses = losses.TryGetValue(row.Driver.Id, out var count) ? count : 0
+                    Losses = row.Losses,
+                    Points = row.Points,
+                    OpponentStrength = row.OpponentStrength
                 })
                 .ToList();
         }

--- a/src/RCDragManagerProd/Domain/RaceResults.cs
+++ b/src/RCDragManagerProd/Domain/RaceResults.cs
@@ -52,5 +52,7 @@ namespace RCDragManagerProd.Domain
         public string DriverName { get; set; }
         public int Wins { get; set; }
         public int Losses { get; set; }
+        public double Points { get; set; }
+        public double OpponentStrength { get; set; }
     }
 }

--- a/src/RCDragManagerProd/RaceEngines/RoundRobinEngineAdapter.cs
+++ b/src/RCDragManagerProd/RaceEngines/RoundRobinEngineAdapter.cs
@@ -188,6 +188,13 @@ namespace RCDragManagerProd.RaceEngines
             return top;
         }
 
+        public List<DriverRankResult> GetRankedStandings()
+        {
+            var ranked = _engine.GetRankedStandings();
+            Logger.Log($"[RR-ADAPTER] Detailed standings rows: {ranked.Count}");
+            return ranked;
+        }
+
         public bool IsBye(Driver d) =>
             ByePolicy.IsBye(d);
     }

--- a/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
+++ b/src/RCDragManagerProd/RoundRobinMode/RoundRobinEngine.cs
@@ -326,13 +326,18 @@ namespace RCDragManagerProd.RoundRobinMode
 
         public List<Driver> GetTopRankedDrivers(int count)
         {
-            var ranker = new RoundRobinRanker();
-            var ranked = ranker.Rank(GetResults(), drivers, results);
+            var ranked = GetRankedStandings();
 
             return ranked.Take(count)
                          .Select(r => drivers.FirstOrDefault(d => d.Id == r.DriverId))
                          .Where(d => d != null)
                          .ToList();
+        }
+
+        public List<DriverRankResult> GetRankedStandings()
+        {
+            var ranker = new RoundRobinRanker();
+            return ranker.Rank(GetResults(), drivers, results);
         }
 
         // --------------------------------------------------------------

--- a/src/RCDragManagerProd/ViewModels/RaceResultsPresentation.cs
+++ b/src/RCDragManagerProd/ViewModels/RaceResultsPresentation.cs
@@ -50,5 +50,7 @@ namespace RCDragManagerProd.ViewModels
         public string Driver { get; set; }
         public int Wins { get; set; }
         public int Losses { get; set; }
+        public string Points { get; set; }
+        public string OpponentStrength { get; set; }
     }
 }


### PR DESCRIPTION
## What changed

- Persist the detailed Round Robin ranking data used by the race engine:
  - rank
  - points
  - wins
  - losses
  - opponent strength
- Display points and opponent strength in the saved Round Robin standings view.
- Expose the engine's detailed ranked standings through the adapter instead of rebuilding an incomplete wins-only table.
- Add a real SQLite end-to-end regression covering:
  - Standard Round Robin
  - Losers Bracket
  - Finals
  - champion and runner-up
  - detailed standings after save/reload
- Extend presentation and ranking tests for the additional fields.

## Why

The result archive previously retained only wins and losses, despite the actual Round Robin ranking using points, head-to-head, and opponent strength. That meant a reopened race could display less information than was used to determine the finalists.

This completes the remaining data-integrity and test coverage from #361 and #364.

## Validation

- Full test suite: 290 passed, 11 existing intentional skips, 0 failed.
- WPF Release build succeeded.

## Issues

Part of #359
Completes #361
Completes #364