### PR TITLE
[codex] Complete recent event resume

### DIFF
--- a/src/RCDragManagerProd.Tests/LoadSessionServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/LoadSessionServiceTests.cs
@@ -181,6 +181,59 @@ public class LoadSessionServiceTests
     // ── DeleteSession ─────────────────────────────────────────────────────────
 
     [TestMethod]
+    public void LoadEvent_SingleClassCard_LoadsWrappedSession()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+        repo.SaveSession(MakeSession("Recent Single", "Sportsman", "Pro Ladder"));
+        int id = service.ListSessions()[0].Id;
+
+        var result = service.LoadEvent(id, isMultiClass: false);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("Recent Single", result.Event.EventName);
+        Assert.AreEqual(1, result.Event.ClassSessions.Count);
+    }
+
+    [TestMethod]
+    public void LoadEvent_MultiClassCard_LoadsSavedEvent()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        var repo = new MultiClassEventRepository(db.ConnectionString);
+        repo.SaveEvent(new MultiClassEvent
+        {
+            EventName = "Recent Multi",
+            EventDate = new DateTime(2026, 6, 22),
+            ClassSessions = new List<RaceSession>
+            {
+                MakeSession("Class A", "Open", "Round Robin"),
+                MakeSession("Class B", "Mod", "Round Robin")
+            }
+        });
+        int id = service.ListMultiClassEvents()[0].Id;
+
+        var result = service.LoadEvent(id, isMultiClass: true);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("Recent Multi", result.Event.EventName);
+        Assert.AreEqual(2, result.Event.ClassSessions.Count);
+    }
+
+    [TestMethod]
+    public void LoadEvent_MissingRecentCard_ReturnsFailure()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+
+        var result = service.LoadEvent(999, isMultiClass: false);
+
+        Assert.IsFalse(result.Success);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.ErrorMessage));
+    }
+
+    [TestMethod]
     public void DeleteSession_RemovesRowFromList()
     {
         using var db = new TemporarySqliteDb();

--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml.cs
@@ -12,6 +12,7 @@ namespace RCDragManagerProd.WPF.Windows
     {
         private readonly string _connectionString;
         private readonly LandingViewModel _vm;
+        private readonly LoadSessionService _loadService;
 
         public LandingWindow(string connectionString)
         {
@@ -22,9 +23,9 @@ namespace RCDragManagerProd.WPF.Windows
             var driverRepo = new DriverRepository(connectionString);
             var sessionRepo = new RaceSessionRepository(connectionString);
             var multiClassRepo = new MultiClassEventRepository(connectionString);
-            var loadService = new LoadSessionService(sessionRepo, multiClassRepo);
+            _loadService = new LoadSessionService(sessionRepo, multiClassRepo);
 
-            _vm = new LandingViewModel(loadService, driverRepo);
+            _vm = new LandingViewModel(_loadService, driverRepo);
             DataContext = _vm;
             _vm.Load();
         }
@@ -79,9 +80,17 @@ namespace RCDragManagerProd.WPF.Windows
 
         private void EventCard_Click(object sender, RoutedEventArgs e)
         {
-            if (e.Source is FrameworkElement el && el.Tag is RecentEventRow row)
+            if (sender is FrameworkElement el && el.Tag is RecentEventRow row)
             {
-                MessageDialog.Info(this, $"Resume '{row.EventName}' — coming soon.");
+                var result = _loadService.LoadEvent(row.Id, row.IsMultiClass);
+                if (!result.Success)
+                {
+                    MessageDialog.Error(this, result.ErrorMessage, "Load error");
+                    _vm.Load();
+                    return;
+                }
+
+                OpenConsole(result.Event, restore: true);
             }
         }
 

--- a/src/RCDragManagerProd/AppServices/LoadSessionService.cs
+++ b/src/RCDragManagerProd/AppServices/LoadSessionService.cs
@@ -45,6 +45,9 @@ namespace RCDragManagerProd.AppServices
         /// Loads a single-class session by id and wraps it into a one-class
         /// <see cref="MultiClassEvent"/> ready to open in <c>MultiClassRaceForm</c>.
         /// </summary>
+        public LoadResult LoadEvent(int id, bool isMultiClass) =>
+            isMultiClass ? LoadMultiClassEvent(id) : LoadSingleClassSession(id);
+
         public LoadResult LoadSingleClassSession(int id)
         {
             Logger.Log($"[SVC][LoadSession] LoadSingleClassSession(id={id})");


### PR DESCRIPTION
## What changed

- Replace the Recent events `coming soon` placeholder with direct saved-event loading.
- Route single-class cards through the existing single-session loader and multi-class cards through the multi-class loader.
- Open the loaded event in the same race console used by the full Load saved event window.
- Show the existing load error dialog and refresh the recent list if a saved record no longer exists.
- Use the button sender rather than the routed event source so clicks on card text and whitespace behave consistently.
- Add repository-backed tests for single-class, multi-class, and missing recent-event records.

## Operator impact

The five Recent events cards on the landing page are now functional shortcuts. Clicking one immediately resumes an in-progress race or opens a completed race in results-only mode.

## Validation

- Full test suite: 296 passed, 11 intentionally skipped, 0 failed.
- WPF Release build: succeeded with 0 errors.
- `git diff --check`: clean.