### PR TITLE
[codex] Handle damaged saved race sessions

### DIFF
--- a/src/RCDragManagerProd.Tests/LoadSessionServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/LoadSessionServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Data.SQLite;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RCDragManagerProd.AppServices;
 using RCDragManagerProd.Domain;
@@ -122,6 +123,20 @@ public class LoadSessionServiceTests
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Event);
         Assert.IsFalse(string.IsNullOrWhiteSpace(result.ErrorMessage));
+    }
+
+    [TestMethod]
+    public void LoadSingleClassSession_DamagedDataExplainsThatItWasNotDeleted()
+    {
+        using var db = new TemporarySqliteDb();
+        var service = NewService(db);
+        int id = InsertRawSession(db.ConnectionString, "{not-json");
+
+        var result = service.LoadSingleClassSession(id);
+
+        Assert.IsFalse(result.Success);
+        StringAssert.Contains(result.ErrorMessage, "damaged");
+        StringAssert.Contains(result.ErrorMessage, "not been deleted");
     }
 
     [TestMethod]
@@ -303,6 +318,18 @@ public class LoadSessionServiceTests
             EventDate = new DateTime(2026, 1, 1),
             Drivers = new List<Driver>()
         };
+
+    private static int InsertRawSession(string connectionString, string sessionData)
+    {
+        using var connection = new SQLiteConnection(connectionString);
+        connection.Open();
+        using var command = new SQLiteCommand(@"
+INSERT INTO RaceSessions (EventName, EventDate, ClassType, RaceType, SessionData)
+VALUES ('Damaged Session', '2026-06-22 12:00:00', 'Open', 'Pro Ladder', @SessionData);
+SELECT last_insert_rowid();", connection);
+        command.Parameters.AddWithValue("@SessionData", sessionData);
+        return Convert.ToInt32(command.ExecuteScalar());
+    }
 
     private sealed class TemporarySqliteDb : IDisposable
     {

--- a/src/RCDragManagerProd.Tests/RaceSessionRepositoryTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceSessionRepositoryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Data.SQLite;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RCDragManagerProd.Domain;
 using RCDragManagerProd.Repositories;
@@ -70,6 +71,45 @@ public class RaceSessionRepositoryTests
         Assert.AreEqual(newerId, sessions[0].Id);
         Assert.AreEqual("QA Newer Session", sessions[0].EventName);
         Assert.AreEqual(olderId, sessions[1].Id);
+    }
+
+    [TestMethod]
+    public void GetAllSessions_UnloadableRowsAreHiddenWithoutBeingDeleted()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repository = new RaceSessionRepository(db.ConnectionString);
+        int validId = repository.SaveSession(
+            CreateSession("QA Valid Session", new DateTime(2026, 6, 22), "Pro Ladder"));
+        int missingDataId = InsertRawSession(db.ConnectionString, "QA Missing Data", "");
+        int invalidDataId = InsertRawSession(db.ConnectionString, "QA Invalid Data", "{not-json");
+
+        var sessions = repository.GetAllSessions();
+
+        Assert.AreEqual(1, sessions.Count);
+        Assert.AreEqual(validId, sessions[0].Id);
+        Assert.AreEqual(3, CountSessionRows(db.ConnectionString),
+            "Listing sessions must never delete or overwrite damaged saved data");
+        Assert.AreEqual(
+            RaceSessionLoadStatus.MissingData,
+            repository.TryLoadSession(missingDataId).Status);
+        Assert.AreEqual(
+            RaceSessionLoadStatus.InvalidData,
+            repository.TryLoadSession(invalidDataId).Status);
+    }
+
+    [TestMethod]
+    public void TryLoadSession_MissingIdReportsNotFound()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repository = new RaceSessionRepository(db.ConnectionString);
+
+        var result = repository.TryLoadSession(999);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(RaceSessionLoadStatus.NotFound, result.Status);
+        Assert.IsNull(result.Session);
     }
 
     [TestMethod]
@@ -205,6 +245,28 @@ public class RaceSessionRepositoryTests
                 Seed = i + 1
             }).ToList()
         };
