### PR TITLE
[codex] Prevent completed races from restarting

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerSaveCloseTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerSaveCloseTests.cs
@@ -63,6 +63,60 @@ public class RaceControllerSaveCloseTests
     }
 
     [TestMethod]
+    public void RestoreFromSave_ClosedRace_RemainsResultsOnly()
+    {
+        var (session, controller) = NewMidEventRace();
+        controller.SaveProgress();
+        controller.CloseRace();
+        var loaded = Persist(session);
+
+        var restored = new RaceController(loaded, new NoOpStandingsDialogService());
+        restored.RestoreFromSave();
+
+        Assert.IsTrue(restored.IsCompleted);
+        Assert.IsFalse(restored.HasBracketStarted,
+            "A closed race must not reconstruct a live engine that can be rerun");
+
+        restored.GenerateBracket(loaded.RaceType, loaded.Drivers);
+        Assert.IsFalse(restored.HasBracketStarted,
+            "GenerateBracket must reject completed races");
+    }
+
+    [TestMethod]
+    public void RestoreFromSave_RaceWithCompletedResults_RemainsResultsOnly()
+    {
+        var (session, controller) = NewMidEventRace();
+        controller.SaveProgress();
+        session.ResultsArchive.CompletedAt = new DateTime(2026, 6, 8, 10, 0, 0);
+        var loaded = Persist(session);
+
+        var restored = new RaceController(loaded, new NoOpStandingsDialogService());
+        restored.RestoreFromSave();
+
+        Assert.IsTrue(restored.IsCompleted);
+        Assert.IsFalse(restored.HasBracketStarted);
+    }
+
+    [TestMethod]
+    public void GenerateBracket_WhenEngineAlreadyExists_RejectsPhaseNameWithoutCrashing()
+    {
+        var session = NewSession("Round Robin");
+        var drivers = TestDriverFactory.CreateRoundRobinPack(6);
+        var controller = new RaceController(session, new NoOpStandingsDialogService());
+        controller.GenerateBracket("Round Robin", drivers);
+        var before = controller.PeekUpcomingMatches(10)
+            .Select(m => m.MatchId)
+            .ToArray();
+
+        session.RaceType = "Finals";
+        controller.GenerateBracket(session.RaceType, drivers);
+
+        CollectionAssert.AreEqual(before, controller.PeekUpcomingMatches(10)
+            .Select(m => m.MatchId)
+            .ToArray());
+    }
+
+    [TestMethod]
     public void SaveProgress_AndCloseRace_AreNotTheSameAction()
     {
         var (saveSession, saveController) = NewMidEventRace();

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
@@ -71,6 +71,7 @@ namespace RCDragManagerProd.WPF.Views
             }
             UpdatePrimaryButtons();
             UpdateRaceResultsButton();
+            ApplyCompletedRaceState();
 
             _controller.BracketRedrawn += OnBracketRedrawn;
             _controller.NextMatchReady += OnNextMatchReady;
@@ -81,7 +82,29 @@ namespace RCDragManagerProd.WPF.Views
             _controller.CanStartFinalsChanged += OnCanStartFinalsChanged;
             _controller.TournamentCompleted += OnTournamentCompleted;
 
-            _controller.StartDialInPolling();
+            if (!_controller.IsCompleted)
+                _controller.StartDialInPolling();
+        }
+
+        private void ApplyCompletedRaceState()
+        {
+            if (!_controller.IsCompleted) return;
+
+            LblEventTitle.Text = $"{_raceConsole.GetState().EventTitle} — completed (results only)";
+            TxtName.IsEnabled = false;
+            TxtTime.IsEnabled = false;
+            DgDrivers.IsHitTestVisible = false;
+            BtnEditResult.IsEnabled = false;
+            BtnStandings.IsEnabled = false;
+            BtnBuybacks.IsEnabled = false;
+            BtnReset.IsEnabled = false;
+            BtnWinner1.IsEnabled = false;
+            BtnWinner2.IsEnabled = false;
+            BtnMoreTime.IsEnabled = false;
+            BtnGenerateBracket.IsEnabled = false;
+            BtnNextRound.IsEnabled = false;
+            UpdatePrimaryButtons();
+            Logger.Log($"[WPF][CONSOLE] Completed race '{_session?.EventName}' opened results-only.");
         }
 
         /// <summary>Explicit cleanup — called by the host window on close (not on tab
