### PR TITLE
[codex] Improve race results and winner presentation

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceResultsPresentationBuilderTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceResultsPresentationBuilderTests.cs
@@ -78,6 +78,96 @@ public class RaceResultsPresentationBuilderTests
         Assert.AreEqual("16.00", view.Standings[0].OpponentStrength);
     }
 
+    [TestMethod]
+    public void ClassCompletionBuild_CreatesPodiumAndSmallerRemainingResults()
+    {
+        var session = new RaceSession
+        {
+            EventName = "Summer Meet",
+            ClassType = "Pro Mod",
+            ResultsArchive = new RaceResultsArchive
+            {
+                ChampionDriverId = 1,
+                ChampionName = "Ava",
+                RunnerUpDriverId = 2,
+                RunnerUpName = "Casey",
+                RoundRobinStandings = new List<RoundRobinStandingSnapshot>
+                {
+                    Standing(1, 1, "Ava"),
+                    Standing(2, 3, "Blake"),
+                    Standing(3, 2, "Casey"),
+                    Standing(4, 4, "Drew")
+                },
+                Phases = new List<RacePhaseResultSnapshot>
+                {
+                    new RacePhaseResultSnapshot
+                    {
+                        Phase = RaceTypes.Finals,
+                        Matches = new List<RaceResultMatchSnapshot>
+                        {
+                            Match(1, "SF", "Ava", "Drew", "Ava", "Drew"),
+                            Match(2, "SF", "Blake", "Casey", "Casey", "Blake"),
+                            Match(3, "F", "Ava", "Casey", "Ava", "Casey")
+                        }
+                    }
+                }
+            }
+        };
+
+        var view = ClassCompletionPresentationBuilder.Build(session);
+
+        Assert.AreEqual("Ava", view.ChampionName);
+        Assert.AreEqual("Casey", view.RunnerUpName);
+        Assert.AreEqual("Blake", view.ThirdName);
+        Assert.AreEqual("3rd place", view.ThirdLabel);
+        Assert.AreEqual(1, view.OtherFinishers.Count);
+        Assert.AreEqual("Drew", view.OtherFinishers[0].Driver);
+        Assert.AreEqual(3, view.FinalsResults.Count);
+    }
+
+    [TestMethod]
+    public void ClassCompletionBuild_UsesSemiFinalistsWhenNoRoundRobinRankingExists()
+    {
+        var session = new RaceSession
+        {
+            ResultsArchive = new RaceResultsArchive
+            {
+                ChampionName = "Ava",
+                RunnerUpName = "Casey",
+                Phases = new List<RacePhaseResultSnapshot>
+                {
+                    new RacePhaseResultSnapshot
+                    {
+                        Phase = RaceTypes.Finals,
+                        Matches = new List<RaceResultMatchSnapshot>
+                        {
+                            Match(1, "SF", "Ava", "Drew", "Ava", "Drew"),
+                            Match(2, "SF", "Blake", "Casey", "Casey", "Blake")
+                        }
+                    }
+                }
+            }
+        };
+
+        var view = ClassCompletionPresentationBuilder.Build(session);
+
+        Assert.AreEqual("Semi-finalists", view.ThirdLabel);
+        StringAssert.Contains(view.ThirdName, "Drew");
+        StringAssert.Contains(view.ThirdName, "Blake");
+    }
+
+    private static RoundRobinStandingSnapshot Standing(int rank, int id, string name) =>
+        new RoundRobinStandingSnapshot
+        {
+            Rank = rank,
+            DriverId = id,
+            DriverName = name,
+            Wins = 3,
+            Losses = 1,
+            Points = 10 - rank,
+            OpponentStrength = 20 - rank
+        };
+
     private static RaceResultMatchSnapshot Match(
         int id, string round, string d1, string d2, string winner, string loser) =>
         new RaceResultMatchSnapshot

--- a/src/RCDragManagerProd.Tests/TestFoundationTests.cs
+++ b/src/RCDragManagerProd.Tests/TestFoundationTests.cs
@@ -94,11 +94,13 @@ public class TestFoundationTests
     }
 
     [TestMethod]