+    }
+
+    private static int InsertRawSession(string connectionString, string eventName, string sessionData)
+    {
+        using var connection = new SQLiteConnection(connectionString);
+        connection.Open();
+        using var command = new SQLiteCommand(@"
+INSERT INTO RaceSessions (EventName, EventDate, ClassType, RaceType, SessionData)
+VALUES (@EventName, @EventDate, 'Open', 'Pro Ladder', @SessionData);
+SELECT last_insert_rowid();", connection);
+        command.Parameters.AddWithValue("@EventName", eventName);
+        command.Parameters.AddWithValue("@EventDate", "2026-06-22 12:00:00");
+        command.Parameters.AddWithValue("@SessionData", sessionData);
+        return Convert.ToInt32(command.ExecuteScalar());
+    }
+
+    private static int CountSessionRows(string connectionString)
+    {
+        using var connection = new SQLiteConnection(connectionString);
+        connection.Open();
+        using var command = new SQLiteCommand("SELECT COUNT(*) FROM RaceSessions", connection);
+        return Convert.ToInt32(command.ExecuteScalar());
     }
 
     private sealed class TemporarySqliteDb : IDisposable

--- a/src/RCDragManagerProd/AppServices/LoadSessionService.cs
+++ b/src/RCDragManagerProd/AppServices/LoadSessionService.cs
@@ -51,13 +51,20 @@ namespace RCDragManagerProd.AppServices
         public LoadResult LoadSingleClassSession(int id)
         {
             Logger.Log($"[SVC][LoadSession] LoadSingleClassSession(id={id})");
-            var session = _sessionRepo.LoadSession(id);
-            if (session == null)
+            var repositoryResult = _sessionRepo.TryLoadSession(id);
+            if (!repositoryResult.Success)
             {
-                Logger.Log("[SVC][LoadSession][WARN] Repository returned null session");
-                return LoadResult.Fail("Unable to load the selected session.");
+                Logger.Log(
+                    $"[SVC][LoadSession][WARN] Session load failed with status " +
+                    $"{repositoryResult.Status}");
+                return repositoryResult.Status == RaceSessionLoadStatus.NotFound
+                    ? LoadResult.Fail("This saved race no longer exists.")
+                    : LoadResult.Fail(
+                        "This saved race is damaged or from an unsupported older version. " +
+                        "It has not been deleted.");
             }
 
+            var session = repositoryResult.Session;
             var wrapped = new MultiClassEvent
             {
                 EventName = session.EventName,

--- a/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
+++ b/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
@@ -159,7 +159,7 @@ WHERE Id = @Id;";
             var list = new List<RaceSessionSummary>();
 
             const string sql = @"
-SELECT Id, EventName, EventDate, ClassType, RaceType
+SELECT Id, EventName, EventDate, ClassType, RaceType, SessionData
 FROM RaceSessions
 ORDER BY datetime(EventDate) DESC";
 
@@ -169,11 +169,28 @@ ORDER BY datetime(EventDate) DESC";
             {
                 while (rd.Read())
                 {
+                    int id = rd.GetInt32(0);
+                    string eventName = rd.IsDBNull(1) ? "" : rd.GetString(1);
+                    string json = rd.IsDBNull(5) ? null : rd.GetString(5);
+                    var loadResult = DeserializeSession(id, json);
+                    if (!loadResult.Success)
+                    {
+                        Logger.Log(
+                            $"[DB][SessionRepo][WARN] Skipping unloadable session " +
+                            $"Id={id}, EventName='{eventName}', Status={loadResult.Status}");
+                        continue;
+                    }
+
+                    DateTime eventDate;
+                    string rawEventDate = rd.IsDBNull(2) ? null : rd.GetString(2);
+                    if (!DateTime.TryParse(rawEventDate, out eventDate))
+                        eventDate = DateTime.MinValue;
+
                     var s = new RaceSessionSummary
                     {
-                        Id = rd.GetInt32(0),
-                        EventName = rd.IsDBNull(1) ? "" : rd.GetString(1),
-                        EventDate = rd.IsDBNull(2) ? DateTime.MinValue : DateTime.Parse(rd.GetString(2)),
+                        Id = id,
+                        EventName = eventName,
+                        EventDate = eventDate,
                         ClassType = rd.IsDBNull(3) ? "" : rd.GetString(3),
                         RaceType = rd.IsDBNull(4) ? "" : rd.GetString(4)
                     };
@@ -188,7 +205,13 @@ ORDER BY datetime(EventDate) DESC";
         // ---------- LOAD ----------
         public RaceSession LoadSession(int id)
         {
-            Logger.Log($"[DB][SessionRepo] LoadSession(id={id})");
+            var result = TryLoadSession(id);
+            return result.Session;
+        }
+
+        public RaceSessionLoadResult TryLoadSession(int id)
+        {
+            Logger.Log($"[DB][SessionRepo] TryLoadSession(id={id})");
 
             const string sql = "SELECT SessionData FROM RaceSessions WHERE Id = @Id";
 
@@ -197,26 +220,43 @@ ORDER BY datetime(EventDate) DESC";
             {
                 cmd.Parameters.AddWithValue("@Id", id);
 
-                var json = cmd.ExecuteScalar() as string;
-                if (string.IsNullOrWhiteSpace(json))
+                object value = cmd.ExecuteScalar();
+                if (value == null || value == DBNull.Value)
                 {
-                    Logger.Log("[DB][SessionRepo][WARN] No JSON session data found");
-                    return null;
+                    Logger.Log($"[DB][SessionRepo][WARN] Session Id={id} was not found");
+                    return RaceSessionLoadResult.Fail(RaceSessionLoadStatus.NotFound);
                 }
 
-                try
+                return DeserializeSession(id, value as string);
+            }
+        }
+
+        private static RaceSessionLoadResult DeserializeSession(int id, string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                Logger.Log($"[DB][SessionRepo][WARN] Session Id={id} has no JSON session data");
+                return RaceSessionLoadResult.Fail(RaceSessionLoadStatus.MissingData);
+            }
+
+            try
+            {
+                var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var session = JsonSerializer.Deserialize<RaceSession>(json, opts);
+                if (session == null)
                 {
-                    var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                    var session = JsonSerializer.Deserialize<RaceSession>(json, opts);
-                    if (session != null) session.Id = id;
-                    Logger.Log("[DB][SessionRepo] LoadSession → OK");
-                    return session;
+                    Logger.Log($"[DB][SessionRepo][WARN] Session Id={id} deserialized to null");
+                    return RaceSessionLoadResult.Fail(RaceSessionLoadStatus.InvalidData);
                 }
-                catch (Exception ex)
-                {
-                    Logger.Log($"[DB][SessionRepo][ERROR] Deserialize failed: {ex}");
-                    return null;
-                }
+
+                session.Id = id;
+                Logger.Log($"[DB][SessionRepo] Session Id={id} deserialized successfully");
+                return RaceSessionLoadResult.Ok(session);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[DB][SessionRepo][ERROR] Session Id={id} deserialize failed: {ex}");
+                return RaceSessionLoadResult.Fail(RaceSessionLoadStatus.InvalidData);
             }
         }
 
@@ -251,5 +291,34 @@ ORDER BY datetime(EventDate) DESC";
             Logger.Log("[DB][SessionRepo] DeleteSession → OK");
         }
 
+    }
+
+    public enum RaceSessionLoadStatus
+    {
+        Loaded,
+        NotFound,
+        MissingData,
+        InvalidData
+    }
+
+    public sealed class RaceSessionLoadResult
+    {
+        public bool Success => Status == RaceSessionLoadStatus.Loaded;
+        public RaceSessionLoadStatus Status { get; }
+        public RaceSession Session { get; }
+
+        private RaceSessionLoadResult(RaceSessionLoadStatus status, RaceSession session)
+        {
+            Status = status;
+            Session = session;
+        }
+
+        public static RaceSessionLoadResult Ok(RaceSession session) =>
+            new RaceSessionLoadResult(
+                RaceSessionLoadStatus.Loaded,
+                session ?? throw new ArgumentNullException(nameof(session)));
+
+        public static RaceSessionLoadResult Fail(RaceSessionLoadStatus status) =>
+            new RaceSessionLoadResult(status, null);
     }
 }


### PR DESCRIPTION
## What changed
- validate each saved-session payload before showing it in the load/recent-races list
- distinguish missing, blank, and invalid saved data when loading
- keep damaged rows in the database so recovery remains possible
- show a clear non-destructive error if a damaged race is loaded directly
- tolerate malformed summary dates without crashing the saved-race list

## Root cause
The saved-race list only read summary columns, while opening a race depended on a separate JSON payload. Rows with blank or invalid JSON therefore appeared selectable but could not be loaded.

## Validation
- 301 tests passed, 11 skipped
- Release build succeeded
- regression coverage verifies damaged rows are hidden but not deleted

Closes #372