@@ -218,17 +241,18 @@ namespace RCDragManagerProd.WPF.Views
 
         private void OnCanAdvanceChanged(bool can) => Run(() =>
         {
-            BtnNextRound.IsEnabled = can;
+            BtnNextRound.IsEnabled = can && !_controller.IsCompleted;
             if (can) _controller.UnlockDialIn();
             UpdatePrimaryButtons();
         });
 
-        private void OnCanDeferChanged(bool can) => Run(() => BtnMoreTime.IsEnabled = can);
+        private void OnCanDeferChanged(bool can) =>
+            Run(() => BtnMoreTime.IsEnabled = can && !_controller.IsCompleted);
 
         private void OnCanOfferBuybackChanged(bool enabled) => Run(() =>
         {
-            BtnBuybacks.IsEnabled = enabled;
-            BtnStandings.IsEnabled = enabled;
+            BtnBuybacks.IsEnabled = enabled && !_controller.IsCompleted;
+            BtnStandings.IsEnabled = enabled && !_controller.IsCompleted;
             if (enabled && !IsHostedMode)
                 MessageDialog.Info(Host, "Round-Robin complete.\nClick 'Open buybacks' to add drivers to the Losers Bracket.",
                     "Buyback phase ready");
@@ -236,7 +260,7 @@ namespace RCDragManagerProd.WPF.Views
 
         private void OnCanStartFinalsChanged(bool enabled) => Run(() =>
         {
-            BtnGenerateBracket.IsEnabled = enabled;
+            BtnGenerateBracket.IsEnabled = enabled && !_controller.IsCompleted;
             if (enabled)
             {
                 BtnGenerateBracket.Content = "Start finals";
@@ -253,6 +277,9 @@ namespace RCDragManagerProd.WPF.Views
 
         private void OnTournamentCompleted(RaceController.RaceSummary summary) => Run(() =>
         {
+            UpdateRaceResultsButton();
+            ApplyCompletedRaceState();
+
             // In hosted mode the multi-class window records stats and shows the popup.
             if (IsHostedMode) return;
 
@@ -321,8 +348,19 @@ namespace RCDragManagerProd.WPF.Views
 
         // ── Driver actions ────────────────────────────────────────────────────
 
+        private bool RejectCompletedRaceEdit()
+        {
+            if (!_controller.IsCompleted) return false;
+            MessageDialog.Info(Host,
+                "This race is complete and is available for viewing only. Use Results to view the saved winners and ladder.",
+                "Race complete");
+            return true;
+        }
+
         private void BtnAddDriver_Click(object sender, RoutedEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             if (_controller.HasBracketStarted)
             {
                 MessageDialog.Info(Host, "This race has already started — drivers can't be added to the active race.",
@@ -360,6 +398,8 @@ namespace RCDragManagerProd.WPF.Views
 
         private void BtnEditDriver_Click(object sender, RoutedEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             if (_controller.HasBracketStarted)
             {
                 MessageDialog.Info(Host, "This race has already started — driver identity is fixed.",
@@ -382,6 +422,8 @@ namespace RCDragManagerProd.WPF.Views
 
         private void BtnSetQual_Click(object sender, RoutedEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             var row = DgDrivers.SelectedItem as ConsoleDriverRow;
             if (row == null) { MessageDialog.Info(Host, "Select a driver.", "Set qual time"); return; }
             var driver = _drivers.FirstOrDefault(d => d.Id == row.DriverId);
@@ -404,6 +446,8 @@ namespace RCDragManagerProd.WPF.Views
 
         private void BtnSetDialIn_Click(object sender, RoutedEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             var row = DgDrivers.SelectedItem as ConsoleDriverRow;
             if (row == null) { MessageDialog.Info(Host, "Select a driver.", "Set dial-in"); return; }
             EditDialIn(row.DriverId, row.Name);
@@ -411,11 +455,15 @@ namespace RCDragManagerProd.WPF.Views
 
         private void DgDrivers_DoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             if (DgDrivers.SelectedItem is ConsoleDriverRow row) EditDialIn(row.DriverId, row.Name);
         }
 
         private void EditDialIn(int driverId, string name)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             if (_controller.DialInLocked)
             {
                 if (!MessageDialog.Confirm(Host,
@@ -499,6 +547,13 @@ namespace RCDragManagerProd.WPF.Views
 
         private void BtnGenerateBracket_Click(object sender, RoutedEventArgs e)
         {
+            if (_controller.IsCompleted)
+            {
+                MessageDialog.Info(Host, "This race is complete. Use Results to view the saved winners and ladder.",
+                    "Race complete");
+                return;
+            }
+
             var raceType = _controller.Session?.RaceType ?? _session?.RaceType;
             var action = _raceConsole.ExecutePrimaryAction(_drivers, raceType);
             BtnGenerateBracket.IsEnabled = false;
@@ -531,6 +586,8 @@ namespace RCDragManagerProd.WPF.Views
 
         private void BtnReset_Click(object sender, RoutedEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             if (_controller.HasBracketStarted)
             {
                 if (!MessageDialog.Confirm(Host,
@@ -579,6 +636,8 @@ namespace RCDragManagerProd.WPF.Views
 
         private void BtnBuybacks_Click(object sender, RoutedEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             var eligible = _raceConsole.GetEligibleBuybacks();
             if (eligible == null || eligible.Count < 2)
             {
@@ -607,6 +666,8 @@ namespace RCDragManagerProd.WPF.Views
 
         private void BtnEditResult_Click(object sender, RoutedEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             var selectable = (IcWinners.ItemsSource as IEnumerable<WinnerDisplayRow>)
                 ?.Where(r => !r.IsHeader && r.MatchId > 0).ToList();
             if (selectable == null || selectable.Count == 0)
@@ -646,6 +707,8 @@ namespace RCDragManagerProd.WPF.Views
 
         private void BtnSaveProgress_Click(object sender, RoutedEventArgs e)
         {
+            if (RejectCompletedRaceEdit()) return;
+
             if (_session == null)
             {
                 MessageDialog.Info(Host, "Quick session has no saved file to update.", "Nothing to save");

--- a/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleService.cs
@@ -71,6 +71,12 @@ namespace RCDragManagerProd.AppServices
         /// <param name="raceType">Engine key used only when building the initial bracket.</param>
         public RaceConsolePrimaryAction ExecutePrimaryAction(List<Driver> drivers, string raceType)
         {
+            if (_controller.IsCompleted)
+            {
+                Logger.Log($"[CONSOLE][REJECT] Primary action blocked for completed race '{_controller.Session?.EventName}'.");
+                return RaceConsolePrimaryAction.None;
+            }
+
             var action = RaceConsoleViewModelBuilder.ResolvePrimaryAction(
                 _controller.IsFinalsPending, _controller.IsInLosersBracketPhase);
 
@@ -97,6 +103,12 @@ namespace RCDragManagerProd.AppServices
         /// </summary>
         public void AdvanceRound()
         {
+            if (_controller.IsCompleted)
+            {
+                Logger.Log($"[CONSOLE][REJECT] Advance blocked for completed race '{_controller.Session?.EventName}'.");
+                return;
+            }
+
             _controller.LockDialIn();
             _controller.AdvanceRound();
         }

--- a/src/RCDragManagerProd/AppServices/RaceConsoleViewModel.cs
+++ b/src/RCDragManagerProd/AppServices/RaceConsoleViewModel.cs
@@ -12,6 +12,7 @@ namespace RCDragManagerProd.AppServices
     {
         /// <summary>Initial state — build the bracket from the entered drivers.</summary>
         BuildBracket,
+        None,
 
         /// <summary>Round Robin done and buybacks stored — start the Losers Bracket.</summary>
         StartLosersBracket,

--- a/src/RCDragManagerProd/Controllers/RaceController.Results.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Results.cs
@@ -18,6 +18,12 @@ namespace RCDragManagerProd.Controllers
     {
         public void SubmitWinner(int matchId, bool firstOption)
         {
+            if (IsCompleted)
+            {
+                Logger.Log($"[WINNER] Reject — completed race '{_session.EventName}' is results-only.");
+                return;
+            }
+
             EnsureReady();
 
             var match = EngineGetMatches(_engine, matchId: matchId).FirstOrDefault(m => m.MatchId == matchId);
@@ -129,6 +135,12 @@ namespace RCDragManagerProd.Controllers
 
         public bool EditWinnerInActiveRound(int matchId, bool firstOption)
         {
+            if (IsCompleted)
+            {
+                Logger.Log($"[CTRL][EDIT] Reject — completed race '{_session.EventName}' is results-only.");
+                return false;
+            }
+
             EnsureReady();
 
             var match = EngineGetMatches(_engine, matchId: matchId).FirstOrDefault(m => m.MatchId == matchId);

--- a/src/RCDragManagerProd/Controllers/RaceController.Resume.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Resume.cs
@@ -24,6 +24,20 @@ namespace RCDragManagerProd.Controllers
         /// </summary>
         public void RestoreFromSave()
         {
+            if (IsCompleted)
+            {
+                _tournamentClosed = true;
+                Logger.Log($"[RESUME] Completed race '{_session.EventName}' opened results-only; live engine restore skipped.");
+                BracketRedrawn?.Invoke(Array.Empty<RCDragManagerProd.ViewModels.PairingRow>());
+                WinnersUpdated?.Invoke(Array.Empty<RCDragManagerProd.ViewModels.WinnerRow>());
+                NextMatchReady?.Invoke(null);
+                CanAdvanceChanged?.Invoke(false);
+                CanPickWinnerChanged?.Invoke(false);
+                CanOfferBuybackChanged?.Invoke(false);
+                CanStartFinalsChanged?.Invoke(false);
+                return;
+            }
+
             if (_session?.Resume == null)
             {
                 Logger.Log("[RESUME] No resume snapshot — nothing to restore (fresh or pre-feature session).");

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -33,6 +33,20 @@ namespace RCDragManagerProd.Controllers
         // ------------------  PUBLIC API (CORE FLOW)  ------------------
         public void GenerateBracket(string raceType, List<Driver> drivers)
         {
+            if (IsCompleted)
+            {
+                Logger.Log($"[CTRL][REJECT] GenerateBracket blocked for completed race '{_session.EventName}'.");
+                CanAdvanceChanged?.Invoke(false);
+                CanPickWinnerChanged?.Invoke(false);
+                return;
+            }
+
+            if (_engine != null)
+            {
+                Logger.Log($"[CTRL][REJECT] GenerateBracket blocked because a '{_engine.GetType().Name}' race is already active (requested type='{raceType}').");
+                return;
+            }
+
             if (drivers == null || drivers.Count < 2)
             {
                 Logger.Log("? Cannot generate bracket � provided driver list is invalid.");
@@ -202,6 +216,13 @@ namespace RCDragManagerProd.Controllers
 
         public void AdvanceRound()
         {
+            if (IsCompleted)
+            {
+                Logger.Log($"[CTRL][REJECT] AdvanceRound blocked for completed race '{_session.EventName}'.");
+                CanAdvanceChanged?.Invoke(false);
+                return;
+            }
+
             Logger.Log($"[SNAP] AdvanceRound-entry  |  _engine={_engine?.GetType().Name ?? "null"}  |  _losersEngine={_losersEngine?.GetType().Name ?? "null"}  |  revealedRounds={string.Join(",", _revealedRounds)}");
 
             if (_engine == null)

--- a/src/RCDragManagerProd/Controllers/RaceController.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.cs
@@ -25,6 +25,8 @@ namespace RCDragManagerProd.Controllers
         private readonly List<WinnerRow> _winners = new();
 
         public RaceSession Session => _session;
+        public bool IsCompleted =>
+            _session.IsClosed || _session.ResultsArchive?.CompletedAt != null;
         private readonly MatchResult _matchResult = new();
         private MatchResult _results => _matchResult;
 


### PR DESCRIPTION
## What changed

- Treat races as completed when they are closed or have a persisted completion timestamp.
- Open completed races in results-only mode instead of rebuilding a live race engine.
- Disable bracket generation, round advancement, winner entry, result editing, roster changes, dial-in changes, reset, buybacks, and save-progress actions for completed races.
- Keep the saved Results window available for viewing the champion, runner-up, ladder, result list, and Round Robin standings.
- Reject duplicate bracket generation whenever a race engine is already active, preventing phase labels such as `Finals` from reaching `RaceEngineFactory`.
- Add regression tests for closed sessions, completed-result sessions, and duplicate generation during the Finals phase.

## Root cause

A saved completed race retained a resume snapshot and `RaceType` had mutated from its original engine mode to the current phase name, `Finals`. The console restored or allowed live actions against that historical session. A subsequent Generate action called `RaceEngineFactory.Create(Finals)`, which is not a valid engine key and raised the exception seen in the race-day log at 22:18:46 on June 21, 2026.

## Operator impact

Reopening a completed race now clearly shows `completed (results only)`. It cannot be accidentally rerun or altered; the Results button remains the path to the saved winners and ladder.

## Validation

- Full test suite: 293 passed, 11 intentionally skipped, 0 failed.
- WPF Release build: succeeded with 0 errors.
- `git diff --check`: clean.