### PR TITLE
[codex] Improve create event actions

### DIFF
--- a/src/RCDragManagerProd.Tests/MultiClassSetupServiceTests.cs
+++ b/src/RCDragManagerProd.Tests/MultiClassSetupServiceTests.cs
@@ -93,6 +93,18 @@ public class MultiClassSetupServiceTests
     // ── ValidateCanStart ──────────────────────────────────────────────────────
 
     [TestMethod]
+    public void ValidateCanStart_NoClasses_ReturnsError()
+    {
+        using var db = new TemporarySqliteDb();
+        var svc = NewService(db);
+
+        var error = svc.ValidateCanStart(Array.Empty<ClassConfigDto>());
+
+        Assert.IsNotNull(error);
+        StringAssert.Contains(error, "at least one class");
+    }
+
+    [TestMethod]
     public void ValidateCanStart_AllClassesHaveDrivers_ReturnsNull()
     {
         using var db = new TemporarySqliteDb();

--- a/src/RCDragManagerProd.WPF/Resources/Styles.xaml
+++ b/src/RCDragManagerProd.WPF/Resources/Styles.xaml
@@ -336,6 +336,12 @@
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="bd" Property="Background" Value="{StaticResource Brush.PrimaryPressed}"/>
                         </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource Brush.Raised}"/>
+                            <Setter Property="Foreground" Value="{StaticResource Brush.TextMuted}"/>
+                            <Setter Property="Cursor" Value="Arrow"/>
+                            <Setter Property="Opacity" Value="0.7"/>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/RCDragManagerProd.WPF/Resources/Styles.xaml
+++ b/src/RCDragManagerProd.WPF/Resources/Styles.xaml
@@ -388,6 +388,14 @@
         </Setter>
     </Style>
 
+    <Style x:Key="Style.TextBox.Compact"
+           TargetType="TextBox"
+           BasedOn="{StaticResource Style.TextBox}">
+        <Setter Property="Padding" Value="8,2"/>
+        <Setter Property="MinHeight" Value="28"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+    </Style>
+
     <!-- ── Stat card (used in DriverStatsWindow) ─────────────────────────── -->
 
     <Style x:Key="Style.StatCard" TargetType="Border">

--- a/src/RCDragManagerProd.WPF/ViewModels/SetupViewModel.cs
+++ b/src/RCDragManagerProd.WPF/ViewModels/SetupViewModel.cs
@@ -55,6 +55,7 @@ namespace RCDragManagerProd.WPF.ViewModels
         }
 
         public bool HasSelection => _selectedClass != null;
+        public bool CanStart => _configs.Count > 0 && ValidateCanStart() == null;
 
         // ── Class list management ─────────────────────────────────────────────
 
@@ -67,6 +68,7 @@ namespace RCDragManagerProd.WPF.ViewModels
 
             _configs.Add(config);
             Classes.Add(ToRow(config));
+            OnPropertyChanged(nameof(CanStart));
             return null;
         }
 
@@ -78,6 +80,7 @@ namespace RCDragManagerProd.WPF.ViewModels
             if (index < 0 || index >= _configs.Count) return;
             _configs[index] = config;
             Classes[index] = ToRow(config);
+            OnPropertyChanged(nameof(CanStart));
         }
 
         public void RemoveClass(int index)
@@ -85,6 +88,7 @@ namespace RCDragManagerProd.WPF.ViewModels
             if (index < 0 || index >= _configs.Count) return;
             _configs.RemoveAt(index);
             Classes.RemoveAt(index);
+            OnPropertyChanged(nameof(CanStart));
         }
 
         public int IndexOf(ClassRow row) => Classes.IndexOf(row);

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml
@@ -122,16 +122,16 @@
                 </Border>
 
                 <StackPanel Grid.Row="1" Margin="12,10">
-                    <TextBox x:Name="TxtName" Style="{StaticResource Style.TextBox}"
-                             Height="28" VerticalContentAlignment="Center" Margin="0,0,0,6"/>
+                    <TextBox x:Name="TxtName" Style="{StaticResource Style.TextBox.Compact}"
+                             Margin="0,0,0,6"/>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="8"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Grid.Column="0" x:Name="TxtTime" Style="{StaticResource Style.TextBox}"
-                                 Height="28" VerticalContentAlignment="Center"/>
+                        <TextBox Grid.Column="0" x:Name="TxtTime"
+                                 Style="{StaticResource Style.TextBox.Compact}"/>
                         <Button Grid.Column="2" Style="{StaticResource Style.Button.Toolbar}"
                                 Content="Add" Click="BtnAddDriver_Click" Width="56"/>
                     </Grid>

--- a/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/SetupWindow.xaml
@@ -89,8 +89,10 @@
                                    Foreground="{StaticResource Brush.TextHint}"
                                    VerticalAlignment="Center"/>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                            <Button Style="{StaticResource Style.Button.Toolbar}"
-                                    Content="Add class" Click="BtnAddClass_Click" Margin="0,0,6,0"/>
+                            <Button Style="{StaticResource Style.Button.Dialog.Primary}"
+                                    Content="Add class" Click="BtnAddClass_Click"
+                                    MinWidth="118" MinHeight="38"
+                                    FontWeight="SemiBold" Margin="0,0,10,0"/>
                             <Button Style="{StaticResource Style.Button.Toolbar}"
                                     Content="Edit" Click="BtnEditClass_Click" Margin="0,0,6,0"
                                     IsEnabled="{Binding HasSelection}"/>
@@ -180,7 +182,8 @@
                         <Button Style="{StaticResource Style.Button.Dialog.Secondary}"
                                 Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"/>
                         <Button Style="{StaticResource Style.Button.Dialog.Primary}"
-                                Content="Start event" Click="BtnStart_Click"/>
+                                Content="Start event" Click="BtnStart_Click"
+                                IsEnabled="{Binding CanStart}"/>
                     </StackPanel>
                 </Grid>
             </Border>

--- a/src/RCDragManagerProd/AppServices/MultiClassSetupService.cs
+++ b/src/RCDragManagerProd/AppServices/MultiClassSetupService.cs
@@ -71,7 +71,11 @@ namespace RCDragManagerProd.AppServices
         /// </summary>
         public string ValidateCanStart(IEnumerable<ClassConfigDto> classes)
         {
-            foreach (var cc in classes ?? Enumerable.Empty<ClassConfigDto>())
+            var configuredClasses = (classes ?? Enumerable.Empty<ClassConfigDto>()).ToList();
+            if (configuredClasses.Count == 0)
+                return "Add at least one class with drivers to start.";
+
+            foreach (var cc in configuredClasses)
             {
                 if (cc.DriverEntries == null || cc.DriverEntries.Count == 0)
                     return $"Class '{cc.ClassName}' has no drivers. Add at least one driver or remove the class.";


### PR DESCRIPTION
## What changed
- make **Add class** a larger orange primary action
- keep **Start event** disabled and visually neutral until a class with drivers exists
- update the start-button state immediately after adding, editing, or removing a class
- reject empty events in the underlying validation, not only in the UI
- give disabled primary buttons a clear gray appearance
- fix clipped/invisible driver-name and qualifying-time text in the race console

## Why
The create-event screen emphasized Start event before the event was ready, while the first required action—adding a class—was visually understated. Empty class lists were also incorrectly accepted by service validation. The compact race inputs also reused dialog padding inside a fixed 28-pixel height, clipping the entered text.

## Validation
- 302 tests passed, 11 skipped
- WPF Release build succeeded with 0 warnings and 0 errors
- added regression coverage for starting with no classes