-    public void Standings_SurfacedOnCompletion_AndReShownOnDemand()
+    public void Standings_CompletionEventRaisedOnce_AndReShownOnDemand()
     {
         var recorder = new RecordingStandingsDialogService();
         var controller = new RaceController(
             TestSessionFactory.RoundRobin(variant: "Standard"), recorder);
+        int completionEvents = 0;
+        controller.RoundRobinCompleted += () => completionEvents++;
 
         // 6 drivers (not 4): completion then leaves >=2 buyback-eligible drivers, so the
         // controller takes the buyback path. The standings auto-show fires on RR completion
@@ -107,8 +109,8 @@ public class TestFoundationTests
         // MessageBox that would block a headless test host.
         controller.GenerateBracket("Round Robin", TestDriverFactory.CreateRoundRobinPack(6));
 
-        // Resolve every revealed match and advance until RR completion auto-surfaces standings.
-        for (int i = 0; i < 40 && recorder.ShowCount == 0; i++)
+        // Resolve every revealed match and advance until RR completion is announced.
+        for (int i = 0; i < 40 && completionEvents == 0; i++)
         {
             var matches = controller.PeekUpcomingMatches(50).ToList();
             if (matches.Count > 0)
@@ -118,14 +120,15 @@ public class TestFoundationTests
                 controller.AdvanceRound();
         }
 
-        Assert.IsTrue(recorder.ShowCount >= 1,
-            "RR completion must surface standings through the dialog service");
-        int afterAutoShow = recorder.ShowCount;
+        Assert.AreEqual(1, completionEvents,
+            "RR completion must raise exactly one event for the results UI");
+        Assert.AreEqual(0, recorder.ShowCount,
+            "RR completion must not open the legacy text standings dialog automatically");
 
         // The "Standings" button re-shows the cached card on demand.
         Assert.IsTrue(controller.TryShowRoundRobinStandings(),
             "Standings must be available on demand once RR is complete");
-        Assert.AreEqual(afterAutoShow + 1, recorder.ShowCount,
+        Assert.AreEqual(1, recorder.ShowCount,
             "On-demand Standings must route exactly one more call through the dialog service");
         Assert.IsFalse(string.IsNullOrWhiteSpace(recorder.LastShow?.Content),
             "Standings content must be non-empty");

--- a/src/RCDragManagerProd.WPF/Dialogs/ClassCompletionWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassCompletionWindow.xaml
@@ -1,0 +1,153 @@
+<Window x:Class="RCDragManagerProd.WPF.Dialogs.ClassCompletionWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Class complete"
+        Width="920" Height="700" MinWidth="760" MinHeight="560"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None" ResizeMode="CanResizeWithGrip"
+        KeyDown="Window_KeyDown"
+        Background="{StaticResource Brush.Background}"
+        FontFamily="Segoe UI" ShowInTaskbar="False">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="38" GlassFrameThickness="0"
+                      ResizeBorderThickness="5" UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Border Background="{StaticResource Brush.Background}"
+            BorderBrush="{StaticResource Brush.WindowEdge}" BorderThickness="1">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="38"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <Grid Grid.Row="0" Background="{StaticResource Brush.Chrome}">
+                <TextBlock Text="Class complete"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           FontSize="12" Foreground="{StaticResource Brush.TextHint}" FontWeight="Medium"/>
+                <Button Style="{StaticResource Style.WinCtrl.Close}"
+                        HorizontalAlignment="Right" VerticalAlignment="Center"
+                        Margin="0,0,14,0" Click="BtnClose_Click"/>
+            </Grid>
+
+            <Border Grid.Row="1" Padding="28,20"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,0,0,1">
+                <StackPanel>
+                    <TextBlock Text="{Binding EventName}"
+                               FontSize="{StaticResource FontSize.Md}"
+                               Foreground="{StaticResource Brush.TextMuted}"/>
+                    <TextBlock Text="{Binding ClassName}" Margin="0,3,0,0"
+                               FontSize="{StaticResource FontSize.Xxl}" FontWeight="SemiBold"
+                               Foreground="{StaticResource Brush.TextPrimary}"/>
+                </StackPanel>
+            </Border>
+
+            <Grid Grid.Row="2" Margin="28,24,28,18">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1.4*"/>
+                    <ColumnDefinition Width="14"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <Border Grid.Column="0" Padding="26,24"
+                        Background="{StaticResource Brush.Primary}"
+                        CornerRadius="{StaticResource Radius.Panel}">
+                    <StackPanel HorizontalAlignment="Center">
+                        <TextBlock Text="★" FontSize="34" Foreground="White"
+                                   HorizontalAlignment="Center"/>
+                        <TextBlock Text="CLASS CHAMPION" Margin="0,8,0,7"
+                                   FontSize="{StaticResource FontSize.Sm}" FontWeight="SemiBold"
+                                   Foreground="#CCFFFFFF" HorizontalAlignment="Center"/>
+                        <TextBlock Text="{Binding ChampionName}" TextWrapping="Wrap"
+                                   FontSize="30" FontWeight="Bold" Foreground="White"
+                                   HorizontalAlignment="Center" TextAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+
+                <Grid Grid.Column="2">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="10"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0" Padding="18,15"
+                            Background="{StaticResource Brush.Surface}"
+                            BorderBrush="{StaticResource Brush.Border}" BorderThickness="1"
+                            CornerRadius="{StaticResource Radius.Panel}">
+                        <StackPanel>
+                            <TextBlock Text="2ND PLACE"
+                                       FontSize="{StaticResource FontSize.Xs}" FontWeight="SemiBold"
+                                       Foreground="{StaticResource Brush.TextHint}"/>
+                            <TextBlock Text="{Binding RunnerUpName}" Margin="0,6,0,0"
+                                       FontSize="{StaticResource FontSize.Xl}" FontWeight="SemiBold"
+                                       Foreground="{StaticResource Brush.TextPrimary}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Row="2" Padding="18,15"
+                            Background="{StaticResource Brush.Surface}"
+                            BorderBrush="{StaticResource Brush.Border}" BorderThickness="1"
+                            CornerRadius="{StaticResource Radius.Panel}">
+                        <StackPanel>
+                            <TextBlock Text="{Binding ThirdLabel}"
+                                       FontSize="{StaticResource FontSize.Xs}" FontWeight="SemiBold"
+                                       Foreground="{StaticResource Brush.TextHint}"/>
+                            <TextBlock Text="{Binding ThirdName}" Margin="0,6,0,0"
+                                       FontSize="{StaticResource FontSize.Lg}" FontWeight="SemiBold"
+                                       Foreground="{StaticResource Brush.TextSecondary}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Grid>
+
+            <TabControl Grid.Row="3" Margin="22,0,22,12"
+                        Background="{StaticResource Brush.Background}"
+                        Foreground="{StaticResource Brush.TextPrimary}">
+                <TabItem Header="Finals results">
+                    <DataGrid ItemsSource="{Binding FinalsResults}" AutoGenerateColumns="False"
+                              IsReadOnly="True" CanUserAddRows="False" Margin="8,12"
+                              Background="{StaticResource Brush.Background}"
+                              Foreground="{StaticResource Brush.TextPrimary}"
+                              RowBackground="{StaticResource Brush.Background}"
+                              AlternatingRowBackground="{StaticResource Brush.Surface}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Round" Binding="{Binding Round}" Width="130"/>
+                            <DataGridTextColumn Header="Pairing" Binding="{Binding Pairing}" Width="*"/>
+                            <DataGridTextColumn Header="Winner" Binding="{Binding Winner}" Width="170"/>
+                            <DataGridTextColumn Header="Loser" Binding="{Binding Loser}" Width="170"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </TabItem>
+                <TabItem Header="Other finishers">
+                    <DataGrid ItemsSource="{Binding OtherFinishers}" AutoGenerateColumns="False"
+                              IsReadOnly="True" CanUserAddRows="False" Margin="8,12"
+                              Background="{StaticResource Brush.Background}"
+                              Foreground="{StaticResource Brush.TextPrimary}"
+                              RowBackground="{StaticResource Brush.Background}"
+                              AlternatingRowBackground="{StaticResource Brush.Surface}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Rank" Binding="{Binding Rank}" Width="70"/>
+                            <DataGridTextColumn Header="Driver" Binding="{Binding Driver}" Width="*"/>
+                            <DataGridTextColumn Header="W" Binding="{Binding Wins}" Width="65"/>
+                            <DataGridTextColumn Header="L" Binding="{Binding Losses}" Width="65"/>
+                            <DataGridTextColumn Header="Points" Binding="{Binding Points}" Width="90"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </TabItem>
+            </TabControl>
+
+            <Border Grid.Row="4" Padding="24,12"
+                    BorderBrush="{StaticResource Brush.BorderSubtle}" BorderThickness="0,1,0,0">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
+                            Content="View full results" Margin="0,0,8,0" Click="BtnFullResults_Click"/>
+                    <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                            Content="Done" Click="BtnClose_Click"/>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/RCDragManagerProd.WPF/Dialogs/ClassCompletionWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Dialogs/ClassCompletionWindow.xaml.cs
@@ -5,16 +5,20 @@ using RCDragManagerProd.Domain;
 
 namespace RCDragManagerProd.WPF.Dialogs
 {
-    public partial class RaceResultsWindow : Window
+    public partial class ClassCompletionWindow : Window
     {
-        public RaceResultsWindow(RaceSession session, bool showRoundRobinStandings = false)
+        private readonly RaceSession _session;
+
+        public ClassCompletionWindow(RaceSession session)
         {
+            _session = session;
             InitializeComponent();
             WindowSizing.RoundCorners(this);
-            DataContext = RaceResultsPresentationBuilder.Build(session);
-            if (showRoundRobinStandings)
-                ResultsTabs.SelectedIndex = 2;
+            DataContext = ClassCompletionPresentationBuilder.Build(session);
         }
+
+        private void BtnFullResults_Click(object sender, RoutedEventArgs e) =>
+            new RaceResultsWindow(_session) { Owner = this }.ShowDialog();
 
         private void BtnClose_Click(object sender, RoutedEventArgs e) => Close();
 

--- a/src/RCDragManagerProd.WPF/Dialogs/RaceResultsWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Dialogs/RaceResultsWindow.xaml
@@ -100,7 +100,7 @@
                 </StackPanel>
             </Border>
 
-            <TabControl Grid.Row="2" Margin="18,12"
+            <TabControl x:Name="ResultsTabs" Grid.Row="2" Margin="18,12"
                         Background="{StaticResource Brush.Background}"
                         Foreground="{StaticResource Brush.TextPrimary}">
                 <TabItem Header="Ladder">

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
@@ -79,6 +79,7 @@ namespace RCDragManagerProd.WPF.Views
             _controller.CanAdvanceChanged += OnCanAdvanceChanged;
             _controller.CanDeferChanged += OnCanDeferChanged;
             _controller.CanOfferBuybackChanged += OnCanOfferBuybackChanged;
+            _controller.RoundRobinCompleted += OnRoundRobinCompleted;
             _controller.CanStartFinalsChanged += OnCanStartFinalsChanged;
             _controller.TournamentCompleted += OnTournamentCompleted;
 
@@ -119,6 +120,7 @@ namespace RCDragManagerProd.WPF.Views
                 _controller.CanAdvanceChanged -= OnCanAdvanceChanged;
                 _controller.CanDeferChanged -= OnCanDeferChanged;
                 _controller.CanOfferBuybackChanged -= OnCanOfferBuybackChanged;
+                _controller.RoundRobinCompleted -= OnRoundRobinCompleted;
                 _controller.CanStartFinalsChanged -= OnCanStartFinalsChanged;
                 _controller.TournamentCompleted -= OnTournamentCompleted;
             }
@@ -253,9 +255,12 @@ namespace RCDragManagerProd.WPF.Views
         {
             BtnBuybacks.IsEnabled = enabled && !_controller.IsCompleted;
             BtnStandings.IsEnabled = enabled && !_controller.IsCompleted;
-            if (enabled && !IsHostedMode)
-                MessageDialog.Info(Host, "Round-Robin complete.\nClick 'Open buybacks' to add drivers to the Losers Bracket.",
-                    "Buyback phase ready");
+        });
+
+        private void OnRoundRobinCompleted() => Run(() =>
+        {
+            UpdateRaceResultsButton();
+            new RaceResultsWindow(_session, showRoundRobinStandings: true) { Owner = Host }.ShowDialog();
         });
 
         private void OnCanStartFinalsChanged(bool enabled) => Run(() =>
@@ -286,9 +291,7 @@ namespace RCDragManagerProd.WPF.Views
             var winner = summary.Winner?.Name ?? "N/A";
             var runnerUp = summary.RunnerUp?.Name ?? "N/A";
             Logger.Log($"[RESULT][EVENT] '{summary.EventName}' complete — winner={winner}, runner-up={runnerUp}, matches={summary.TotalMatches}");
-            MessageDialog.Info(Host,
-                $"Event: {summary.EventName}\nWinner: {winner}\nRunner-up: {runnerUp}\nMatches: {summary.TotalMatches}",
-                "Event complete");
+            new ClassCompletionWindow(_session) { Owner = Host }.ShowDialog();
             _raceConsole.RecordTournamentCompletion(summary, _drivers);
         });
 

--- a/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
@@ -158,10 +158,7 @@ namespace RCDragManagerProd.WPF.Windows
             Logger.Log($"[WPF][MultiClass] RR gate: {_rrComplete.Count}/{_controllers.Count} complete");
 
             if (_controllers.Count > 0 && _rrComplete.Count == _controllers.Count)
-                MessageDialog.Info(this,
-                    "All classes have completed Round Robin.\nThe buyback phase is now open for every class.\n\n" +
-                    "Switch to each class tab to run buybacks.",
-                    "Buyback phase ready — all classes");
+                Logger.Log("[WPF][MultiClass] All classes completed Round Robin; buybacks are available.");
         }
 
         // ── Completion ─────────────────────────────────────────────────────────
@@ -175,9 +172,7 @@ namespace RCDragManagerProd.WPF.Windows
 
             var className = _multiEvent.ClassSessions[classIndex].ClassType;
             Logger.Log($"[RESULT][CLASS] '{className}' complete — winner={summary.Winner?.Name ?? "N/A"}, runner-up={summary.RunnerUp?.Name ?? "N/A"}");
-            MessageDialog.Info(this,
-                $"Class: {className}\nWinner: {summary.Winner?.Name ?? "N/A"}\nRunner-up: {summary.RunnerUp?.Name ?? "N/A"}",
-                "Class complete");
+            new ClassCompletionWindow(_multiEvent.ClassSessions[classIndex]) { Owner = this }.ShowDialog();
 
             _completed.Add(classIndex);
             UpdateAllTabStates();
@@ -185,7 +180,6 @@ namespace RCDragManagerProd.WPF.Windows
             if (_completed.Count == _controllers.Count)
             {
                 Logger.Log($"[RESULT][EVENT] '{_multiEvent.EventName}' complete — all {_controllers.Count} classes finished");
-                ShowCombinedSummary();
             }
         }
 

--- a/src/RCDragManagerProd/AppServices/ClassCompletionPresentationBuilder.cs
+++ b/src/RCDragManagerProd/AppServices/ClassCompletionPresentationBuilder.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.ViewModels;
+
+namespace RCDragManagerProd.AppServices
+{
+    public static class ClassCompletionPresentationBuilder
+    {
+        public static ClassCompletionPresentation Build(RaceSession session)
+        {
+            var archive = session?.ResultsArchive ?? new RaceResultsArchive();
+            var standings = (archive.RoundRobinStandings ?? new List<RoundRobinStandingSnapshot>())
+                .OrderBy(s => s.Rank)
+                .ToList();
+
+            var result = new ClassCompletionPresentation
+            {
+                EventName = string.IsNullOrWhiteSpace(session?.EventName) ? "Race complete" : session.EventName,
+                ClassName = string.IsNullOrWhiteSpace(session?.ClassType) ? "Class results" : session.ClassType,
+                ChampionName = archive.ChampionName ?? "Winner not recorded",
+                RunnerUpName = archive.RunnerUpName ?? "Runner-up not recorded"
+            };
+
+            var podiumIds = new HashSet<int>();
+            if (archive.ChampionDriverId.HasValue) podiumIds.Add(archive.ChampionDriverId.Value);
+            if (archive.RunnerUpDriverId.HasValue) podiumIds.Add(archive.RunnerUpDriverId.Value);
+
+            var third = standings.FirstOrDefault(s => !podiumIds.Contains(s.DriverId));
+            if (third != null)
+            {
+                result.ThirdLabel = "3rd place";
+                result.ThirdName = third.DriverName;
+                result.HasThird = true;
+                podiumIds.Add(third.DriverId);
+            }
+            else
+            {
+                var semiFinalists = FindSemiFinalLosers(archive)
+                    .Where(n => !string.Equals(n, archive.ChampionName, StringComparison.OrdinalIgnoreCase) &&
+                                !string.Equals(n, archive.RunnerUpName, StringComparison.OrdinalIgnoreCase))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                if (semiFinalists.Count > 0)
+                {
+                    result.ThirdLabel = semiFinalists.Count == 1 ? "3rd place" : "Semi-finalists";
+                    result.ThirdName = string.Join("  •  ", semiFinalists);
+                    result.HasThird = true;
+                }
+            }
+
+            if (!result.HasThird)
+            {
+                result.ThirdLabel = "Next finisher";
+                result.ThirdName = "Not recorded";
+            }
+
+            result.OtherFinishers = standings
+                .Where(s => !podiumIds.Contains(s.DriverId))
+                .Select(s => new RaceResultsStandingRow
+                {
+                    Rank = s.Rank,
+                    Driver = s.DriverName,
+                    Wins = s.Wins,
+                    Losses = s.Losses,
+                    Points = s.Points.ToString("0.00"),
+                    OpponentStrength = s.OpponentStrength.ToString("0.00")
+                })
+                .ToList();
+
+            result.FinalsResults = RaceResultsPresentationBuilder.Build(session).ResultRows
+                .Where(r => string.Equals(r.Phase, "Finals — Pro Ladder", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            return result;
+        }
+
+        private static IEnumerable<string> FindSemiFinalLosers(RaceResultsArchive archive) =>
+            (archive.Phases ?? new List<RacePhaseResultSnapshot>())
+                .Where(p => string.Equals(p?.Phase, RaceTypes.Finals, StringComparison.OrdinalIgnoreCase))
+                .SelectMany(p => p.Matches ?? new List<RaceResultMatchSnapshot>())
+                .Where(m => string.Equals(RoundLabels.Normalize(m.RoundLabel), "SF", StringComparison.OrdinalIgnoreCase))
+                .Select(m => m.LoserName)
+                .Where(n => !string.IsNullOrWhiteSpace(n));
+    }
+}

--- a/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.RoundFlow.Core.cs
@@ -410,7 +410,6 @@ namespace RCDragManagerProd.Controllers
                         {
                             var card = RoundRobinScorecardLogger.BuildScorecard(rr, _matchResult);
                             _rrStandingsCardCache = card;
-                            _standingsDialogService.Show("Round Robin � Standings", card);
                         }
                         catch (Exception ex)
                         {
@@ -428,6 +427,11 @@ namespace RCDragManagerProd.Controllers
                         Logger.Log("[RR][QMDRA] Finals seed order: " + (rankedAll.Count == 0 ? "(none)" : string.Join(", ", rankedAll.Select(d => d.Name))));
 
                         CaptureRoundRobinResultSnapshot(rr);
+                        if (!_rrCompletionAnnounced)
+                        {
+                            _rrCompletionAnnounced = true;
+                            RoundRobinCompleted?.Invoke();
+                        }
                         InjectFinalsAllAdvance(rankedAll);
                         return;
                     }
@@ -463,13 +467,17 @@ namespace RCDragManagerProd.Controllers
                     {
                         var card = RoundRobinScorecardLogger.BuildScorecard(rr, _matchResult);
                         _rrStandingsCardCache = card;
-                        _standingsDialogService.Show("Round Robin � Standings", card);
                     }
                     catch (Exception ex)
                     {
                         Logger.Log($"[RR] Scorecard popup failed: {ex.Message}");
                     }
                     RoundRobinScorecardLogger.Log(rr, _matchResult);
+                    if (!_rrCompletionAnnounced)
+                    {
+                        _rrCompletionAnnounced = true;
+                        RoundRobinCompleted?.Invoke();
+                    }
 
                     var eligible = GetEligibleBuybackDrivers(); // uses _rrTop3 snapshot
                     if (eligible.Count >= 2)

--- a/src/RCDragManagerProd/Controllers/RaceController.Session.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.Session.cs
@@ -31,6 +31,7 @@ namespace RCDragManagerProd.Controllers
             _rrMatchesSnapshot = null;
             _rrRoundOrderSnapshot = null;
             _rrTop3 = null;
+            _rrCompletionAnnounced = false;
             _buybackChampionOverride = null;
             _rrStandingsCardCache = null;
             _rrLoggedRounds.Clear();

--- a/src/RCDragManagerProd/Controllers/RaceController.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.cs
@@ -47,6 +47,7 @@ namespace RCDragManagerProd.Controllers
 
         // Round-robin snapshot (captured at completion)
         private List<Driver> _rrTop3;
+        private bool _rrCompletionAnnounced;
 
         // ────────────────────  EVENTS  ────────────────────
         public event Action<IReadOnlyList<PairingRow>> BracketRedrawn;
@@ -55,6 +56,7 @@ namespace RCDragManagerProd.Controllers
         public event Action<bool> CanAdvanceChanged;
         public event Action<bool> CanPickWinnerChanged;
         public event Action<bool> CanOfferBuybackChanged;
+        public event Action RoundRobinCompleted;
 
         // Finals gating
         public event Action<bool> CanStartFinalsChanged;

--- a/src/RCDragManagerProd/RCDragManagerProd.csproj
+++ b/src/RCDragManagerProd/RCDragManagerProd.csproj
@@ -120,6 +120,7 @@
     <Compile Include="AppServices\RaceConsoleViewModel.cs" />
     <Compile Include="AppServices\RaceConsoleViewModelBuilder.cs" />
     <Compile Include="AppServices\RaceResultsPresentationBuilder.cs" />
+    <Compile Include="AppServices\ClassCompletionPresentationBuilder.cs" />
     <Compile Include="Controllers\IStandingsDialogService.cs" />
     <Compile Include="Controllers\LaneFairnessManager.cs" />
     <Compile Include="Controllers\RaceController.DialIn.cs" />
@@ -337,6 +338,7 @@
     <Compile Include="ViewModels\PairingRow.cs" />
     <Compile Include="ViewModels\WinnerRow.cs" />
     <Compile Include="ViewModels\RaceResultsPresentation.cs" />
+    <Compile Include="ViewModels\ClassCompletionPresentation.cs" />
     <EmbeddedResource Include="UI\Forms\Drivers\DriverManagerForm.resx">
       <DependentUpon>DriverManagerForm.cs</DependentUpon>
       <SubType>Designer</SubType>

--- a/src/RCDragManagerProd/ViewModels/ClassCompletionPresentation.cs
+++ b/src/RCDragManagerProd/ViewModels/ClassCompletionPresentation.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace RCDragManagerProd.ViewModels
+{
+    public sealed class ClassCompletionPresentation
+    {
+        public string EventName { get; set; }
+        public string ClassName { get; set; }
+        public string ChampionName { get; set; }
+        public string RunnerUpName { get; set; }
+        public string ThirdLabel { get; set; }
+        public string ThirdName { get; set; }
+        public bool HasThird { get; set; }
+        public List<RaceResultsStandingRow> OtherFinishers { get; set; } =
+            new List<RaceResultsStandingRow>();
+        public List<RaceResultsListRow> FinalsResults { get; set; } =
+            new List<RaceResultsListRow>();
+    }
+}


### PR DESCRIPTION
## What changed

- Replace the automatic Round Robin text scorecard with the existing Race Results window.
- Open Race Results directly on the Round Robin standings tab when the RR phase completes.
- Keep the manual Standings button available for reopening the cached text scorecard if needed.
- Add a dedicated class-completion presentation with:
  - a prominent champion panel
  - runner-up and third-place/top-finisher cards
  - compact Finals results
  - smaller remaining Round Robin standings
  - a link to the full saved Race Results window
- Use the highest remaining saved RR rank as third place after champion and runner-up; pure ladder races show the semifinalists when no RR ranking exists.
- Remove the duplicate Round Robin-ready messages, plain class-complete message, and final multi-class text dump.
- Guard the RR completion event so it is raised only once.

## Operator impact

The end-of-phase flow is now intentional instead of a stack of text popups:

1. Round Robin ends → saved Results window opens on standings.
2. Finals end → a winner-focused class celebration opens.
3. Full ladder/list details remain one click away and stay persisted with the race.

## Validation

- Full test suite: 295 passed, 11 intentionally skipped, 0 failed.
- WPF Release build: succeeded with 0 warnings and 0 errors.
- `git diff --check`: clean.

## Note

This PR branches directly from `main` and does not depend on open PR #370.