### PR TITLE
[codex] Add Claude routines and planning docs

### DIFF
--- a/.github/claude-routines/README.md
+++ b/.github/claude-routines/README.md
@@ -1,0 +1,46 @@
+# Claude Routines
+
+These files are reusable instructions for Claude/Codex-style workers.
+
+The model is:
+
+- `AGENTS.md` defines repo rules.
+- GitHub issues define the work queue.
+- Routine markdown files define how the worker behaves.
+- Pull requests are the output.
+
+## Routine Files
+
+- `worker.md` - implement one GitHub issue.
+- `reviewer.md` - review one pull request.
+- `fixer.md` - address review comments or failing CI on one pull request.
+- `reporter.md` - summarize repo status and recommend the next task.
+- `release-check.md` - verify release readiness.
+
+## Standard Usage
+
+Give the routine an issue or pull request number and tell it which file to read.
+
+Examples:
+
+```text
+Read .github/claude-routines/worker.md and work issue #302.
+```
+
+```text
+Read .github/claude-routines/reviewer.md and review PR #123.
+```
+
+```text
+Read .github/claude-routines/fixer.md and fix PR #123.
+```
+
+## Hard Rules
+
+- One issue per branch.
+- One pull request per issue.
+- Do not auto-merge.
+- Do not change unrelated files.
+- Do not start WPF work unless the issue explicitly asks for WPF.
+- Preserve race-day correctness over cosmetic changes.
+- Run the required tests and report the exact result.

--- a/.github/claude-routines/fixer.md
+++ b/.github/claude-routines/fixer.md
@@ -1,0 +1,48 @@
+# Claude Fixer Routine
+
+Use this routine to address review comments or failing CI on exactly one pull request.
+
+## Inputs
+
+Required:
+
+- Repository: `stewmac570/RC-Drag-Manager`
+- Pull request number
+
+## Process
+
+1. Read `AGENTS.md`.
+2. Read the pull request, review comments, and CI failures.
+3. Identify the smallest fix that addresses the feedback.
+4. Change only files needed for the review or CI failure.
+5. Run the relevant tests.
+6. Push updates to the same pull request branch.
+7. Reply with what was fixed and what remains.
+
+## Rules
+
+- Do not add new feature work.
+- Do not broaden the PR scope.
+- Do not rewrite code unrelated to the review/CI failure.
+- Do not dismiss a failing test as unrelated without proof.
+- Do not auto-merge.
+
+## Required Validation
+
+Run:
+
+```powershell
+dotnet test src\RCDragManagerProd.Tests\RCDragManagerProd.Tests.csproj -m:1 --logger "console;verbosity=minimal"
+```
+
+If the failure is CI-only, inspect CI logs and explain the environment difference.
+
+## Output
+
+Report:
+
+- PR fixed
+- Review comments addressed
+- CI failures addressed
+- Tests run and exact result
+- Remaining risk or unresolved failures

--- a/.github/claude-routines/release-check.md
+++ b/.github/claude-routines/release-check.md
@@ -1,0 +1,71 @@
+# Claude Release Check Routine
+
+Use this routine to check whether the app is ready for a release candidate.
+
+## Inputs
+
+Required:
+
+- Repository: `stewmac570/RC-Drag-Manager`
+
+Optional:
+
+- Release branch
+- Version number
+- Include live server repo: `stewmac570/RCDragLiveServer`
+
+## Process
+
+1. Read `AGENTS.md`.
+2. Review open issues marked for the next release.
+3. Check open pull requests.
+4. Check CI status.
+5. Run or verify the app test command.
+6. Verify installer/release package instructions.
+7. Verify operator docs and release notes are current.
+8. Report blockers and non-blocking polish.
+
+## Required Validation
+
+Run or verify:
+
+```powershell
+dotnet test src\RCDragManagerProd.Tests\RCDragManagerProd.Tests.csproj -m:1 --logger "console;verbosity=minimal"
+```
+
+If installer verification is available, run or verify the documented installer build command.
+
+## Blockers
+
+Treat these as release blockers unless explicitly waived:
+
+- Failing test baseline.
+- Open race-day correctness issues.
+- Known save/resume data loss risk.
+- Broken installer/update path.
+- Missing operator docs for changed workflows.
+- Live server publishing regression if live scoreboard is part of the release.
+
+## Output
+
+Use this shape:
+
+```text
+Release readiness:
+ready / not ready
+
+Blockers:
+- ...
+
+Non-blocking polish:
+- ...
+
+Tests:
+- ...
+
+Installer/release package:
+- ...
+
+Recommended next action:
+- ...
+```

--- a/.github/claude-routines/reporter.md
+++ b/.github/claude-routines/reporter.md
@@ -1,0 +1,60 @@
+# Claude Reporter Routine
+
+Use this routine to summarize current project status and recommend the next task.
+
+## Inputs
+
+Required:
+
+- Repository: `stewmac570/RC-Drag-Manager`
+
+Optional:
+
+- Include live server repo: `stewmac570/RCDragLiveServer`
+
+## Process
+
+1. Read open issues relevant to the next-release backlog.
+2. Read open pull requests.
+3. Check CI status where available.
+4. Identify blocked issues and dependencies.
+5. Recommend the next best issue to work.
+6. Do not change code.
+
+## Priority Order
+
+Recommend work in this order:
+
+1. Green test baseline.
+2. CI and automation gates.
+3. Save/resume/recovery safety.
+4. UI-independent service/view-model extraction.
+5. Button-free workflow tests.
+6. Current WinForms UI/UX cleanup.
+7. Live server polish.
+8. Release/installer polish.
+9. Operator docs.
+10. WPF prototype after contracts/services exist.
+
+## Output
+
+Use this shape:
+
+```text
+Status:
+- ...
+
+Open PRs:
+- ...
+
+Blocked:
+- ...
+
+Next recommended issue:
+- #123 - reason
+
+Risks:
+- ...
+```
+
+Keep the report short enough to use as a daily status update.

--- a/.github/claude-routines/reviewer.md
+++ b/.github/claude-routines/reviewer.md
@@ -1,0 +1,68 @@
+# Claude Reviewer Routine
+
+Use this routine to review exactly one pull request.
+
+## Inputs
+
+Required:
+
+- Repository: `stewmac570/RC-Drag-Manager`
+- Pull request number
+
+## Process
+
+1. Read `AGENTS.md`.
+2. Read the pull request title, body, linked issue, comments, and changed files.
+3. Compare the diff against the linked issue scope.
+4. Review for race-day correctness, data safety, test coverage, and scope creep.
+5. Check whether tests were run and whether CI passed.
+6. Leave a review with findings or approval.
+
+## Review Priorities
+
+Follow `AGENTS.md` priorities:
+
+1. Logic and correctness.
+2. Data integrity.
+3. Performance and UI thread blocking.
+4. Code structure where it affects maintainability or future UI migration.
+5. Security and unsafe file/path handling.
+
+## What To Flag
+
+- Race state transitions that can become wrong.
+- Save/resume/close behavior that can lose or corrupt race data.
+- UI changes that allow unsafe race-day actions.
+- Missing tests for changed workflow logic.
+- PRs that change unrelated files.
+- WPF work started before UI-neutral contracts/services exist.
+- CI or local test failures without explanation.
+
+## What Not To Flag
+
+- Minor formatting.
+- Preference-only naming.
+- Missing XML docs on private methods.
+- Existing warnings unrelated to the PR.
+
+## Output
+
+Start with findings.
+
+Use this shape:
+
+```text
+Findings:
+- [P1/P2/P3] File and line: issue and risk.
+
+Missing tests:
+- ...
+
+Risk:
+low / medium / high
+
+Decision:
+approve / request changes / comment only
+```
+
+If there are no findings, say so clearly and mention any remaining test or release risk.

--- a/.github/claude-routines/worker.md
+++ b/.github/claude-routines/worker.md
@@ -1,0 +1,74 @@
+# Claude Worker Routine
+
+Use this routine to implement exactly one GitHub issue.
+
+## Inputs
+
+Required:
+
+- Repository: `stewmac570/RC-Drag-Manager`
+- GitHub issue number
+
+Optional:
+
+- Target branch
+- Extra user instructions
+
+## Process
+
+1. Read `AGENTS.md`.
+2. Read the GitHub issue body, labels, comments, and linked issues.
+3. Check whether the issue is blocked by another issue.
+4. Inspect the relevant code before changing anything.
+5. Create a branch named `codex/issue-<number>-short-title`.
+6. Implement only the issue scope.
+7. Add or update tests when behavior changes.
+8. Run the required validation command.
+9. Create or update a pull request.
+10. Stop and report the PR, tests, risks, and follow-ups.
+
+## Required Validation
+
+For normal app changes, run:
+
+```powershell
+dotnet test src\RCDragManagerProd.Tests\RCDragManagerProd.Tests.csproj -m:1 --logger "console;verbosity=minimal"
+```
+
+If the issue only changes docs or GitHub metadata, explain why tests were not run.
+
+If tests fail:
+
+- Identify whether the failure is new or pre-existing.
+- Do not hide or ignore failures.
+- Do not weaken tests without explaining the intended behavior.
+
+## Scope Rules
+
+- Work one issue only.
+- Do not rewrite whole forms unless the issue explicitly requires it.
+- Do not perform broad cleanup while implementing a narrow issue.
+- Do not change race rules unless the issue explicitly requires it.
+- Do not change persistence behavior unless the issue explicitly requires it.
+- Do not touch installer/release logic unless the issue is release related.
+- Do not start WPF migration unless the issue is WPF related.
+
+## Architecture Rules
+
+- Prefer UI-independent services/view models for new workflow logic.
+- Keep WinForms as the production UI unless the issue says otherwise.
+- Preserve existing race-day behavior while extracting logic.
+- Add service-level tests for extracted behavior.
+- Avoid adding logic directly into form event handlers.
+
+## Output
+
+Report:
+
+- Issue worked
+- Branch name
+- Pull request URL
+- Summary of changes
+- Tests run and exact result
+- Known risks
+- Follow-up issues created or recommended

--- a/Docs/12_Live_Server_Integration.md
+++ b/Docs/12_Live_Server_Integration.md
@@ -1,0 +1,133 @@
+# RC Drag Manager - Live Server Integration
+
+Last updated: 2026-06-06
+
+The desktop app and live server are separate repositories that operate as one product.
+
+| Role | Repository |
+| --- | --- |
+| Race control desktop app | `C:\Users\Stewart McMillan\source\repos\RC-Drag-Manager` |
+| Public live scoreboard server | `C:\Users\Stewart McMillan\source\repos\RCDragLiveServer` |
+
+## Desktop Client
+
+Desktop live integration is in:
+
+```text
+src\RCDragManagerProd\Integration\LiveApiClient.cs
+src\RCDragManagerProd\Integration\LiveRaceUpdateDto.cs
+```
+
+Current endpoints:
+
+| Method | URL | Purpose | Auth |
+| --- | --- | --- | --- |
+| `POST` | `https://stewmacrc.com/api/update` | Push current live race state. | `X-API-KEY` |
+| `POST` | `https://stewmacrc.com/api/reset` | Clear one event from live server state. | `X-API-KEY` |
+| `GET` | `https://stewmacrc.com/api/dialin?eventId=...` | Poll submitted dial-ins. | `X-API-KEY` |
+
+Live pushes are skipped unless `AppSettings.LiveBroadcastEnabled` is true.
+
+`LiveApiClient` maintains one serial send channel per `(eventId, classType)`. Pending updates are latest-wins; reset operations are preserved as ordered barriers.
+
+## Shared Payload
+
+The desktop `LiveRaceUpdateDto` and server `LiveRaceState` currently share this shape using camelCase JSON:
+
+```json
+{
+  "eventId": "",
+  "eventName": "",
+  "eventDate": "",
+  "classType": "",
+  "raceType": "",
+  "currentRound": "",
+  "nextUp": "",
+  "rrStandings": null,
+  "matches": [],
+  "winners": [],
+  "dialInLocked": false
+}
+```
+
+`matches` is required by the server update endpoint. Missing/null `matches` returns `400 invalid_payload`.
+
+Current match shape:
+
+```json
+{
+  "roundLabel": "RR1",
+  "driver1": "Driver A",
+  "driver2": "Driver B",
+  "leftDriver": "Driver A",
+  "rightDriver": "Driver B",
+  "leftDriverId": 1,
+  "rightDriverId": 2,
+  "winnerName": null,
+  "leftDriverDialIn": 3.25,
+  "rightDriverDialIn": 3.4
+}
+```
+
+Current winner shape:
+
+```json
+{
+  "roundLabel": "RR1",
+  "winnerName": "Driver A",
+  "loserName": "Driver B"
+}
+```
+
+Timing fields are not currently part of the live DTO.
+
+## Live Server Public Surface
+
+`RCDragLiveServer` exposes:
+
+| Method | Route | Purpose | Auth |
+| --- | --- | --- | --- |
+| `GET` | `/` | Public landing page listing active events. | none |
+| `GET` | `/event/{eventId}` | Public scoreboard and dial-in form for one event. | none |
+| `GET` | `/api/live` | Public JSON snapshot of active class states. | none |
+| `GET` | `/health` | Health check. | none |
+| `POST` | `/api/dialin` | Public driver dial-in submission. | none, rate-limited |
+| `GET` | `/api/dialin?eventId=...` | Dial-in polling for desktop app. | `X-API-KEY` |
+| `POST` | `/api/update` | Desktop live state ingestion. | `X-API-KEY` |
+| `POST` | `/api/reset` | Clear an event from server state. | `X-API-KEY` |
+
+## Live Server State Model
+
+The live server stores state in memory:
+
+- Events are bucketed primarily by `eventName`, falling back to `eventId` when event name is blank.
+- Event aliases are registered for event name, event id, and GUID formats.
+- Each event bucket stores class states keyed by `classType`.
+- Active events expire after two hours without updates.
+- When a new non-empty session `eventId` arrives for the same event bucket, old class state and dial-ins are cleared.
+
+This means the server is currently volatile. Restarting the server loses active race state and submitted dial-ins until the desktop app pushes again.
+
+## Dial-In Flow
+
+1. Public user opens `/event/{eventId}`.
+2. The page builds a driver list from active match data.
+3. User submits `eventId`, `driverId`, `dialIn`, and optional 4-digit `pin` to `POST /api/dialin`.
+4. Server validates event, driver, dial-in value, lock state, PIN format, and rate limit.
+5. Desktop app polls protected `GET /api/dialin`.
+6. Desktop app applies returned driver-id-to-dial-in values.
+
+When `dialInLocked` is true for an event, public updates return `423 locked`.
+
+## Config Requirements
+
+`RCDragLiveServer` refuses to start without `ApiKey` configured through appsettings, development settings, launch settings, or environment variables.
+
+The desktop app must have the same API key in `App.config` under `ApiKey`.
+
+## Not Implemented Yet
+
+- Persistent live-server storage.
+- Timing/Portatree result fields.
+- OBS-specific timing overlay endpoint.
+- Server-side authentication for public dial-in users beyond optional per-driver PIN storage.

--- a/Docs/PORTATREE-RCDM-INTEGRATION.md
+++ b/Docs/PORTATREE-RCDM-INTEGRATION.md
@@ -1,0 +1,374 @@
+# RCDM × Portatree Integration — Architecture & Design
+
+> Status: planned design, not implemented in the current desktop app or live server as of 2026-06-06. Current code has no Portatree watcher, Paradox reader, timing result model, timing persistence table, or live timing DTO fields. Use this document as a design plan only.
+*Last updated: May 2026*
+
+---
+
+## Goal
+
+RC Drag Manager (RCDM) manages the event — drivers, bracket, dial-ins, points, live scoreboard.
+Portatree Eliminator Competition runs the actual race — Christmas tree, reaction times, ETs, MPH.
+
+The integration connects them so:
+1. RCDM shows the operator what entry numbers and dial-ins to type into the Eliminator for each pairing
+2. The Eliminator runs the race and records the result
+3. The result flows back into RCDM automatically — bracket advances, timing data stored, live scoreboard updates
+4. OBS overlay displays real-time race results for streaming
+
+---
+
+## Architecture Overview
+
+```
+RCDM (bracket master)
+  │
+  ├─ "Now Racing" panel → operator reads entry numbers + dial-ins
+  │    └─ operator manually types into Eliminator touchscreen
+  │
+  └─ Portatree Bridge Service (new, in-process)
+       │
+       ├─ FileSystemWatcher on C:\Res2024\{date}\{date}.db
+       │    └─ Paradox table watcher (pypxlib or raw Paradox reader)
+       │
+       ├─ On new row detected:
+       │    ├─ Read pair of rows (same RaceNumber, left + right lane)
+       │    ├─ Look up CarNumber → RCDM Driver via EntryMap
+       │    ├─ Determine winner (Win=1 row)
+       │    └─ Call RaceController.SubmitWinner(winnerDriverId)
+       │
+       └─ Extend LiveRaceUpdateDto with timing fields
+            └─ RCDragLiveServer pushes to OBS browser source
+```
+
+---
+
+## Portatree Results Database Schema
+
+**File:** `C:\Res2024\{YYMMDD}\{YYMMDD}.db` (Paradox format, created per event)
+**Written by:** ElimComp.exe with AutoSave ON (real-time after each run)
+**Key fields for integration:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `RaceNumber` | Long | Sequential run counter. Both lanes (left + right) share the SAME RaceNumber. Two rows per race. |
+| `CarNumber` | Alpha(6) | Entry number typed by operator — links to RCDM EntryMap |
+| `Type` | Short | Race type: 1=Time Trial, 2=Qualification, 4=Elimination |
+| `Cat` | Short | Category number |
+| `Round` | Short | Round number |
+| `Time` | Timestamp | When result was recorded |
+| `DialIn` | Long | Dial-in × 10000 (e.g. 2.580 → 25800) |
+| `RT` | Long | Reaction time × 10000 (e.g. 0.035 → 350) |
+| `60Foot` | Long | 60ft ET × 10000 |
+| `330Foot` | Long | 330ft ET × 10000 |
+| `660Foot` | Long | 660ft ET × 10000 |
+| `990Foot` | Long | 990ft ET × 10000 |
+| `1320Foot` | Long | 1320ft ET × 10000 (the main elapsed time) |
+| `Mph1` | Long | Mid-track MPH × 10000 |
+| `Mph2` | Long | Trap MPH × 10000 |
+| `Win` | Short | 1 = this lane won, 0 = lost |
+| `Red` | Short | 1 = red light (foul start) |
+| `BO` | Short | 1 = breakout (ran quicker than dial-in) |
+| `DisQ` | Short | 1 = disqualified |
+| `OverDial` | Long | Over/under dial × 10000 (negative = under = breakout) |
+| `eMOV` | Long | Margin of victory × 10000 |
+| `RacerName` | Alpha(20) | Racer name (populated from racer.db if entry matched) |
+| `CatName` | Alpha(25) | Category name |
+
+**Scaling rule:** All time/speed Long fields are stored as integer × 10000. To get the display value: `displayValue = rawLong / 10000.0`. Example: RT=350 → 0.0350s, 1320Foot=92430 → 9.2430s.
+
+**Row pattern per race:**
+```
+RaceNumber=1, CarNumber="007", Win=1, RT=350, 1320Foot=92430 ...  ← left lane winner
+RaceNumber=1, CarNumber="012", Win=0, RT=412, 1320Foot=94180 ...  ← right lane loser
+```
+
+---
+
+## Portatree Racer Database Schema
+
+**File:** `C:\Portatree\racer.db` (Paradox, 76 fields, same schema as race.db roster)
+
+Key fields for integration:
+
+| Field | Notes |
+|-------|-------|
+| `EntryNumber` | Alpha(6) — the number typed at the tower |
+| `RacerNumber` | Alpha(6) — internal roster number |
+| `FirstName` | Alpha(20) |
+| `LastName` | Alpha(20) |
+| `DefaultDial` | Long × 10000 — stored default dial-in |
+
+The `EntryNumber` in racer.db corresponds to the `CarNumber` written to the results db. This is the join key.
+
+---
+
+## RCDM Data Gaps (Confirmed)
+
+From CC's audit of the current codebase:
+
+**`MatchResult.cs`** — stores only `(Driver Winner, Driver Loser)` per matchId. No timing fields.
+
+**`MatchResultSave`** — stores only `MatchId`, `WinnerDriverId`, `LoserDriverId`. No timing fields.
+
+**`RaceSession`** — no RT, ET, MPH, DialIn-result, or timing fields at session or match level.
+
+**`LiveRaceUpdateDto`** / **`LiveWinnerDto`** — no timing fields. `LiveMatchDto` has `LeftDriverDialIn` / `RightDriverDialIn` (double?) but nothing for post-race actuals.
+
+**Conclusion:** RCDM has no existing timing data model. All timing storage is new work.
+
+---
+
+## Build Phases
+
+### Phase 1 — Results Bridge (core, build first)
+
+**What it does:** Portatree result → RCDM bracket advance + timing storage
+
+**New components required:**
+
+1. **`PortatreeTimingResult`** (new domain class)
+   ```csharp
+   public class PortatreeTimingResult
+   {
+       public int RaceNumber { get; set; }
+       public string CarNumber { get; set; }      // entry number
+       public int DriverId { get; set; }          // resolved from EntryMap
+       public double DialIn { get; set; }
+       public double RT { get; set; }
+       public double ET { get; set; }             // 1320Foot / 10000.0
+       public double MPH { get; set; }            // Mph2 / 10000.0
+       public double OverUnder { get; set; }
+       public double MOV { get; set; }
+       public bool Win { get; set; }
+       public bool RedLight { get; set; }
+       public bool Breakout { get; set; }
+       public bool Disqualified { get; set; }
+       public DateTime RecordedAt { get; set; }
+   }
+   ```
+
+2. **`PortatreeEntryMap`** (new, per-session)
+   - Simple `Dictionary<string, int>` mapping CarNumber string → RCDM DriverId
+   - Populated at session start by operator assigning entry numbers to drivers
+   - Persisted as part of `RaceSession` JSON (new field `List<EntryAssignment>`)
+
+3. **`PortatreeResultWatcher`** (new service)
+   - `FileSystemWatcher` on the dated results `.db` file path
+   - On `Changed` event: read new rows since last `RaceNumber` seen
+   - Pairs the two rows for the same `RaceNumber`
+   - Resolves `CarNumber` → `DriverId` via `EntryMap`
+   - Calls `RaceController.SubmitWinner(winnerDriverId, loserDriverId)`
+   - Stores `PortatreeTimingResult` pair in new `MatchTimingStore`
+
+4. **`MatchTimingStore`** (new, in-memory + persisted)
+   - Stores `PortatreeTimingResult` per matchId
+   - Serialized as `List<PortatreeTimingResult>` in `RaceSession` JSON
+   - New SQLite table `MatchTimingResults` for permanent storage post-session
+
+5. **`PortatreeParadoxReader`** (new utility)
+   - Pure C# Paradox file reader (no BDE dependency — BDE is not reliable in all deployments)
+   - Reads `.db` file header for field descriptors
+   - Reads records sequentially by row index
+   - Returns `List<Dictionary<string, object>>` rows
+   - Tested against `C:\Res2024\240913\240913.db` and `C:\Portatree\racer.db`
+
+6. **Config additions to `appsettings.json`:**
+   ```json
+   "PortatreeEnabled": false,
+   "PortatreeResultsPath": "C:\\Res2024",
+   "PortatreeAutoDetectDate": true
+   ```
+   When `PortatreeEnabled = false`, the watcher never starts. Existing manual winner-entry path unchanged.
+
+**New UI element on Form1 / MultiClassRaceForm:**
+- "Entry Numbers" panel: shows current pairing with assigned entry numbers + dial-ins
+- Operator reads this and types into the Eliminator touchscreen
+- Small "Assign Entries" button opens a modal at session start for mapping drivers to entry numbers
+
+**Guard — active match sync:**
+RCDM's bracket has a concept of "currently active match" via `RaceController.PushNextMatch()`. The watcher must only fire `SubmitWinner` if the incoming `CarNumber` pair matches the current active match's entry assignments. If no match found (stale run, test pass, wrong category) — log and ignore, do NOT advance the bracket.
+
+---
+
+### Phase 2 — OBS Overlay (build second)
+
+**What it does:** Live race result data visible in OBS as a browser source
+
+**Changes to `LiveRaceUpdateDto`:**
+
+Add timing fields to `LiveWinnerDto`:
+```csharp
+public class LiveWinnerDto
+{
+    public string RoundLabel { get; set; }
+    public string WinnerName { get; set; }
+    public string LoserName { get; set; }
+    // NEW:
+    public double? WinnerRT { get; set; }
+    public double? WinnerET { get; set; }
+    public double? WinnerMPH { get; set; }
+    public double? WinnerDialIn { get; set; }
+    public double? LoserRT { get; set; }
+    public double? LoserET { get; set; }
+    public double? LoserMPH { get; set; }
+    public double? LoserDialIn { get; set; }
+    public bool WinnerRedLight { get; set; }
+    public bool LoserRedLight { get; set; }
+    public bool WinnerBreakout { get; set; }
+    public bool LoserBreakout { get; set; }
+    public double? MOV { get; set; }
+}
+```
+
+Add a `LiveLastRunDto` to `LiveRaceUpdateDto` for the most recent completed run (for live commentary panel):
+```csharp
+public LiveLastRunDto LastRun { get; set; }
+```
+
+**RCDragLiveServer side:**
+- Add a new endpoint or extend existing update endpoint to serve `LastRun` and enhanced `Winners`
+- OBS browser source HTML page polls this endpoint every ~500ms
+- Page shows: driver names, dial-ins, RT, ET, MPH, win/red/BO flags, MOV
+- Styled for readability at 1080p (dark background, large numbers)
+
+---
+
+### Phase 3 — Entry Number Display Panel (build third)
+
+**What it does:** Shows operator what to type into the Eliminator for the current pairing
+
+**New UI panel on Form1 (pnlBottom or pnlRail area):**
+```
+┌─────────────────────────────────────────┐
+│  NOW RACING                             │
+│  LEFT:  007  Dave Smith    dial: 2.580  │
+│  RIGHT: 012  Mike Jones    dial: 2.640  │
+└─────────────────────────────────────────┘
+```
+
+This panel updates automatically when `NextMatchReady` fires, pulling from the active `EntryMap`.
+
+**"Assign Entry Numbers" dialog** (new, shown at session start when `PortatreeEnabled = true`):
+- DataGridView: Driver Name | Entry Number (editable) | Dial-In
+- Pre-fills entry numbers sequentially (001, 002, 003…)
+- Operator can override any number
+- Saves to `RaceSession.EntryAssignments`
+
+---
+
+## Data Flow Diagram (Race Day)
+
+```
+1. RCDM session starts
+   → EntryMap created: Dave Smith = 007, Mike Jones = 012, etc.
+   → PortatreeResultWatcher starts watching C:\Res2024\260528\260528.db
+
+2. RCDM generates bracket: Match 1 = Dave Smith (L) vs Mike Jones (R)
+   → "Now Racing" panel shows: LEFT 007 2.580 | RIGHT 012 2.640
+   → Operator reads panel, types into Eliminator touchscreen
+
+3. Eliminator runs race
+   → AutoSave writes two rows to 260528.db (RaceNumber=1)
+
+4. FileSystemWatcher fires
+   → Reader detects 2 new rows for RaceNumber=1
+   → CarNumber "007" → DriverId 3 (Dave Smith)
+   → CarNumber "012" → DriverId 7 (Mike Jones)
+   → Win=1 on "007" row
+   → Guard check: active match is Match 1, expected entries 007 + 012 ✓
+   → RaceController.SubmitWinner(winnerId=3, loserId=7)
+   → MatchTimingStore.Store(matchId=1, leftResult, rightResult)
+
+5. RCDM bracket advances normally (same path as manual entry)
+   → LiveApiClient pushes updated DTO to stewmacrc.com
+   → DTO now includes timing data in LiveWinnerDto
+
+6. OBS browser source polls stewmacrc.com
+   → Overlay updates with Dave Smith RT=0.035 ET=9.243 MPH=143.2 WIN
+```
+
+---
+
+## Paradox Reader — Implementation Notes
+
+Do NOT use BDE/ODBC from C#. BDE is a 32-bit COM server and requires registration. Instead, write a pure C# Paradox reader:
+
+**Paradox file structure (relevant parts):**
+- Bytes 0–1: record size
+- Bytes 2–3: header size
+- Byte 4: file type (3 = indexed, 0 = non-indexed)
+- Bytes 5–6: max table size
+- Bytes 7–8: number of records
+- Bytes 9–10: next block
+- Byte 21: number of fields
+- Field descriptor array starts at byte 120 (for Paradox 7 format): each descriptor is 1 byte type + 1 byte size + 1 byte offset
+- Field name table follows header
+
+The CC research pass already confirmed `pypxlib 2.5` reads these files correctly. For the C# port, implement the same header parsing logic. The scaling factor for all Long timing fields is **÷ 10000**.
+
+Reference: `C:\Res2024\240913\240913.db` is the test fixture (0 rows but correct schema). When the box arrives and a real race is run, this file will have data to test against.
+
+---
+
+## Open Questions Before Implementation
+
+1. **Results path detection:** Does ElimComp create `C:\Res2024\{YYMMDD}\{YYMMDD}.db` automatically, or does the operator create the folder first? Need to verify path creation on first run with the box.
+
+2. **FileSystemWatcher vs polling:** Paradox `.db` files have companion `.PX`, `.VAL`, `.XG0`, `.YG0` index files that ElimComp may write in a burst after the main `.db`. Watch the `.db` file only but add a 200ms debounce before reading to let the write complete.
+
+3. **Paradox file locking:** ElimComp holds the file open while running. C# reader must open with `FileShare.ReadWrite` or the watcher read will fail while ElimComp is active. Test this scenario before shipping.
+
+4. **PortatreeEnabled feature flag:** Confirm `appsettings.json` is the right config surface (consistent with `LiveBroadcastEnabled` already there) vs `App.config`. Current pattern in RCDM uses `AppSettings.cs` loading from `%APPDATA%\RC_Drag_Manager\appsettings.json`.
+
+5. **New DB table vs JSON blob:** `MatchTimingResults` as a new SQLite table is cleaner for querying post-event stats. Add migration via `DatabaseInitializer` with `CREATE TABLE IF NOT EXISTS` pattern already used in the project.
+
+6. **Multi-class events:** `MultiClassEvent` has multiple `RaceSession` objects. Each class needs its own `EntryMap` and its own results file watch path. Design the watcher as per-session, not per-event.
+
+---
+
+## Files To Create / Modify
+
+### New files
+- `src/RCDragManagerProd/Integration/PortatreeTimingResult.cs`
+- `src/RCDragManagerProd/Integration/PortatreeEntryMap.cs`
+- `src/RCDragManagerProd/Integration/PortatreeResultWatcher.cs`
+- `src/RCDragManagerProd/Integration/PortatreeParadoxReader.cs`
+- `src/RCDragManagerProd/UI/Forms/Session/AssignEntryNumbersDialog.cs`
+
+### Modified files
+- `src/RCDragManagerProd/Domain/RaceSession.cs` — add `List<EntryAssignment> EntryAssignments`
+- `src/RCDragManagerProd/Domain/MatchResult.cs` — no change needed (timing is separate store)
+- `src/RCDragManagerProd/Repositories/DatabaseInitializer.cs` — add `MatchTimingResults` table
+- `src/RCDragManagerProd/Integration/LiveRaceUpdateDto.cs` — add timing fields to `LiveWinnerDto`, add `LiveLastRunDto`
+- `src/RCDragManagerProd/Config/AppSettings.cs` — add `PortatreeEnabled`, `PortatreeResultsPath`
+- `src/RCDragManagerProd/UI/Forms/Main/Form1.cs` — add "Now Racing" panel wiring
+- `src/RCDragManagerProd/Controllers/RaceController.cs` — expose hook for watcher to call SubmitWinner
+
+### Test files to add
+- `src/RCDragManagerProd.Tests/PortatreeParadoxReaderTests.cs` — test against fixture `.db` files
+- `src/RCDragManagerProd.Tests/PortatreeResultWatcherTests.cs` — test guard logic, entry map lookup, scaling
+
+---
+
+## Prerequisites Before Starting Phase 1
+
+1. Portatree box physically connected and ElimComp confirmed communicating (COM port INI fixed — see PORTATREE-SETUP.md)
+2. At least one real race run through ElimComp with AutoSave ON, producing a populated results `.db` file
+3. That file copied to `C:\Res2024\{date}\{date}.db` for use as a test fixture
+4. Confirm pypxlib row reads match the actual data visible in ElimComp's Race Screen (sanity check the scaling factor)
+
+---
+
+## Suggested CC Prompt Sequence (Phase 1)
+
+1. **Research pass** — read `PortatreeParadoxReader` skeleton, existing `LiveApiClient`, `AppSettings`, `DatabaseInitializer` before writing any code
+2. **Implement `PortatreeParadoxReader`** — pure C# Paradox reader, tested against fixture files
+3. **Implement `PortatreeResultWatcher`** — FileSystemWatcher + debounce + guard logic
+4. **Add `EntryAssignment` to `RaceSession`** + `AssignEntryNumbersDialog`
+5. **Wire into `RaceController`** — `SubmitWinner` hook from watcher
+6. **Add `MatchTimingResults` table** to `DatabaseInitializer`
+7. **Extend `LiveRaceUpdateDto`** with timing fields
+8. **Add "Now Racing" panel** to Form1
+
+Each step is a separate CC prompt with its own research pass. Never implement more than one step per prompt.

--- a/Docs/PORTATREE-SETUP.md
+++ b/Docs/PORTATREE-SETUP.md
@@ -1,0 +1,102 @@
+# Portatree Eliminator Competition — Setup Status
+
+> Status: hardware/software setup notes. This is not evidence that Portatree result ingestion is implemented in RC Drag Manager. See `PORTATREE-RCDM-INTEGRATION.md` for the planned integration design.
+*Last updated: May 2026*
+
+---
+
+## Hardware
+
+**Unit:** Portatree Eliminator Competition (Next Gen)
+- Full-colour touchscreen, standalone operation
+- USB Type A-to-B connection to PC (top-left of unit)
+- Enumerates in Windows as **"Communication Device Class ASF Example"** under Ports (COM & LPT)
+- **Expected COM port: COM3** (USB CDC / Atmel driver)
+- Firmware: v1.15C, Serial: P0039900 (from CCConnect screenshot)
+
+**USB-to-serial adapter (FTDI):** present on **COM6** — this is for scoreboards / dial-in boards, NOT the Eliminator box itself.
+
+**Cable required:** USB Type A (PC) to Type B (Eliminator box top-left port). Standard printer-style cable.
+
+---
+
+## Software Installed
+
+| App | Location | Purpose |
+|-----|----------|---------|
+| ElimComp.exe | C:\Portatree\ | Full race software — bracket, results, DB |
+| newannou.exe | C:\Portatree\ | Announcer screen (second PC on LAN) |
+| Project2.exe | C:\Portatree\ | Post-processor / results reporting |
+| CCConnect.exe | C:\Portatree\CompetitionConnect\ | Free monitoring tool — download race files, update time slip message |
+
+**Runtime:** All three EXEs are Delphi/CLX apps (not VB6). Runtime dependency is `qtintf70.dll` — confirmed present at `C:\Windows\SysWOW64\qtintf70.dll`.
+
+**BDE:** Borland Database Engine 5.2 installed at `C:\Program Files (x86)\Borland\Common Files\BDE\`. Paradox driver (IDPDX32.DLL) present. Config file `IDAPI32.CFG` last modified 13/09/2024 — was configured during initial setup.
+
+---
+
+## Current Status
+
+### What Works
+- ElimComp.exe launches cleanly (run as Administrator from C:\Portatree\)
+- Paradox databases load — category "Outlaw" visible, race screen fully functional
+- Race Screen, bracket queue, scoreboard controls all render correctly
+- AutoSave is ON — results will write to the dated `.db` file automatically after each run
+
+### What Is Blocked
+
+**Error on launch:**
+> *"Can Not Read PtsPro.ini Com Port value to Connect to Gold Box"*
+
+**Root cause:** `C:\Portatree\PTSPRO.INI` has no COM port section. The app expects a section (exact key name TBD — not exposed as a static string in the binary, likely in a compiled DFM resource) specifying which COM port to open for the Eliminator box.
+
+**Why we parked it:** Cannot resolve without the box physically present on the other end. With the box plugged in on COM3, the correct port number will be known and testable.
+
+### What To Do When The Box Arrives
+
+1. Plug USB Type A-to-B cable from PC to Eliminator box (top-left port on box).
+2. Power on the box. Navigate to **Main Menu** on the touchscreen (not Race Screen — CCConnect requires Main Menu to connect).
+3. Open Device Manager → Ports (COM & LPT). Confirm the box appears as **"Communication Device Class ASF Example"**. Note the COM number (expected COM3).
+4. If driver doesn't install automatically: right-click the device → Update Driver → Browse my computer → `C:\Portatree\CompetitionConnect\` (Atmel CDC .inf files are there).
+5. Launch **CCConnect.exe** first (simpler tool). Click Connect. If it goes green and shows serial number + firmware version, hardware comms are confirmed.
+6. Then launch **ElimComp.exe** (as Administrator). Dismiss the COM port popup with OK. Go to **Setup menu** and look for a Com Port / Communications option, OR use the "Open PTSPRO.ini" button on the main screen and manually add:
+
+   ```ini
+   [ComPort]
+   Port=3
+   ```
+   (Substitute the actual COM number from step 3 if different.)
+
+7. Restart ElimComp. If the popup is gone and the status panel shows serial/version/config data in green — connected and ready.
+
+---
+
+## File Locations
+
+| File | Path | Purpose |
+|------|------|---------|
+| PTSPRO.INI | C:\Portatree\PTSPRO.INI | Master config — track settings, paths, COM port (missing) |
+| PTSPATHS.INI | C:\Portatree\PTSPATHS.INI | Pointer to PTSPRO.INI location |
+| racer.db | C:\Portatree\racer.db | Racer roster (76-field Paradox table) |
+| category.db | C:\Portatree\category.db | Category settings (20-field Paradox table) |
+| Results DB | C:\Res2024\{YYMMDD}\{YYMMDD}.db | Per-event results, created by ElimComp on session start |
+| CCConnect AppData | C:\Users\...\AppData\Roaming\Portatree\Competition\Standalone\ | CCConnect INI only — no race files stored here |
+
+---
+
+## Key Facts About The Next Gen Box
+
+- **Standalone operation** (no PC): full touchscreen race control, stores up to 20 result files internally
+- **Entry field:** 6-character alphanumeric (e.g. "007", "1643") — this is what links to RCDM's entry number mapping
+- **Dial-in:** entered per lane per race on the touchscreen (0.00–30.00). Both lanes need valid dials or they are cleared at race start
+- **Results saved to internal storage:** operator presses clipboard icon → Save. Up to 20 files.
+- **CCConnect downloads** internal files to PC as proprietary binary format, then Export converts to CSV
+- **ElimComp AutoSave** writes directly to the dated Paradox `.db` results file after each run — no manual save step needed when using PC software
+
+---
+
+## Notes
+
+- ElimComp references "Gold Box" in its strings — this is Portatree's older generation hardware name. The Next Gen box is compatible but the ElimComp version on disk may predate the Next Gen. If connection issues persist after the INI fix, check with Portatree (508-278-2189 / sales@portatree.com) that this ElimComp version supports the Next Gen box.
+- Do NOT use "Quick Session" path in ElimComp (the empty RaceSession path in older builds) — use the full Setup → Race flow.
+- Build the `RCDragManagerProd` project directly in Visual Studio, not Build Solution — the test project has pre-existing errors that don't affect the main app.

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,0 +1,32 @@
+# RC Drag Manager Documentation Index
+
+Last updated: 2026-06-06
+
+Use these docs as the current source of truth:
+
+| Doc | Purpose |
+| --- | --- |
+| `02_System_Overview.md` | Current desktop + live-server product architecture. |
+| `03_Controller_Engine_Contracts.md` | Current `RaceController`, `IRaceEngine`, and engine contract. |
+| `05_Mode_RoundRobin_Spec.md` | Current Round Robin/QMDRA behavior. |
+| `06_SQLite_Schema.md` | Current SQLite tables. |
+| `07_Repository_Contracts.md` | Current repository behavior. |
+| `08_UI_UX_Surface_Map.md` | Current WinForms surfaces and public scoreboard UI boundary. |
+| `09_Error_Handling_Logging.md` | Current logging and error handling. |
+| `10_Race_Log_and_Reporting.md` | Current result storage plus reporting gaps. |
+| `11_Installer_Packaging.md` | Current installer script behavior. |
+| `12_Live_Server_Integration.md` | Shared contract between desktop app and `RCDragLiveServer`. |
+
+## Historical Or Planning Docs
+
+The repo also contains handover files, dev logs, QA plans, Claude context, and feature specs. Keep them for history, but do not treat them as current source of truth without checking the code.
+
+Notably:
+
+- `PROJECT_STATUS.md` is historical and contains old claims about missing Random/Round Robin/session persistence work.
+- `DevLog/*` is historical narrative.
+- `claude-context/*` is research/context from prior sessions.
+- `PORTATREE-*` files describe setup/planned integration work, not implemented timing ingestion.
+- `LiveIntegration*` docs are implementation/review notes from the live scoreboard work.
+
+When adding a new canonical doc, add it to the table above. When writing a planning doc, label it clearly as planned or historical.

--- a/Docs/SESSION-HANDOVER (1).md
+++ b/Docs/SESSION-HANDOVER (1).md
@@ -1,0 +1,142 @@
+# RC Drag Manager — Session Handover
+*Generated: May 2026*
+
+---
+
+## What Was Accomplished This Session
+
+### v1.2.0 Released
+All outstanding issues from the previous session were resolved by the automated routine overnight. The full ENH-09a → ENH-09b → ENH-09c → ENH-09d → ENH-10 → ENH-11 chain completed. v1.2.0 was tagged and released with installer attached.
+
+**Closed this session (routine + manual):**
+- ✅ ENH-09a/b/c/d — MultiClassRaceForm now supports all race types per class
+- ✅ ENH-08 — Quick Session button removed
+- ✅ ENH-06 — Dial-in panel added to Form1
+- ✅ ENH-05 — QR code generator in app
+- ✅ BUG-12 — Single class events no longer skip landing page
+- ✅ BUG-13 — stewmacrc.com always shows branding/landing page
+- ✅ ENH-10 — Load Saved Event rerouted through MultiClassRaceForm
+- ✅ ENH-11 — Standalone SessionSetupForm retired; orphaned .resx build error fixed
+- ✅ Landing page button shift — buttons shifted up after Quick Session removal
+- ✅ Version label updated to v1.2.0 on landing page
+
+### UI/UX Work Completed This Session
+
+#### MultiClassConfigDialog — Race Format Redesign (PR #233, merged)
+- Replaced Race Type dropdown with 3 card-style selectors: Pro Ladder, Random Draw, Round Robin
+- Cards span full width matching the driver list
+- Round Robin card expands inline config panel: Rounds (N) spinner (default 3) + "Buyback race for 4th finals spot" checkbox
+- Replaced Standard/QMDRA radio buttons entirely — buyback checkbox maps to Standard (checked) / QMDRA (unchecked) internally
+- Controller fix: Standard RR now respects RoundsToRun from session instead of always auto-calculating min(3, n-1)
+
+#### Form1 Layout Refactor (PR #234, merged)
+- Introduced proper container panels — pnlHeader, pnlLeft, pnlBottom, pnlRail, tlpMain
+- pnlLeft (Dock=Left): driver list and editing controls
+- tlpMain (Dock=Fill): TableLayoutPanel 50/50 split — pnlCenter (pairings) and pnlRight (winners)
+- pnlRail (Dock=Right): action buttons in TableLayoutPanel with Save & Close pushed to bottom
+- pnlBottom (Dock=Bottom): Generate Bracket | race queue rows | Generate Next Round
+- ListView columns fixed — no horizontal overflow
+- 4px gap between pairings and winners panels
+- Edit Match Result button aligned with top of lvWinners
+- Driver List controls aligned with pairings/winners header row
+- Race Type dropdown (cmbRaceType) removed — dead code since SessionSetupForm retired
+
+---
+
+## Current State
+
+### Open Issues
+| # | Title | Priority | Status |
+|---|-------|----------|--------|
+| #190 | REVIEW-11: LiveApiClient.SendAsync serialises all pushes through global SemaphoreSlim | Low | Open — low priority, not blocking anything |
+
+**Board is essentially clear.**
+
+### Known Remaining UI Rough Edges (not filed as issues yet)
+- "Driver List:" label sits a couple of pixels above "Current Round Pairings:" label — minor alignment
+- txtName and txtTime input boxes have no placeholder labels — not discoverable which is which
+- Bottom-left corner under Generate Bracket is empty grey — looks bare
+- Form1 column widths in driver list truncate names — lvDrivers is 224px wide, Name column is only 80px
+
+---
+
+## Automated Routine — Current State
+
+**Location:** Claude Code Desktop → Routines → rc-drag-issue-fixer
+**Schedule:** Hourly
+**Both repos:**
+- `C:\Users\Stewart McMillan\source\repos\RC-Drag-Manager`
+- `C:\Users\Stewart McMillan\source\repos\RCDragLiveServer`
+
+**How it works:**
+1. Fetches all open issues ordered by priority (high bugs first, down to low enhancements)
+2. Skips issues labelled `blocked`, `wip`, `on-hold`, `skip`
+3. Checks `Depends On` sections — skips if dependencies not yet merged
+4. Creates branch, implements, builds, tests
+5. Pass → merges PR, closes issue. Fail → raises WIP PR, comments error, leaves open
+
+**Labels:** `priority:high` + `bug` → first … `priority:low` + `enhancement` → last
+
+**To block:** `gh issue edit {number} --repo stewmac570/RC-Drag-Manager --add-label "blocked"`
+**To unblock:** `gh issue edit {number} --repo stewmac570/RC-Drag-Manager --remove-label "blocked"`
+
+---
+
+## Architecture — Current State
+
+### Landing Page (clean)
+1. Create Race Session → MultiClassSetupForm → MultiClassRaceForm (hosted Form1 tabs)
+2. Load Saved Event → MultiClassRaceForm (hosted)
+3. Driver Lists
+4. Settings
+5. Exit
+
+SessionSetupForm and standalone Form1 path are fully retired.
+
+### Form1 Layout — Panel Structure
+```
+Form1
+├── pnlHeader (Dock=Top, H=50)       — event title
+├── pnlBottom (Dock=Bottom, H=170)   — generate bracket | race queue | generate next round
+├── pnlRail (Dock=Right, W=116)      — action buttons, save & close at bottom
+├── pnlLeft (Dock=Left, W=224)       — driver list + editing controls
+└── tlpMain (Dock=Fill, 50/50)
+    ├── pnlCenter                    — current round pairings
+    └── pnlRight                     — match winners
+```
+
+### MultiClassConfigDialog — Race Format Cards
+- Pro Ladder | Random Draw | Round Robin (card selector)
+- Round Robin expands: Rounds (N, default 3) + Buyback checkbox
+- Buyback checked → Variant="Standard", RoundsToRun=N
+- Buyback unchecked → Variant="QMDRA", RoundsToRun=N
+
+---
+
+## Key Learnings This Session
+
+- **For pixel-level WinForms layout work: run CC interactively, not through me as middleman.** CC can see the file, make the change, build, and adjust in one loop. I can't see results between changes so I was guessing. Use me for design decisions and prompt structure only.
+- **pnlRail/pnlLeft Dock=Right/Left already start below pnlHeader at runtime** — adding Padding(0, 50, 0, 0) double-offsets. For Dock panels, WinForms handles the header offset automatically.
+- **Absolutely positioned controls inside a panel ignore Padding** — only docked children respect it.
+- **CC stops on exact string mismatch** — prompts using `System.Windows.Forms.Padding` may not match files that use the `using` shorthand `Padding`. Use the unqualified form or instruct CC to match either.
+
+---
+
+## Repos
+
+| Repo | URL | Purpose |
+|------|-----|---------|
+| RC-Drag-Manager | github.com/stewmac570/RC-Drag-Manager | Desktop app (C# .NET 4.8 WinForms) |
+| RCDragLiveServer | github.com/stewmac570/RCDragLiveServer | Live scoreboard server + frontend (ASP.NET Core 8) |
+
+---
+
+## Next Session
+
+Board is clear. Options for next focus:
+
+1. **Tidy remaining Form1 rough edges** — placeholder labels on txtName/txtTime, Driver List label alignment, empty bottom-left corner
+2. **Live broadcast push feature** — GUID-based token, toggle button on Form1, designed but not yet implemented
+3. **File new issues** for anything above and let the routine handle them overnight
+
+Start next session by checking the open issues list — the routine may have picked up REVIEW-11 overnight.

--- a/Docs/SESSION-HANDOVER.md
+++ b/Docs/SESSION-HANDOVER.md
@@ -1,0 +1,162 @@
+# RC Drag Manager — Session Handover
+*Generated: May 2026*
+
+---
+
+## What Was Accomplished This Session
+
+### Issues Filed and Resolved
+- **9 original issues** filed (#159–#167) covering live scoreboard bugs and enhancements
+- **Automated issue-fix routine** set up in Claude Code Desktop — runs hourly, builds, tests, raises and merges PRs unattended
+- The routine worked overnight and closed 5 issues automatically (#159, #160, #162, #164, #166)
+- Cross-repo support added to the routine — it now works across both RC-Drag-Manager and RCDragLiveServer
+
+### New Issues Filed This Session
+| # | Title | Priority | Status |
+|---|-------|----------|--------|
+| #202 | BUG-11: Stale server state not flushed on new session | High | Open |
+| #211 | BUG-12: Single class events skip landing page | High | Open |
+| #212 | BUG-13: No landing page / branding on stewmacrc.com | High | Open |
+| #213 | ENH-05: QR code generator in app | Medium | Open |
+| #215 | ENH-06: Visible dial-in edit panel on Form1 | Medium | Open |
+| #216 | ENH-08: Remove Quick Session button | Medium | Open |
+| #217 | ENH-09: Extend MultiClass to support all race types | High | Blocked (replaced by 09a-09d) |
+| #218 | ENH-10: Reroute Load Saved Event through MultiClassRaceForm | High | Blocked (needs ENH-09) |
+| #219 | ENH-11: Remove Create Race Session / retire SessionSetupForm | Medium | Blocked (needs ENH-09 + 10) |
+| #220 | ENH-09a: Remove RaceType hardcode in MultiClassSetupForm | High | Open |
+| #221 | ENH-09b: Add race type selector to MultiClassConfigDialog | High | Open |
+| #222 | ENH-09c: Add class type selector to MultiClassConfigDialog | High | Open |
+| #223 | ENH-09d: Add QMDRA/RoundsToRun config to MultiClassConfigDialog | Medium | Open |
+
+### Research Completed
+- **ISSUE-PRIORITY.md** — CC assessed all issues and recommended order
+- **TIME-FIELDS-RESEARCH.md** — CC traced QualifyingTime and DialIn through the full codebase
+- **LANDING-PAGE-CONSOLIDATION-RESEARCH.md** — CC traced all three landing page paths and identified what blocks consolidation
+
+---
+
+## Automated Routine — Current State
+
+**Location:** Claude Code Desktop → Routines → rc-drag-issue-fixer
+**Schedule:** Hourly
+**Folder:** `C:\Users\Stewart McMillan\source\repos\RC-Drag-Manager`
+
+**Both repos the routine works across:**
+- `C:\Users\Stewart McMillan\source\repos\RC-Drag-Manager`
+- `C:\Users\Stewart McMillan\source\repos\RCDragLiveServer`
+
+**How it works:**
+1. Fetches all open issues ordered by priority (high bugs first, down to low enhancements)
+2. Skips issues labelled `blocked`, `wip`, `on-hold`, `skip`
+3. Checks dependency `Depends On` sections — skips if dependencies not yet merged
+4. Creates a branch (`fix/` for bugs, `feature/` for enhancements)
+5. Implements the fix, builds, runs tests
+6. If pass: merges PR, comments on issue, closes issue
+7. If fail: raises WIP PR, comments with error output, leaves issue open
+
+**Labels used for priority sorting:**
+- `priority:high` + `bug` → first
+- `priority:high` + `enhancement` → second
+- `priority:medium` + `bug` → third
+- `priority:medium` + `enhancement` → fourth
+- `priority:low` + `bug` → fifth
+- `priority:low` + `enhancement` → last
+
+**To add new issues to the routine:** Just create the issue with the right labels. The routine picks it up automatically on the next run.
+
+**To block an issue:** `gh issue edit {number} --repo stewmac570/RC-Drag-Manager --add-label "blocked"`
+**To unblock:** `gh issue edit {number} --repo stewmac570/RC-Drag-Manager --remove-label "blocked"`
+
+---
+
+## Landing Page — Current State and Problems
+
+The landing page currently has these buttons in this order:
+1. Quick Session ← broken, creates empty session, should be removed
+2. Create Race Session ← legacy standalone Form1 path
+3. Load Saved Event
+4. Driver Lists
+5. Settings
+6. New Multi-Class Event ← the correct hosted path
+
+### The Core Problem
+There are two ways to create a race and they behave differently:
+- **Create Race Session** → SessionSetupForm → standalone Form1 (not hosted)
+- **New Multi-Class Event** → MultiClassSetupForm → MultiClassRaceForm hosting Form1 tabs
+
+The hosted path (MultiClassRaceForm) is the correct one — it supports tab color coding, Save and Close, and multiple classes. But it currently only supports Round Robin. ENH-09a through 09d will extend it to support all race types, after which the standalone path can be retired.
+
+### Desired End State
+1. **Create Race Session** (renamed from New Multi-Class Event)
+2. **Load Saved Event**
+3. **Driver Lists**
+4. **Settings**
+5. **Exit**
+
+Quick Session and the old Create Race Session both gone. One entry point, one flow.
+
+---
+
+## UI/UX Problems Identified — For Next Session
+
+These are the UI/UX issues that need a dedicated focused session:
+
+### Landing Page
+- Wrong button order
+- Two race creation entry points (confusing)
+- Quick Session button is broken and shouldn't exist
+- Desired order: Create Race Session → Load Saved Event → Driver Lists → Settings → Exit
+
+### MultiClassRaceForm / Form1 Layout
+- Form layout breaks at different screen sizes (BUG-10 / #210 filed)
+- Columns cut off in Current Round Pairings and Match Winners ListViews
+- Form does not stretch cleanly to screen size
+- The hosted Form1 inside MultiClassRaceForm needs proper anchor/dock settings
+
+### Race Console (Form1)
+- Dial-in times hidden behind right-click — not discoverable (ENH-06 / #215)
+- Qualifying times section exists but dial-in has no equivalent visible panel
+- Set Time button updates local driver list only, not controller-mediated
+
+### Live Scoreboard (stewmacrc.com)
+- Landing page inconsistent — sometimes bypassed for single class events (BUG-12/13)
+- Stale results from previous session showing (BUG-11)
+- Various layout and ordering issues partially addressed by overnight routine runs
+
+---
+
+## Dependencies Chain
+
+```
+ENH-09a (#220) ← no dependencies, safe to run now
+    └── ENH-09b (#221) ← needs 09a merged
+            └── ENH-09c (#222) ← needs 09b merged
+                    └── ENH-09d (#223) ← needs 09c merged
+                            └── ENH-10 (#218) ← needs all 09a-09d merged
+                                    └── ENH-11 (#219) ← needs ENH-10 merged
+```
+
+ENH-08 (#216), ENH-06 (#215), ENH-05 (#213) are all independent and can run in any order.
+
+---
+
+## Repos
+
+| Repo | URL | Purpose |
+|------|-----|---------|
+| RC-Drag-Manager | github.com/stewmac570/RC-Drag-Manager | Desktop app (C# .NET 4.8 WinForms) |
+| RCDragLiveServer | github.com/stewmac570/RCDragLiveServer | Live scoreboard server + frontend (ASP.NET Core 8) |
+
+---
+
+## Next Session Focus — UI/UX
+
+The next session should be dedicated to:
+
+1. **Mockup the desired landing page** — get agreement on layout before writing any code
+2. **Mockup the desired MultiClassRaceForm layout** — agree on how it should look at different screen sizes
+3. **Mockup the dial-in panel on Form1** — where does it live, what does it look like
+4. **Create properly scoped UI issues** for CC to implement
+5. **Confirm ENH-09a has merged** and unblock ENH-09b before starting that session
+
+Start the next session by pulling up this handover and the current open issues list.

--- a/Docs/claude-context/ISSUE-PRIORITY.md
+++ b/Docs/claude-context/ISSUE-PRIORITY.md
@@ -1,0 +1,143 @@
+# Issue Priority — Recommended Order
+
+Recommendation for tackling open issues #159–#167. Ordering balances regression
+risk, RD/driver impact, and inter-issue dependencies. Issue numbers and labels
+are as filed on `github.com/stewmac570/RC-Drag-Manager`.
+
+---
+
+## Suggested Order
+
+### 1. #159 — BUG-01: Live scoreboard stops updating after RR rounds complete
+**Risk:** Low. **Impact:** Very high. **Blocks:** every other live-data work item.
+
+The live broadcast plumbing is already in place — `QueueLiveUpdate` is called
+from `RaceController.Results.cs:81` (SubmitWinner) and
+`RaceController.RoundFlow.Core.cs:169/220/243` (GenerateBracket, AdvanceRound).
+The gap is that neither `StartLosersBracket()`
+(`RaceController.RoundFlow.Losers.cs:33`) nor `InjectFinal4Bracket()` /
+`StartFinalsTop3NoBuyback()` / `InjectFinalsAllAdvance()`
+(`RaceController.RoundFlow.Finals.cs`) call `QueueLiveUpdate` after they swap
+the engine and reveal the first round of the new phase. The fix is additive:
+one call at the end of each phase-transition method. No existing code path
+changes. This is also a **prerequisite** — there is no value pushing dial-ins
+(ENH-02), lane data (ENH-01), or richer scorecards (ENH-03) until LB and
+Finals reach the server in the first place.
+
+### 2. #162 — BUG-04: Form1 winners bracket column alignment broken
+**Risk:** Very low. **Impact:** Medium (RD daily UX). **Blocks:** nothing.
+
+Isolated to `Form1.Display.cs` (`RebuildWinnersView`) and the designer column
+widths. No domain logic, no engine paths, no DB. Easy win that improves the
+operator's primary view every event. Independent of all other issues.
+
+### 3. #160 — BUG-02: Live scoreboard tabs auto-switch on refresh
+**Risk:** Very low (frontend-only). **Impact:** High during multi-class
+events. **Blocks:** nothing.
+
+Lives entirely in the stewmacrc.com frontend — does not touch the C# app.
+Persisting active tab in localStorage or URL hash is a small, well-understood
+pattern. High impact for the multi-class scenario which the app already
+supports. Independent of BUG-01 in code, but pairs naturally with it: once
+LB/Finals push correctly, the user actually has stable data to look at across
+tab refreshes.
+
+### 4. #161 — BUG-03: Live scoreboard classes flicker / change on refresh
+**Risk:** Very low. **Impact:** Medium. **Blocks:** nothing.
+
+Frontend-only ordering bug, plus a one-line stabilising sort on the server
+side (sort `InMemoryLiveRaceStateStore` keys before serialising). Cheap to
+fix once BUG-02 has the team in the live-site frontend already.
+
+### 5. #163 — BUG-05: Single buyback driver forces LB run instead of going direct to finals
+**Risk:** Medium. **Impact:** Medium (event-blocking when it occurs).
+**Blocks:** nothing.
+
+The override mechanism already exists: `_buybackChampionOverride` in
+`RaceController.RoundFlow.Finals.cs:32-36` is a documented wildcard path that
+sends a single driver straight into Finals without an LB engine. The fix is
+not "build a new path" but "route the single-driver case into the existing
+override path." `BuybackDriverSelectionForm.cs:31-36` already accepts
+`>=1` selections — the rejection is at `GenerateLosersBracket` /
+`StartLosersBracket`, which both gate on `< 2`. Lift those gates for the
+single-driver case, set `_buybackChampionOverride`, and call
+`InjectFinal4Bracket()` directly. Medium risk only because it touches the
+LB→Finals control flow; testable against existing event scenarios.
+
+### 6. #164 — ENH-01: Show lane assignments (Left/Right) on live scoreboard
+**Risk:** Low. **Impact:** Medium-high. **Depends on:** BUG-01.
+
+Additive change: one new field on `LiveMatchDto`, populated in
+`RaceController.LiveUpdate.cs:74-82` from the existing `LaneFairnessManager`
+(`GetLaneAdjustedNames` is already called for `nextUp` — extend the
+projection). Server passes through; frontend renders side-by-side. Why after
+BUG-01: there is no point sending lane data for LB/Finals matches if those
+matches never reach the server.
+
+### 7. #166 — ENH-03: Round Robin scoring transparency — detailed scorecard
+**Risk:** Low. **Impact:** Medium (driver-facing). **Depends on:** BUG-01
+(for the live-site portion).
+
+`RoundRobinScorecardLogger.BuildScorecard` is already piped into
+`LiveRaceUpdateDto.RRStandings` (`RaceController.LiveUpdate.cs:95-101`) and
+into the post-round popup. Extension is additive — expose more detail from
+`RoundRobinRanker.Rank()` and grow the formatter output. No risk to existing
+RR scoring math because the scoring/tiebreaker logic itself is unchanged;
+only the *display* is being expanded.
+
+### 8. #165 — ENH-02: Driver dial-in display and self-update on live scoreboard
+**Risk:** High. **Impact:** Very high (most-requested driver feature).
+**Depends on:** BUG-01 and arguably ENH-04.
+
+Largest of the enhancements: new server endpoint with PIN storage, frontend
+update form, app-side polling to read updates back into `DriverEntries`,
+Form1 winner-button display, plus a "lock on Generate Next Round" gate. The
+server-write-back-into-the-app path is new ground for this codebase — every
+existing live integration is push-only. Also produces concurrency questions
+(driver edits dial-in mid-round, RD edits at the same time, who wins). Worth
+doing because drivers want it, but worth doing carefully and after the
+foundational fixes land. **If ENH-04 is going to happen, it should land
+before ENH-02** so the new endpoint is event-scoped from day one and does
+not need a follow-up migration.
+
+### 9. #167 — ENH-04: Multi-event support on stewmacrc.com
+**Risk:** High (architectural). **Impact:** Low today (only matters with
+concurrent RDs); high once that situation arises. **Depends on:** BUG-01.
+
+Touches `RaceSession`, every live DTO, every server endpoint, the server
+store, and the frontend landing page. Doing this last after BUG-01 means the
+core push path is already correct; doing it before ENH-01/03 means those
+features ship event-scoped from the start. Recommend slotting **immediately
+before ENH-02** if the team is committed to ENH-02 — otherwise leaving it
+last is fine, with the understanding that ENH-01/03 will need a small
+migration when ENH-04 eventually lands.
+
+---
+
+## Dependency Summary
+
+```
+BUG-01 ──┬── ENH-01
+         ├── ENH-03
+         └── ENH-04 ── ENH-02
+
+BUG-04   (independent)
+BUG-02   (independent, frontend-only)
+BUG-03   (independent, frontend-only)
+BUG-05   (independent)
+```
+
+`BUG-01` is the only hard prerequisite for the enhancements — until LB and
+Finals data reach the server, every richer payload is wasted on those
+phases. `ENH-04` is a soft prerequisite for `ENH-02`: if both are planned,
+do `ENH-04` first to avoid a second round of endpoint rework.
+
+---
+
+## Recommended First Issue
+
+**Start with #159 (BUG-01).** It is the lowest-risk fix in the list — purely
+additive `QueueLiveUpdate(...)` calls at three known phase-transition
+points — and it unblocks every live-feed enhancement. Without it, any work
+on ENH-01/02/03/04 is partly invisible to drivers because LB and Finals
+phases never make it to the live site.

--- a/Docs/claude-context/LANDING-PAGE-CONSOLIDATION-RESEARCH.md
+++ b/Docs/claude-context/LANDING-PAGE-CONSOLIDATION-RESEARCH.md
@@ -1,0 +1,411 @@
+# Landing Page Consolidation — Research
+
+Read-only investigation of the three event-creation paths exposed on
+`LandingForm` (formerly `LandingPageForm`) and what would be needed to
+collapse them. No code changes made.
+
+---
+
+## QUESTION 1 — Quick Session path (`btnNewEvent`)
+
+### Trace
+
+`LandingPageForm.cs:37-43`:
+```csharp
+private void btnNewEvent_Click(object sender, EventArgs e)
+{
+    Logger.Log("[QUICK] Launching Quick Session → RaceController(new RaceSession())");
+    var controller = new RaceController(new RaceSession());   // empty quick session
+    var mainForm = new Form1(controller);
+    mainForm.Show();
+}
+```
+
+The button creates an empty `RaceSession` (no event name, no date, no class
+type, no driver entries, no race-type selection), wraps it in a new
+`RaceController`, and shows a standalone `Form1`.
+
+### What's missing vs. Create Race Session path
+
+Comparing to `btnCreateSession_Click` (`LandingPageForm.cs:45-63`), Quick
+Session skips the entire `SessionSetupForm` step. So a Quick Session has:
+
+| Field | Create Race Session | Quick Session |
+|---|---|---|
+| `RaceSession.EventName` | from text box | "" (blank — Form1 falls back to `"Quick Session"` literal at `Form1.cs:54-56`) |
+| `RaceSession.EventDate` | from date picker | `default(DateTime)` |
+| `RaceSession.RaceType` | from `cmbRaceType` (Pro Ladder / Random / RR) | `null` (set later when GenerateBracket is called from Form1's own `cmbRaceType`) |
+| `RaceSession.ClassType` | from setup form | `null` |
+| `RaceSession.DriverEntries` | populated from selected drivers + cars | empty list — user has to add drivers via Form1's `txtName` + `txtTime` form |
+| `FixedDialIn` | optional (Bracket Class) | not set |
+| `RoundRobinVariant` / `RoundsToRun` | configurable | defaults (`"Standard"`, null) |
+
+In Quick Session, **driver entries get set only as a side effect** of
+`RaceController.SaveSession()` rebuilding `DriverEntries` from the
+in-memory `drivers` list (`RaceController.Persistence.cs:79-89`).
+
+### Live broadcast behaviour
+
+`RaceController.LiveUpdate.cs:23` and `:533`, plus
+`RoundFlow.Core.cs:169` substitute the literal `"Quick Session"` for the
+`EventName` when blank. So Quick Session events do show up on the live
+feed with that placeholder name and the same `EventId` as any other
+session (`RaceSession` constructor always assigns a new GUID at
+`RaceSession.cs:50`).
+
+### `btnSaveAndClose` short-circuit for Quick Session
+
+`Form1.Events.cs:292-299`:
+```csharp
+if (currentSession == null)
+{
+    MessageBox.Show("Quick Session completed. No session file saved.");
+    Close();
+    return;
+}
+```
+
+Note: `currentSession` is hydrated from `_controller.Session` at
+`Form1.cs:52`, which is the empty `RaceSession` (not null). So this
+guard does **not actually fire** for Quick Session — `currentSession`
+is non-null. The "Quick Session completed" branch is dead code in the
+current flow. The full save path runs even for Quick Session, writing
+an INSERT row to the `RaceSessions` table.
+
+### Other references
+
+- `LandingPageForm.cs:39, 41` — the click handler itself.
+- `LandingPageForm.Designer.cs:12, 31, 58-63` — designer registration.
+- `Form1.cs:56`, `RaceController.LiveUpdate.cs:23`,
+  `RaceController.RoundFlow.Core.cs:169, 533` — the literal string
+  `"Quick Session"` is used as a fallback `EventName`.
+- **No test references** — searched for `btnNewEvent`, `Quick Session`,
+  `new RaceSession()` in tests; only `PairingHistorySerializationTests.cs`
+  constructs `new RaceSession()` directly, and that's a domain-level
+  serialisation test that would survive the button being deleted.
+
+---
+
+## QUESTION 2 — Create Race Session path (`btnCreateSession`)
+
+### Trace
+
+`LandingPageForm.cs:45-63`:
+```csharp
+var setup = new SessionSetupForm(_driverRepo);
+if (setup.ShowDialog() == DialogResult.OK)
+{
+    var rs = setup.RaceSessionResult;
+    var controller = new RaceController(rs);
+    var mainForm = new Form1(controller);
+    mainForm.Show();
+}
+```
+
+`SessionSetupForm.Events.cs:206-243` builds a `RaceSession` with:
+- `EventName`, `EventDate` from the form
+- `RaceType` from `cmbRaceType` — three options
+  (`SessionSetupForm.Designer.cs:79`): `"Pro Ladder"`, `"Random Draw"`,
+  `"Round Robin"`
+- `ClassType` (Heads Up / Dial-In / Bracket Class) — drives whether
+  `QualifyingTime` or `DialIn` is populated per entry
+  (`SessionSetupForm.Events.cs:224-229`)
+- `DriverEntries` populated from the selected event roster
+- `RoundRobinVariant` / `RoundsToRun` if Round Robin
+
+Form1 then opens with the populated session.
+
+### What standalone Form1 does that MultiClassRaceForm does not replicate
+
+| Concern | Standalone Form1 | MultiClassRaceForm equivalent |
+|---|---|---|
+| **Save and Close** | `Form1.Events.cs:292-323` saves via `_controller.SaveSession()` + `sessionRepository.SaveSession(currentSession)` + `_controller.RecomputeEventsWon(...)` + closes the form. | Each hosted Form1's `btnSaveAndClose_Click` runs the same controller/session save, **then** also persists the parent multi-class event via `_multiClassEventRepo.SaveEvent(_multiClassEvent)` (`Form1.Events.cs:304-315`). Hosted mode raises `HostedSaveAndCloseCompleted` instead of closing — the parent `MultiClassRaceForm` closes itself (`MultiClassRaceForm.cs:115-118`). |
+| **TournamentCompleted popup + stats** | `Form1.Events.cs:65-87` shows the per-event winner/runner-up popup and calls `_controller.PersistTournamentStats(...)` — increments EventsEntered for all participants, EventsWon for the winner, TotalWins/TotalLosses for each match. | Suppressed in hosted mode via `if (IsHostedMode) return;` (`Form1.Events.cs:70`). `MultiClassRaceForm.OnClassTournamentCompleted` (`MultiClassRaceForm.cs:235-282`) runs instead — does its own `IncrementWinsAndLosses` per match + `IncrementEventsWon` for the winner. EventsEntered is incremented **up front** in `MultiClassSetupForm.BtnStartRace_Click` (line 155), not on completion. |
+| **Per-match stats** (`PersistMatchStats` / `PersistEventWon`) | Fires from `Form1.WinnerButtons.cs:281, 286` on every Winner1/Winner2 click. | Same — these calls have **no `IsHostedMode` gate**, so they fire in hosted mode too. (Result: stats are written *twice* end-to-end in both standalone and multi-class — once per match, once at completion. Pre-existing behaviour, not a difference between paths.) |
+| **Buy-back popup** | `Form1.Events.cs:35-43` `OnCanOfferBuybackChanged` shows "Round-Robin complete. Click 'Buy Back'..." popup when `enabled && !IsHostedMode`. | Suppressed in hosted mode. `MultiClassRaceForm.CheckAndReleaseRrGate` (`MultiClassRaceForm.cs:207-231`) runs instead — waits for **all classes** to finish RR, then shows a single combined popup. |
+| **Buy-back flow itself** | `Form1.Events.cs:336-399` — `btnGenerateLosersBracket_Click` → `BuybackDriverSelectionForm` → `_controller.GenerateLosersBracket(selectedDrivers)` (with single-driver direct-promotion at line 374). | Same — each hosted Form1 runs its own buy-back independently. The only multi-class addition is the gate at the parent level (don't show buy-back per-class until all classes are RR-complete). |
+| **Finals flow** | `Form1.Events.cs:45-63` `OnCanStartFinalsChanged` shows "Finals Ready" popup when `enabled && !_finalsPopupShown`. **No `IsHostedMode` gate.** | The popup **still fires** in hosted mode (no suppression). `MultiClassRaceForm` doesn't intercept Finals state — finals are run per-class via the embedded Form1. |
+| **Live broadcast** | `_controller.StartDialInPolling()` in `Form1` ctor (`Form1.cs:93`) and `StopDialInPolling()` on close (line 110). Push happens via `QueueLiveUpdate` triggered by controller actions. One controller, one push stream, one EventId. | Each tab has its own `RaceController` (`MultiClassRaceForm.cs:51-54`), so each starts/stops its own dial-in polling and pushes its own stream. With N classes, N concurrent push streams to `/api/update` — each carries the **same `EventId`** if `MultiClassSetupForm.BtnStartRace_Click` reuses the same RaceSession across classes (see Q3). |
+| **`cmbRaceType` selection** | Persisted across reset: `Form1.Events.cs:286-289` re-applies `currentSession.RaceType` after `Reset()`. | Hosted Form1 also has this code; works the same. But MultiClass setup hardcodes `RaceType = RaceTypes.RoundRobin` (see Q3) — so the dropdown is effectively pre-selected to RR with no other option. |
+
+The **one piece of logic standalone exclusively owns** is the
+`OnTournamentCompleted` → `PersistTournamentStats` path and the
+"Quick Session no save" guard. Both have parallel implementations on the
+multi-class side.
+
+---
+
+## QUESTION 3 — New Multi-Class Event path (`btnNewMultiClassEvent`)
+
+### Trace
+
+`LandingPageForm.cs:94-109`:
+```csharp
+var setup = new MultiClassSetupForm(_connStr);
+if (setup.ShowDialog() == DialogResult.OK)
+{
+    var multiEvent = setup.MultiClassEventResult;
+    var form = new MultiClassRaceForm(multiEvent, _connStr);
+    form.Show();
+}
+```
+
+`MultiClassSetupForm.BtnStartRace_Click` (`MultiClassSetupForm.cs:135-183`):
+1. Validates that every class has at least one driver. **No minimum class
+   count check** — `_classList.Count == 0` would build an empty event.
+2. Calls `IncrementEventsEntered` for **every driver in every class** —
+   *up front, before any race has been run*.
+3. Builds a `MultiClassEvent` with one `RaceSession` per class. **Hardcodes
+   `RaceType = RaceTypes.RoundRobin`** for every session
+   (`MultiClassSetupForm.cs:172`). Pro Ladder and Random Draw are
+   **inaccessible** through the multi-class path.
+4. Each session gets its own `EventId` (auto-generated by
+   `RaceSession` ctor at `RaceSession.cs:50`) — note these are *different*
+   per class. The `EventName` and `EventDate` are shared across the
+   sessions.
+
+### `MultiClassRaceForm.BuildTabs` flow
+
+`MultiClassRaceForm.cs:86-113`:
+```csharp
+for (int i = 0; i < _controllers.Count; i++) {
+    var session = _multiEvent.ClassSessions[i];
+    var tab = new TabPage(session.ClassType);
+    var form1 = new Form1(_controllers[i]);
+    form1.IsHostedMode = true;
+    form1._multiClassEvent = _multiEvent;
+    form1._multiClassEventRepo = _multiClassRepo;
+    form1.TopLevel = false;
+    form1.FormBorderStyle = FormBorderStyle.None;
+    form1.Dock = DockStyle.Fill;
+    tab.Controls.Add(form1);
+    form1.HostedSaveAndCloseCompleted += OnHostedSaveAndCloseCompleted;
+    form1.Show();
+    tabControl.TabPages.Add(tab);
+    _classRaceForms.Add(form1);
+}
+```
+
+Each tab embeds a borderless top-level-`false` Form1 instance with:
+- Its own `RaceController` (constructed in
+  `MultiClassRaceForm.cs:49-54`)
+- Hosted-mode flag enabled
+- Pointers to the parent `MultiClassEvent` and `MultiClassEventRepository`
+
+### Differences from standalone (concise)
+
+- **Save**: hosted Form1's save also persists the multi-class event row
+  + raises an event so the parent form closes. Standalone closes itself.
+- **Stats**: pre-race EventsEntered + post-race per-match W/L + post-race
+  EventsWon, all done by the parent. Standalone does it all on
+  TournamentCompleted via `PersistTournamentStats`.
+- **Buy-back gating**: parent waits for all classes RR-complete, then a
+  single combined popup. Standalone shows the popup immediately for that
+  class.
+- **Finals popup**: **NOT suppressed in hosted mode** — it still fires
+  per-class. (Possibly intentional, since each class runs its own finals
+  independently.)
+- **Live broadcast**: N independent push streams from N controllers, each
+  with its own `EventId`. The desktop side does not coordinate them; the
+  server-side store buckets by `EventName` (per
+  `RCDragLiveServer/Services/InMemoryLiveRaceStateStore.cs:73-75`), so
+  multiple class-streams with different `EventId`s but the same
+  `EventName` collapse into one event bucket on the server with one
+  class entry per `ClassType`.
+- **Race type**: hardcoded to Round Robin.
+
+---
+
+## QUESTION 4 — Can MultiClassRaceForm run a single class?
+
+### Code-path inspection
+
+- **`MultiClassSetupForm`**: no minimum class count. The user could click
+  Add Class once, fill the dialog, then Start Race with one class.
+  Validation only checks that each class has ≥1 driver
+  (`MultiClassSetupForm.cs:138-148`).
+- **`MultiClassRaceForm.BuildTabs`**: loops over `_controllers.Count`. One
+  iteration produces one tab containing one hosted Form1 with the same
+  border-less, dock-fill setup as the multi-class case.
+- **`UpdateAllTabStates`** / **`tabControl_Selecting`**: gracefully handle
+  any tab count, including one.
+- **`CheckAndReleaseRrGate`** (lines 207-231): `_rrCompleteClassIndexes
+  .Count == _controllers.Count` triggers the "all RR complete" popup. With
+  one class, this fires immediately when that one class finishes RR. The
+  message reads "All classes have completed Round Robin..." which is
+  technically correct but slightly odd phrasing for a single class.
+- **`OnClassTournamentCompleted`** (lines 235-282): when all classes
+  complete, calls `ShowCombinedEventSummary`. With one class, the summary
+  shows just that class — works but headed `FINAL RESULTS` over a single
+  block.
+
+### What a single-class multi-class event would look like in practice
+
+- LandingForm → "New Multi-Class Event" → MultiClassSetupForm
+- Add one class (e.g. "Heads Up", RR, drivers)
+- Start Race → MultiClassRaceForm with **one tab**
+- The tab shows the same Form1 UI as standalone, just embedded in a tab
+  control with a single page
+- Buy-back ready popup says "All classes have completed Round Robin"
+  (singular phrasing slightly off)
+- On completion, "Class Complete" popup fires, then immediately the
+  combined "Event Complete — Final Results" dialog shows just that class
+
+### Constraints
+
+1. **Race type forced to Round Robin.** Cannot run a single Pro Ladder or
+   Random Draw event through this path without also changing
+   `MultiClassSetupForm`.
+2. **Pre-race EventsEntered increment.** A driver who registers in setup
+   then doesn't actually race still gets their EventsEntered bumped (and
+   not rolled back if the user cancels mid-event).
+3. **Cosmetic phrasing**: "All classes have completed Round Robin" with
+   N=1 sounds wrong but is harmless.
+
+There are **no functional blockers** to running MultiClassRaceForm with
+exactly one class. The setup form already permits it.
+
+---
+
+## QUESTION 5 — What would break if Quick Session and Create Race Session were removed?
+
+### All references to `btnNewEvent`
+
+| File | Line | What |
+|---|---|---|
+| `UI/Forms/Session/LandingPageForm.cs` | 37, 39, 41 | Click handler |
+| `UI/Forms/Session/LandingPageForm.Designer.cs` | 12, 31, 58-63 | Designer button registration |
+
+No production code outside the designer/handler references `btnNewEvent`.
+**No test references.** The string `"Quick Session"` is used as a
+**display-only fallback** for blank `EventName` in three places
+(`Form1.cs:56`, `RaceController.LiveUpdate.cs:23`,
+`RaceController.RoundFlow.Core.cs:169, 533`); those would remain valid
+even if the button were removed (any blank-name session would still
+display "Quick Session"). There's also one dead branch
+(`Form1.Events.cs:292-299`) that was Quick-Session-specific and is
+already unreachable today.
+
+### All references to `btnCreateSession`
+
+| File | Line | What |
+|---|---|---|
+| `UI/Forms/Session/LandingPageForm.cs` | 45 | Click handler |
+| `UI/Forms/Session/LandingPageForm.Designer.cs` | 13, 32, 65-70 | Designer button registration |
+
+No test references. The Create Session click handler depends on:
+- `SessionSetupForm` — used **only** by this handler. Removing this path
+  removes the only entry point to `SessionSetupForm`.
+- `Form1` constructor with a populated session — still used by Quick
+  Session (if kept) and by Load Saved Event for single-class loads
+  (`LandingPageForm.cs:73`).
+
+### Production features only reachable through standalone Form1
+
+| Feature | Where | Replicable in MultiClass? |
+|---|---|---|
+| **Pro Ladder race type** | `SessionSetupForm.Designer.cs:79`, `Form1.Designer.cs:509-512`, `MatchEngine.cs` | ❌ Multi-class hardcodes RR. Migration would require adding a per-class race-type dropdown to `MultiClassConfigDialog` and removing the hardcode in `MultiClassSetupForm.cs:172`. |
+| **Random Draw race type** | Same | ❌ Same as Pro Ladder. |
+| **Heads Up class** | `SessionSetupForm.Events.cs:224-225` | Multi-class has its own `MultiClassConfigDialog` flow that builds `RaceSessionDriverEntry` directly — need to check whether it sets `QualifyingTime` for Heads Up. (Not investigated in this pass.) |
+| **Bracket Class with `FixedDialIn`** | `SessionSetupForm.Events.cs:217, 228-229` | Same — depends on whether `MultiClassConfigDialog` supports `FixedDialIn`. |
+| **Standalone Form1 reset behaviour** (`Form1.Events.cs:286-289`) | Re-applies `currentSession.RaceType` after Reset | Already works in hosted Form1. |
+
+### Things to verify before removing the buttons
+
+1. **Race type parity.** Either preserve standalone for Pro Ladder /
+   Random Draw, or extend `MultiClassConfigDialog` /
+   `MultiClassSetupForm.cs:166-179` to allow per-class `RaceType` and
+   `FixedDialIn`, removing the RR hardcode.
+2. **Heads Up qualifying time**. Confirm `MultiClassConfigDialog` builds
+   `RaceSessionDriverEntry.QualifyingTime` for Heads Up classes (the
+   path SessionSetupForm uses at `SessionSetupForm.Events.cs:225`).
+3. **EventsEntered timing**. Multi-class increments EventsEntered up
+   front; standalone does it on `TournamentCompleted`. After collapsing,
+   pick one and stick to it (or your stats accounting will diverge).
+4. **Live broadcast EventId per-class**. If you collapse to multi-class
+   for *all* events, every event becomes N concurrent streams (one per
+   class). Confirm the server-side bucketing by `EventName` is what
+   you want (it currently is — see
+   `InMemoryLiveRaceStateStore.cs:73-75`).
+5. **"Quick Session" fallback string**. Either remove the literal
+   fallbacks (`Form1.cs:56`, `RaceController.LiveUpdate.cs:23`, etc.) or
+   leave them as harmless dead-string defenders.
+6. **Dead-code cleanup**: `Form1.Events.cs:292-299` (the
+   `currentSession == null` branch) becomes provably dead.
+7. **`SessionSetupForm`** can be deleted entirely if Create Race Session
+   is removed (no other references). Same for `SessionSetupForm.Events.cs`,
+   `SessionSetupForm.Designer.cs`.
+8. **Tests**: only `PairingHistorySerializationTests.cs` uses
+   `new RaceSession()` directly — domain-level, unaffected. No UI tests
+   to update.
+
+### Summary
+
+**Nothing tested or production-critical is unique to the standalone path
+*except* race-type parity (Pro Ladder, Random Draw) and the
+`SessionSetupForm.ClassType`-driven population of `QualifyingTime` /
+`DialIn` / `FixedDialIn` per class type.** If multi-class setup is
+extended to cover those, the standalone path can be removed cleanly.
+
+---
+
+## QUESTION 6 — Load Saved Event
+
+### Trace
+
+`LandingPageForm.cs:65-77` opens `LoadSessionForm` as a modal. Two
+divergent paths:
+
+1. **Single-class session selected** — `LoadSessionForm.btnLoad_Click`
+   sets `LoadedSession` and returns `DialogResult.OK`
+   (`LoadSessionForm.cs:171-172`). Back in `LandingPageForm.cs:71-74`:
+   ```csharp
+   var loaded = load.LoadedSession;
+   var controller = new RaceController(loaded);
+   var mainForm = new Form1(controller);
+   mainForm.Show();
+   ```
+   Standalone Form1.
+
+2. **Multi-class event selected** —
+   `LoadSessionForm.LoadSelectedMultiClassEvent` (`LoadSessionForm.cs:182-215`):
+   ```csharp
+   var evt = _multiClassRepo.LoadEvent(selectedId);
+   var form = new MultiClassRaceForm(evt, _connectionString);
+   form.Show();
+   Close();
+   ```
+   Opens MultiClassRaceForm directly **from inside the load dialog**,
+   bypassing `LandingPageForm`'s OK branch. The parent `LandingPageForm`
+   sees the dialog close with no `DialogResult.OK` and does nothing.
+
+### Would loaded sessions still work if standalone path was removed?
+
+**Single-class loaded sessions would be orphaned.** Today they go through
+`new Form1(controller)`. If standalone Form1 is removed, single-class
+loads need to be migrated to MultiClassRaceForm with one tab.
+
+The simplest migration:
+- Wrap any loaded `RaceSession` in a `MultiClassEvent` with one
+  `ClassSession`, then open `MultiClassRaceForm`.
+- This requires no changes to the persistence schema — the existing
+  `RaceSessions` rows stay valid; you'd just route them through the
+  multi-class viewer.
+
+Caveats:
+- `MultiClassEventRepository.LoadEvent` and `SaveEvent` would need to
+  tolerate "single-class" multi-events (probably already does — loading
+  a multi-class with one class is a subset of loading any multi-class).
+- The `RaceType` on a loaded session might not be Round Robin (e.g. an
+  old Pro Ladder session). MultiClassRaceForm itself doesn't gate on
+  RaceType — it just passes the session to the embedded Form1 — so a
+  loaded Pro Ladder session would keep working, **provided** the
+  hardcode in `MultiClassSetupForm` is only for *new* multi-class
+  events, not a general restriction. Verify this stays true.
+
+### Open question for the user
+
+If the long-term goal is "everything goes through multi-class", consider
+whether `LoadSessionForm` should drop its two-tab UI and present a single
+unified list of "events" (each with 1+ classes). That's a larger UX
+change but eliminates the divergent load paths as well.

--- a/Docs/claude-context/OFFLINE-LOCAL-SERVER-SPEC.md
+++ b/Docs/claude-context/OFFLINE-LOCAL-SERVER-SPEC.md
@@ -1,0 +1,163 @@
+# RCDM — Offline Local Server ("Track Mode") — Spec & Scope
+*Status: **SHELVED 2026-06-15.** Not being built. Decision: rather than have the PC
+host an offline scoreboard, take a 4G router (Mercusys MB230-4G, already owned) to the
+venue with a data SIM — that gives real internet, so the existing stewmacrc.com live
+site works with zero new code. Track Mode only becomes worth building if venues with
+**no cellular coverage at all** turn out to be common. See
+[`TRACK-MODE-RESEARCH.md`](TRACK-MODE-RESEARCH.md) §"Why this is shelved" for the full
+reasoning (RF/range of a PC-hosted AP, and the SIM-router alternative). Do not
+implement without revisiting that decision.*
+
+---
+
+## 1. Problem Statement
+
+RC Drag Manager (the WinForms desktop app) is fully functional offline — brackets, lanes, dial-ins, classes all run locally with no internet dependency. The live scoreboard at stewmacrc.com does NOT work offline, because:
+
+- The desktop app pushes race state to RCDragLiveServer (Render) via `LiveApiClient` — **one-way, push only**. Render never sends data back to the app.
+- With no internet at the venue, the app cannot push. Render holds stale/no data.
+- Racers at the venue have phones but the venue has **no internet, no venue Wi-Fi, no mobile coverage, no hotspots**. The race director has only a PC on a desk.
+
+Result: racers cannot see who they race next, what lane, or what dial-in — they have to keep asking the race director.
+
+## 2. Solution Overview
+
+Make the race director's PC the server.
+
+1. RCDM embeds a **local HTTP server** that serves the existing mobile scoreboard website, fed **directly from the app's in-memory race state** (the same data currently shaped into `LiveRaceUpdateDto`).
+2. The PC broadcasts its **own standalone Wi-Fi network** (software access point — no internet required or involved).
+3. RCDM displays a **QR code**; racers scan it, join the PC's Wi-Fi, and their browser opens the local scoreboard at the PC's IP (e.g. `http://192.168.137.1:5000`).
+4. The scoreboard page keeps its existing ~5-second polling refresh — it just polls the local server instead of Render.
+
+Render and RCDragLiveServer are **completely out of scope**. No changes to the server repo. When the venue has internet, the normal Render push path is used exactly as today; Track Mode is the offline alternative.
+
+## 3. Hard Constraints (Non-Negotiable)
+
+| # | Constraint |
+|---|-----------|
+| C1 | **Zero-config for the race director.** One toggle/button: "Enable Track Mode". No command lines, no settings files, no network knowledge. Installer/elevated setup does ALL plumbing in advance. |
+| C2 | **Off by default, closed by default.** Installing RCDM must NOT leave any port open, hotspot enabled, or server listening. Everything starts only when the toggle is switched ON, and is torn down cleanly when toggled OFF or the app exits. |
+| C3 | **No internet dependency anywhere in the feature.** The hotspot must broadcast with no upstream connection. Assume the PC has a Wi-Fi adapter but no connectivity of any kind. |
+| C4 | **Reuse the existing mobile scoreboard UI.** Racers see the same site they'd see on stewmacrc.com. Frontend assets are bundled into the desktop app; do not redesign the page. |
+| C5 | **Reuse the existing DTO pipeline.** The local server's data endpoint must serve the same JSON shape the live site already consumes (`LiveRaceUpdateDto`), built by the existing `BuildLiveRaceUpdateDto()` path in `RaceController.LiveUpdate.cs`. One source of truth for the payload. |
+| C6 | **.NET Framework 4.8 / WinForms.** No ASP.NET Core, no Kestrel, no out-of-process services. `System.Net.HttpListener` is the expected server. |
+| C7 | **Multi-class aware.** Events run via `MultiClassRaceForm` with multiple `RaceSession` tabs. The local scoreboard must show the same class structure the Render site shows. |
+
+## 4. Architecture
+
+```
+Race Director's PC (no internet)
+│
+├─ RCDM (WinForms, .NET 4.8)
+│   ├─ Settings: [Enable Track Mode] toggle
+│   │     ON → start SoftAP → start HttpListener → show QR code
+│   │     OFF / app exit → stop listener → stop SoftAP
+│   │
+│   ├─ TrackModeServer (new, HttpListener)
+│   │     GET /                → bundled scoreboard index.html
+│   │     GET /assets/*        → bundled css/js/img
+│   │     GET /api/live        → JSON from BuildLiveRaceUpdateDto()
+│   │                            (same shape Render receives today)
+│   │
+│   └─ SoftAP manager (new)
+│         Creates standalone Wi-Fi AP (SSID e.g. "RCDM-TRACK", WPA2 PSK)
+│         Mechanism decided by Phase 0 research (see §6)
+│
+└─ Racer phones
+      Scan QR #1 (Wi-Fi join: WIFI:T:WPA;S:RCDM-TRACK;P:<pwd>;;)
+      Scan QR #2 (URL: http://<pc-ip>:5000)
+      Browser polls /api/live every ~5s — identical UX to stewmacrc.com
+```
+
+### Components
+
+**`TrackModeServer` (new)** — `Integration/TrackModeServer.cs`
+- Wraps `HttpListener`. Prefix bound to the SoftAP adapter IP on a configurable port (default 5000, stored in AppSettings).
+- Serves embedded/bundled static frontend assets + the `/api/live` JSON endpoint.
+- Thread-safe snapshot of the latest DTO: the controller's existing live-update hook also writes the serialized DTO into the TrackModeServer's current-state cache whenever race state changes. The endpoint just returns the cached JSON — no engine access from request threads.
+- Graceful start/stop; never throws to the UI thread; failures surface as a plain-English status label ("Track Mode could not start: …").
+
+**`SoftApManager` (new)** — `Integration/SoftApManager.cs`
+- Starts/stops the standalone access point. Implementation mechanism is the #1 Phase 0 research item (§6).
+- Exposes: `Start() → (ssid, passphrase, gatewayIp)`, `Stop()`, status events.
+
+**`TrackModePanel` (new UI)** — settings area
+- Toggle, status indicator (AP up / server up / N phones not required), and the two QR codes rendered large enough to scan from a phone at arm's length.
+- **"Test Track Mode" button**: runs the full capability check (adapter present, SoftAP mechanism supported, listener can bind) and reports a clear pass/fail with reasons. Directors run this at home before race day — never discover an unsupported adapter trackside.
+- QR generation via **QRCoder** (NuGet, MIT, works on net48).
+  - QR #1: Wi-Fi join string (`WIFI:T:WPA;S:<ssid>;P:<pwd>;;`) — phones auto-join without typing a password.
+  - QR #2: scoreboard URL.
+
+**Bundled frontend (new content)**
+- Copy the current scoreboard frontend (HTML/CSS/JS) from RCDragLiveServer into the desktop repo (e.g. `src/RCDragManagerProd/Assets/TrackMode/`), with its API base URL made relative (`/api/live`) so the same files work locally. Phase 0 must confirm exactly which endpoint(s) and JSON shape the page consumes so the local server mimics them 1:1.
+
+**Installer / elevated one-time setup (modified)**
+- `netsh http add urlacl url=http://+:5000/ user=Everyone` (or app-SID-scoped) so HttpListener can bind without running RCDM as admin.
+- Windows Firewall inbound allow rule for the port, scoped to Private networks.
+- Both are **plumbing only** — they do not open anything until the listener actually starts. This satisfies C1 + C2 together: elevation happens once at install; the runtime toggle needs no admin rights.
+
+## 5. Director Workflow (Acceptance Walkthrough)
+
+1. Director opens RCDM at the track. No internet, doesn't matter.
+2. Settings → flips **Enable Track Mode** ON.
+3. App brings up the Wi-Fi AP and local server automatically (< ~10s) and shows two QR codes with one line of instructions: "1. Scan to join Wi-Fi. 2. Scan to open scoreboard."
+4. Racers scan both. Scoreboard appears on their phones and refreshes live as the director enters results.
+5. End of day: toggle OFF (or just close the app) — AP and server shut down completely.
+
+## 6. Phase 0 — MANDATORY Read-Only Research Pass
+
+Per project rules: research before implementation, report findings, no code changes. CC must answer:
+
+1. **SoftAP mechanism on Windows 10/11 with NO internet — the critical unknown.**
+   - Windows "Mobile Hotspot" (Settings UI / `NetworkOperatorTetheringManager`) historically refuses to start without an active connection to share. Verify current behaviour.
+   - Legacy `netsh wlan set hostednetwork` is deprecated and unsupported by many modern Wi-Fi drivers. Check support detection (`netsh wlan show drivers` → "Hosted network supported").
+   - **Wi-Fi Direct legacy AP** (`Windows.Devices.WiFiDirect.WiFiDirectAdvertisementPublisher` with `IsAutonomousGroupOwnerEnabled` / legacy settings) creates a standalone WPA2 AP with no internet requirement. Confirm it is callable from .NET Framework 4.8 (UWP API via `Windows.winmd` reference or a small helper exe) and that phones can join it like a normal network.
+   - Recommend ONE primary mechanism + ONE fallback, with driver-support detection and a clear failure message for unsupported adapters.
+   - Note: Wi-Fi Direct/SoftAP gateways typically hand out IPs via their own DHCP (e.g. 192.168.137.x). Confirm the server can discover its own AP-side IP to embed in the QR code.
+2. **Frontend contract.** In RCDragLiveServer: identify exactly which static assets make up the public scoreboard page and exactly which endpoint(s)/JSON shape it polls. Confirm the polling interval and whether any server-side rendering or state (e.g. landing/class selection) must be replicated locally.
+3. **DTO reuse point.** In RC-Drag-Manager: confirm where `BuildLiveRaceUpdateDto()` is invoked and the cleanest hook to also feed a local cache (so Track Mode works even when `LiveUpdateEnabled`/broadcast is off). Confirm multi-class: is one DTO pushed per class/session or one combined payload?
+4. **HttpListener plumbing.** Confirm URL ACL + firewall rule approach, and whether binding to `http://+:5000/` vs the specific AP IP is preferable given the ACL is created at install time.
+5. **Captive-portal behaviour.** When phones join a Wi-Fi network with no internet, iOS/Android show "No internet — stay connected?" prompts and may pop a captive-portal sheet. Document expected phone behaviour and any mitigation (this affects racer UX, not architecture).
+
+Phase 0 output: a findings doc in `Docs/claude-context/TRACK-MODE-RESEARCH.md` + a recommendation. **Stop there. No implementation until findings are reviewed and the SoftAP mechanism is validated on Stew's PC (the only available test hardware).**
+
+**Distribution reality:** RCDM is open source and installed on arbitrary, unknown PCs. We cannot validate target hardware in advance. Therefore the SoftAP design must be **detection-first**: at runtime, probe what the machine's Wi-Fi adapter/driver actually supports, pick the best available mechanism, and fail with a plain-English explanation (including what hardware would fix it, e.g. "a USB Wi-Fi adapter that supports hosted networks") rather than a cryptic error. Stew's PC validates the implementation works *somewhere*; detection + messaging handles everywhere else.
+
+## 7. Build Phases (after Phase 0 sign-off)
+
+Each phase = one scoped CC prompt, own branch (`feature/track-mode-*`), own PR, squash-merged. Never combine phases.
+
+- **Phase 1 — `TrackModeServer`**: HttpListener, static asset serving from bundled files, `/api/live` from a stubbed cached DTO. Unit tests (MSTest 4.x, `Assert.ThrowsExactly<T>`) for routing, start/stop, and thread-safe cache swap.
+- **Phase 2 — DTO wiring**: hook the existing live-update build path to refresh the Track Mode cache on every state change, independent of the Render push flag. Multi-class supported.
+- **Phase 3 — `SoftApManager`**: implement the Phase-0-chosen mechanism with detection + fallback + plain-English errors.
+- **Phase 4 — UI + QR**: settings toggle, status panel, QRCoder integration, the two QR codes. Mockup sign-off required before implementation (project rule).
+- **Phase 5 — Installer**: URL ACL + firewall rule added to the Inno Setup script; uninstaller removes both.
+- **Phase 6 — Field test on Stew's PC**: real phones, full race simulated offline (Wi-Fi adapter only, no ethernet/internet). "Builds clean ≠ works" applies doubly here — phones-in-hand verification required before release. This is the reference validation; other users' hardware is covered by the detection + "Test Track Mode" path.
+
+## 8. Out of Scope
+
+- Any change to RCDragLiveServer / Render / stewmacrc.com.
+- Internet failover/sync logic (Render push already just no-ops offline).
+- Authentication on the local scoreboard (read-only data on an air-gapped AP; WPA2 passphrase on the AP is the boundary).
+- WebSockets/push — keep the existing 5s polling model.
+- OBS overlay / Portatree integration (separate workstream).
+
+## 9. Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| No reliable no-internet SoftAP API on a given user's Wi-Fi driver (target hardware is unknown — open-source distribution) | **High — feature-blocking per-machine** | Detection-first design: runtime capability probe, mechanism fallback chain (Wi-Fi Direct → hostednetwork), "Test Track Mode" pre-flight button, plain-English unsupported-adapter message with hardware suggestion. Implementation validated on Stew's PC. |
+| Phones drop the AP because "no internet" | Medium | Document the "stay connected" prompt in racer instructions; test iOS + Android in Phase 6. |
+| HttpListener bind fails without ACL (silent dev-vs-installed difference) | Medium | Installer creates ACL; server start performs a self-check and reports plainly. |
+| Frontend assets drift from RCDragLiveServer over time | Low | Note in release runbook: when scoreboard frontend changes server-side, re-copy bundled assets. |
+
+## 10. Acceptance Criteria
+
+1. Fresh install: no open ports, no AP, no listener until toggle is used (verify with `netstat` and Wi-Fi scan).
+2. With ALL networking disabled except the Wi-Fi adapter (no ethernet, no internet): toggle ON → AP broadcasts, phone joins via QR #1, scoreboard opens via QR #2, data matches the app's current bracket state.
+3. Director enters a result → phone scoreboard reflects it within one poll cycle (≤ ~5s).
+4. Multi-class event shows all classes correctly.
+5. Toggle OFF / app close → AP gone, port closed.
+6. Entire flow achievable by a non-technical director with zero configuration beyond the toggle.
+7. On a machine whose adapter supports no SoftAP mechanism, "Test Track Mode" and the toggle both fail gracefully with a plain-English message — no crash, no half-started state.
+8. Criteria 1–5 verified end-to-end on Stew's PC with real phones (iOS and Android if available) — the reference test bench for this feature.

--- a/Docs/claude-context/TIME-FIELDS-RESEARCH.md
+++ b/Docs/claude-context/TIME-FIELDS-RESEARCH.md
@@ -1,0 +1,273 @@
+# Time Fields Research — Set Time, QualifyingTime, DialIn
+
+Read-only investigation of how `Set Time`, `QualifyingTime`, and `DialIn`
+flow through the desktop app. No code changes made.
+
+---
+
+## 1. What does the "Set Time" button do?
+
+**Control:** `btnSetQualTime` — `Form1.Designer.cs:30,76,253-262`. Text =
+`"Set Time"`. Sits on the driver-setup panel of `Form1`.
+
+**Click handler:** `Form1.Events.cs:174-194` — `btnSetQualTime_Click`.
+
+```csharp
+if (lvDrivers.SelectedItems.Count > 0) {
+    string selectedName = lvDrivers.SelectedItems[0].Text;
+    var driver = drivers.FirstOrDefault(d => d.Name == selectedName);
+    if (driver != null) {
+        var qualDialog = new AddEditQualTimeDialog(driver.Name, driver.QualTime);
+        if (qualDialog.ShowDialog() == DialogResult.OK) {
+            driver.QualTime = qualDialog.QualifyingTime;
+            UpdateDriverList();
+        }
+    }
+}
+```
+
+Steps:
+1. Reads selected driver from `lvDrivers` (the driver-roster ListView).
+2. Looks the driver up in Form1's local `drivers` `List<Driver>`.
+3. Opens `AddEditQualTimeDialog` — a small modal with one `NumericUpDown`
+   (`UI/Forms/Drivers/AddEditQualTimeDialog.cs`).
+4. On OK: writes the new value back to the **local `Driver` object's
+   `QualTime`** property.
+5. Calls `UpdateDriverList()` to refresh the ListView.
+
+**Observations:**
+- The handler **does not** call the `RaceController`, **does not** touch
+  `_session.DriverEntries.QualifyingTime` directly, and **does not** push a
+  live update.
+- The change persists only because the save path
+  (`RaceController.Persistence.cs:79-89`) rebuilds `DriverEntries` from
+  `_drivers` (which references the same `Driver` objects) at save time:
+  ```csharp
+  _session.DriverEntries.Add(new RaceSessionDriverEntry {
+      DriverID = d.Id, DriverName = d.Name, QualifyingTime = d.QualTime
+  });
+  ```
+- **The button has no `Enabled` gate.** It stays clickable throughout the
+  entire session — before, during, and after `GenerateBracket()`. By
+  contrast, `btnGenerateBracket` is gated by
+  `_controller.HasBracketStarted` (`Form1.UI.cs:38`).
+- `MultiClassRaceForm` does not have its own Set Time button — each tab
+  hosts a `Form1` instance (`MultiClassRaceForm.cs:96-104`), so the button
+  appears on every class tab.
+
+---
+
+## 2. Where is `QualifyingTime` stored and displayed?
+
+### Storage (three layers)
+
+| Layer | Field | File:line |
+|---|---|---|
+| Domain (in-memory driver) | `Driver.QualTime` (double?) | `Domain/Drivers.cs:40` |
+| Domain (session entry) | `RaceSessionDriverEntry.QualifyingTime` (double?) | `Domain/RaceSession.cs:72` |
+| Database | `Drivers.QualTime` (REAL) | `Repositories/DatabaseInitializer.cs:23` |
+
+### Set into `DriverEntries`
+
+`SessionSetupForm.Events.cs:219-243` — only populated when
+`classType == "Heads Up"`:
+```csharp
+if (classType == "Heads Up")  qualTime = er.driver.QualTime;
+else if (classType == "Dial-In") dialIn = er.car.DefaultDialIn;
+else if (classType == "Bracket Class") dialIn = fixedDial;
+```
+For Dial-In and Bracket Class, `QualifyingTime` stays `null`.
+
+### Hydrated into Form1's `drivers` list when an existing session loads
+
+`Form1.cs:60-67`:
+```csharp
+drivers = currentSession.DriverEntries
+    .Select(e => new Driver { Id = e.DriverID, Name = e.DriverName, QualTime = e.QualifyingTime })
+    .ToList();
+```
+
+### Persisted back
+
+`RaceController.Persistence.cs:86` — at save time, `DriverEntries` are
+rebuilt with `QualifyingTime = d.QualTime`.
+
+### Displayed
+
+- **`lvDrivers`** (driver-roster ListView on Form1) — `Form1.UI.cs:31`,
+  formatted as `"0.000"` or `"—"`. **This is on the setup panel, not during
+  a race.** It is also the order key for the list (`Form1.UI.cs:22-25`).
+- **`DriverManagerForm`** — `DriverManagerForm.UI.cs:80` shows `"Qual Time"`
+  in the driver detail pane.
+- **Not shown** in the race console (`lvPairings`, `lvWinners`, the winner
+  buttons), or in the live scoreboard payload, or in `MultiClassRaceForm`
+  outside of the embedded Form1's `lvDrivers`.
+
+### Database update path
+
+`DriverRepository.UpdateQualifyingTime(int driverId, double qualTime)` —
+`Repositories/DriverRepository.cs:413-426`. Called from
+`DriverManagerForm.Events.cs:287` (the standalone Driver Manager screen),
+not from Form1's `btnSetQualTime`.
+
+---
+
+## 3. Where is `DialIn` stored? Is it displayed during a race?
+
+### Storage
+
+| Layer | Field | File:line |
+|---|---|---|
+| Domain (session entry) | `RaceSessionDriverEntry.DialIn` (double?) | `Domain/RaceSession.cs:71` |
+| Domain (session-level) | `RaceSession.FixedDialIn` (double?) | `Domain/RaceSession.cs:18` |
+| Domain (per-car) | `Car.DefaultDialIn` (double?) | `Domain/Car.cs:20` |
+
+There is **no `DialIn` column on the `Drivers` DB table** — DialIn lives on
+`Cars` (`DefaultDialIn`) and on the session entry (per-event copy).
+
+### Set into `DriverEntries`
+
+`SessionSetupForm.Events.cs:226-238` — populated for `Dial-In` class (from
+`er.car.DefaultDialIn`) or `Bracket Class` (from session-level
+`fixedDial`).
+
+### Yes, displayed during a race
+
+**On the winner buttons** (`btnWinner1` / `btnWinner2`):
+`Form1.Display.cs:151-155` (in `OnNextMatchReady`):
+```csharp
+double? leftDialIn  = leftDriverId  > 0 ? _controller.GetDriverDialIn(leftDriverId)  : null;
+double? rightDialIn = rightDriverId > 0 ? _controller.GetDriverDialIn(rightDriverId) : null;
+btnWinner1.Text = currentLeft  + FormatDialIn(leftDialIn);
+btnWinner2.Text = currentRight + FormatDialIn(rightDialIn);
+```
+`FormatDialIn` (`Form1.Display.cs:264-268`) appends `" [4.123]"` to the
+button text.
+
+**On the live scoreboard** — `LiveMatchDto.LeftDriverDialIn` /
+`RightDriverDialIn` (`Integration/LiveRaceUpdateDto.cs:28-29`), populated
+in `RaceController.LiveUpdate.cs:89-90`.
+
+It is **not** displayed in `lvDrivers`, `lvPairings`, or `lvWinners` (no
+column for it).
+
+---
+
+## 4. Existing UI for editing time fields after `GenerateBracket()`?
+
+### `QualifyingTime` — yes, but only via the Set Time button
+
+- `btnSetQualTime` has no `Enabled` gate (point 1 above), so it remains
+  clickable post-bracket.
+- Editing affects the same `Driver` reference held by the engine (drivers
+  are passed by reference into `_controller.GenerateBracket(...)`).
+- However, **engines that use `QualTime` for seeding only read it at
+  bracket-generation time** (see point 5). A post-bracket QualTime edit
+  will NOT reseed the existing bracket. It will only show up if a new
+  bracket is generated, or via the save path.
+- There is **no edit-from-bracket** UI for QualifyingTime — the user has
+  to go back to the driver list, select the driver, and click Set Time.
+
+### `DialIn` — yes, two paths
+
+1. **Right-click on a winner button during a race** —
+   `Form1.cs:46-47` registers `MouseUp` → `ShowEditDialInForButton(isLeft)`
+   (`Form1.Events.cs:469-478`). That opens a small dialog
+   (`ShowEditDialInDialog`, lines 480-561) and on OK calls
+   `_controller.UpdateDriverDialIn(driverId, newDialIn)`. This path **does
+   write to `_session.DriverEntries.DialIn`** (controller-mediated, with
+   lock — `RaceController.DialIn.cs:30-41`) and queues a live update.
+2. **Driver self-update from the live scoreboard** — POST `/api/dialin`
+   with optional PIN (ENH-02 / #165). The desktop polls back via
+   `LiveApiClient.GetDialInUpdatesAsync` and `PollAndApplyAsync` applies
+   the changes to `_session.DriverEntries`.
+
+Dial-in edits are **locked** when `Generate Next Round` is clicked —
+`Form1.Events.cs:258` calls `_controller.LockDialIn()`. The lock is honoured
+by both the right-click edit path and the polling path.
+
+There is **no equivalent post-bracket QualifyingTime edit path** — Set
+Time always edits the local driver-list copy, never the controller.
+
+---
+
+## 5. How is `QualifyingTime` used in bracket generation?
+
+### Seeding only — Pro Ladder / `MatchEngine`
+
+`RaceEngines/MatchEngine.cs:21-22,36`:
+```csharp
+.OrderBy(d => d.QualTime.HasValue ? 0 : 1)
+.ThenBy(d => d.QualTime ?? double.MaxValue)
+...
+int timed = allDrivers.Count(d => d.QualTime.HasValue);
+```
+Lower QualTime → better seed; drivers without a time fall to the back.
+
+### Other engines do not use QualifyingTime
+
+- `RoundRobinEngine` — does not reference `QualTime`.
+- `LosersBracketBuilder` / `RandomBracket` — do not reference `QualTime`
+  (Random is purely random with lane-fairness; LB uses RR pairing
+  history).
+
+### Display ordering
+
+- `Form1.UI.cs:22-25` orders `lvDrivers` by QualTime ascending. Display
+  only.
+
+### Summary
+
+QualifyingTime is **read once at bracket generation** (Pro Ladder) for
+seeding, and **continuously for display** in the driver list. It does not
+affect Round Robin or Random Bracket modes at all.
+
+---
+
+## 6. How is `DialIn` used?
+
+### Not passed to any race engine
+
+A grep of `RaceEngines/`, `RoundRobinMode/`, `RandomMode/`, and the
+brackets shows **no `DialIn` references** in any engine. DialIn is purely
+metadata — it does not affect pairings, seeding, BYE assignment, or
+results in this codebase. (Real-world NHRA dial-in racing applies dial-ins
+at the track via handicap start timing, which is outside the app's
+scope.)
+
+### Stored, displayed, synced
+
+| Use | Where |
+|---|---|
+| Stored on session entry | `RaceSession.DriverEntries[i].DialIn` |
+| Displayed on winner buttons during race | `Form1.Display.cs:154-155` (via `FormatDialIn`) |
+| Displayed on live scoreboard | `LiveMatchDto.LeftDriverDialIn` / `RightDriverDialIn` |
+| Displayed on live scoreboard match cards | `RCDragLiveServer/Controllers/PublicLiveController.cs` (DialInBadge) |
+| Updated from RD (right-click) | `Form1.Events.cs:469-561` → `RaceController.UpdateDriverDialIn` |
+| Updated from driver (live form) | `RCDragLiveServer/Controllers/DriverDialInController.cs` → polled back |
+| Locked after `Next Round` | `RaceController.DialIn.cs:43-46` (`LockDialIn`) |
+
+---
+
+## Cross-cutting observations (not code changes — just things noticed)
+
+1. **`btnSetQualTime` updates Form1's local `drivers` list, not the
+   controller.** The change only flows into `_session.DriverEntries`
+   through the save path. Since engines hold the same `Driver` references
+   by reference (not by copy), live edits do mutate engine driver objects
+   — but no engine re-seeds on a QualTime change post-generation.
+
+2. **Asymmetry with DialIn.** DialIn has a controller-mediated update path
+   (`UpdateDriverDialIn`), a lock, and live broadcast. QualifyingTime has
+   none of these.
+
+3. **No way to edit QualifyingTime "in the moment" during a race** — only
+   via the setup-panel button against the `lvDrivers` selection. No
+   right-click on a winner button, no in-bracket editor. This is
+   asymmetric with DialIn's right-click affordance.
+
+4. **DialIn is class-conditional at session creation** but is shown on
+   every class's winner buttons regardless of class type. For Heads Up
+   (which uses QualTime, not DialIn), the button text simply has no
+   bracketed dial-in suffix because `DialIn` is `null` and `FormatDialIn`
+   returns empty string.

--- a/Docs/claude-context/TRACK-MODE-RESEARCH.md
+++ b/Docs/claude-context/TRACK-MODE-RESEARCH.md
@@ -1,0 +1,251 @@
+# Track Mode — Phase 0 Research Findings
+
+*Status: **SHELVED 2026-06-15** — Phase 0 done, build not started and not planned.
+Spec: [`OFFLINE-LOCAL-SERVER-SPEC.md`](OFFLINE-LOCAL-SERVER-SPEC.md).*
+
+## Why this is shelved
+
+The original concept had the race director's **PC** broadcast the Wi-Fi and host the
+scoreboard. Two problems killed that form of it:
+
+1. **RF reality.** A laptop's internal Wi-Fi (and on the reference PC, only Wi-Fi
+   Direct — Soft AP/hosted network is unsupported) is a weak, short-range radio.
+   Across a track's pits and parking, racers walking to their cars drop out of range,
+   and phones abandon a no-internet network rather than rejoining it cleanly. The
+   coverage would be small and flaky.
+2. **The simpler fix wins.** Stew already owns a **Mercusys MB230-4G** 4G LTE router.
+   With a data SIM it provides real internet at the venue, so the **existing**
+   stewmacrc.com live site works with **zero new code**. A real router also broadcasts
+   a far stronger, more stable network than any laptop. So the practical answer to
+   "no internet at the venue" is "bring internet" (SIM in the router), not "build an
+   offline server."
+
+**Track Mode (PC-hosted offline scoreboard) is only worth revisiting if venues with
+no cellular coverage at all prove common.** If that happens, the same router with no
+SIM still works as a strong standalone AP — PC plugs into a LAN port by Ethernet and
+serves the page — which removes the riskiest part of the build below (the whole
+SoftAP / Wi-Fi Direct research item in §1 becomes moot). The findings below are kept
+for that scenario.
+
+---
+
+*Original Phase 0 findings (read-only research, no implementation done):*
+
+*Researched: 2026-06-15. Reference hardware: Stew's PC (the only validation bench).*
+
+---
+
+## TL;DR — the two findings that change the plan
+
+1. **SoftAP is dead on the reference PC; Wi-Fi Direct is the only path.** The Intel
+   Wi-Fi 6 AX201 reports **`Hosted network supported: No`** and **`Soft AP: Not
+   supported`**, but **`Wi-Fi Direct GO: Supported`** (up to 8 clients, 5 GHz GO
+   OK). So the `netsh wlan set hostednetwork` fallback in the spec is *not a
+   fallback on this machine* — it cannot run at all. The design must be
+   **Wi-Fi Direct (legacy GO) first**, and the only meaningful "fallback" is the
+   modern Mobile Hotspot API, not hostednetwork. Detection-first messaging matters
+   even more than the spec assumed.
+
+2. **The live scoreboard is NOT a static site that polls `/api/live`.** It is
+   **server-rendered HTML built as C# strings** inside `PublicLiveController` on the
+   .NET 8 server, and the phone page **does a full `location.reload()` every 5s** —
+   it never consumes `/api/live` as JSON. Spec constraints **C4 ("reuse the existing
+   mobile scoreboard UI… bundle the frontend assets")** and **C5 ("serve the same
+   JSON shape `/api/live`")** are based on an assumption that does not hold. There
+   are no frontend asset files to bundle, and `/api/live` is not what renders the
+   page. This needs a decision before Phase 1 (see §2).
+
+Everything else (DTO hook, HttpListener plumbing, captive portal) is as the spec
+expected and is low-risk.
+
+---
+
+## 1. SoftAP mechanism — the critical unknown
+
+### Reference PC capability probe (actual output)
+
+`netsh wlan show drivers`:
+- `Hosted network supported  : No`
+
+`netsh wlan show wirelesscapabilities`:
+- `Soft AP                  : Not supported`
+- `Wi-Fi Direct Device      : Supported`
+- `Wi-Fi Direct GO          : Supported`
+- `P2P GO on 5 GHz          : Supported`
+- `P2P Max Mobile AP Clients: 8`
+- Adapter: Intel(R) Wi-Fi 6 AX201 160MHz, driver 24.20.0.4
+
+**Conclusion:** the only standalone-AP mechanism this adapter exposes is **Wi-Fi
+Direct acting as Group Owner**. 8 simultaneous clients is enough for a club race.
+
+### Mechanism ranking (revised from the spec)
+
+| Rank | Mechanism | Verdict on this PC | Notes |
+|------|-----------|--------------------|-------|
+| 1 | **Wi-Fi Direct legacy GO** via `WiFiDirectAdvertisementPublisher` + `WiFiDirectLegacySettings` | **Only viable option** | `WiFiDirectLegacySettings` lets the GO advertise a normal SSID + WPA2 passphrase so non-Wi-Fi-Direct phones join it "like a normal network". No internet required. Hands out DHCP on its own subnet (typically 192.168.137.x). |
+| 2 | Mobile Hotspot (`NetworkOperatorTetheringManager`) | Untested; historically refuses with no upstream connection | Keep as a *detection-time* alternative only. Do **not** assume it works offline. |
+| 3 | `netsh wlan set hostednetwork` | **Impossible here** (`Hosted network supported: No`) | Drop as the primary fallback the spec named. Only relevant on older adapters that still expose it. |
+
+### Calling Wi-Fi Direct from .NET Framework 4.8
+
+Feasible but needs interop plumbing — these are WinRT APIs, not classic Win32:
+- Reference `Windows.winmd` (the union contract) **and** `System.Runtime.WindowsRuntime`
+  so the project can consume `Windows.Devices.WiFiDirect.*` and await `IAsyncOperation`s.
+- The relevant types are `WiFiDirectAdvertisementPublisher`,
+  `.Advertisement.IsAutonomousGroupOwnerEnabled = true`, and
+  `.Advertisement.LegacySettings` (`WiFiDirectLegacySettings` → `IsEnabled`, `Ssid`,
+  `Passphrase`).
+- Recommend isolating all WinRT calls behind the planned `SoftApManager` so the rest
+  of the .NET 4.8 app never touches `winmd` types directly. If interop in-process
+  proves fragile, the spec's "small helper exe" option (a tiny UWP/console host that
+  the app launches) is the fallback — decide during Phase 3, not now.
+
+### Self-IP discovery for the QR code
+
+Wi-Fi Direct GO brings up its own virtual adapter ("Microsoft Wi-Fi Direct Virtual
+Adapter") with a gateway IP it assigns (commonly `192.168.137.1`). The server must
+read **that adapter's** IPv4 address at runtime (enumerate `NetworkInterface`s, match
+the Wi-Fi Direct virtual adapter) rather than assuming `192.168.137.1`. Embed that IP
+in QR #2.
+
+### ⚠️ iOS risk (unchanged, now the top field risk)
+
+Apple devices **cannot create** a Wi-Fi Direct group and have historically been
+finicky joining one. The mitigation — and the reason `WiFiDirectLegacySettings`
+matters — is that legacy mode makes the GO present as an ordinary WPA2 AP, which iOS
+*can* join like any infrastructure AP. **This must be validated with a real iPhone in
+Phase 6 before release.** If iOS cannot join reliably, Track Mode is Android-only on
+this hardware, which is a product decision for Stew.
+
+---
+
+## 2. Frontend contract — the big surprise
+
+**The public scoreboard has no static assets.** The entire page is generated as C#
+string concatenation in
+`RCDragLiveServer/src/RCDragLiveServer/Controllers/PublicLiveController.cs`:
+
+- `GET /` → `BuildLandingPage()` — full HTML doc, lists active events.
+- `GET /event/{eventId}` → `BuildHomePage()` → `BuildClassPanel()` +
+  `BuildDialInForm()` — full HTML doc with **inline `<style>` and inline `<script>`**.
+- `GET /api/live` → returns `List<LiveRaceState>` JSON — **exists, but the phone page
+  does not poll it.**
+
+The refresh model is **whole-page reload**: the inline script calls
+`location.reload()` every 5 seconds (the bracket cycles tabs client-side between
+reloads). All the presentation logic — round sorting/relabelling (`RR1`→"Round 1",
+`LB-R1`→"Buyback Round 1"), dial-in merge, winner/loser styling, multi-class tabs,
+the dial-in submission form — lives **server-side in .NET 8**.
+
+### Why this breaks C4/C5
+
+- **C4 ("bundle the existing frontend assets, don't redesign")** — there are no asset
+  files to bundle. The "frontend" is ~700 lines of C# in a .NET 8 controller.
+- **C5 ("serve the same JSON shape `/api/live`")** — serving `/api/live` would *not*
+  reproduce the page, because the page isn't built from `/api/live`.
+
+### Options (decision needed before Phase 1)
+
+| Option | What Track Mode's HttpListener serves | Pros | Cons |
+|--------|---------------------------------------|------|------|
+| **A. Port the renderer** | Re-implement `BuildHomePage`/`BuildClassPanel`/etc. in the WinForms app, fed from the local DTO cache; same whole-page-reload model | Pixel-identical to stewmacrc.com; reuses proven markup | Copies ~700 lines of C# into the desktop repo; two copies drift over time (spec risk "frontend assets drift" — now worse) |
+| **B. New static SPA** | One bundled `index.html` + JS that polls `/api/live` and renders client-side (the spec's original mental model) | One source of truth the local server serves; matches C5; no server-side HTML in WinForms | Net-new frontend; diverges from the Render page unless the server is *also* migrated to serve it; more work |
+| **C. Migrate server first** | Convert `RCDragLiveServer` to the static+`/api/live` model, then both repos share the same static bundle | Cleanest end state; true single source | Largest scope; touches the "out of scope" server repo; not a Phase-0-sized change |
+
+**Recommendation for review:** Option **A** for the first shippable Track Mode (least
+risk, identical UX, no server-repo changes — honours "Render is out of scope"), with a
+note in the release runbook that the rendering code is now duplicated and must be kept
+in sync. Revisit Option C as a later unification if Track Mode proves valuable. **Stew
+to decide** — this is the one open product/architecture question from Phase 0.
+
+### Dial-in submission offline
+
+The page includes a dial-in form posting to `POST /api/dialin`, backed on the server
+by `IDialInStore` + rate limiter + lock state. If racers should be able to set
+dial-ins from their phones in Track Mode, the local server must replicate that store
+and the lock semantics. **Suggest deferring dial-in submission for v1 of Track Mode**
+(read-only scoreboard) and revisit — it keeps Phase 1–4 much smaller and matches the
+spec's "read-only data on the local AP" framing in §8. Flag for Stew.
+
+---
+
+## 3. DTO reuse point — confirmed, clean
+
+- `BuildLiveRaceUpdateDto()` lives in
+  [`RaceController.LiveUpdate.cs:18`](../../src/RCDragManagerProd/Controllers/RaceController.LiveUpdate.cs)
+  and is private to the controller.
+- The single broadcast choke point is **`QueueLiveUpdate(reason)`** (same file,
+  line 173): it early-returns when `AppSettings.LiveBroadcastEnabled` is false, else
+  builds the DTO and calls `_liveApiClient.SendAsync(dto)`.
+- **Cleanest hook:** in `QueueLiveUpdate`, after `BuildLiveRaceUpdateDto()` returns a
+  valid DTO, also write the serialized DTO into a Track Mode cache — **before** the
+  `LiveBroadcastEnabled` gate so Track Mode works even when Render push is off. (The
+  gate currently returns early at the top; the Track Mode write must be reordered to
+  sit ahead of it, or live in `BroadcastLiveSnapshot`, which is already the
+  "make this class visible" entry point and calls both `QueueLiveUpdate` and
+  `BroadcastInitialState`.)
+- **Multi-class:** one DTO is built **per class/session** (one `RaceController` per
+  tab). The server buckets by event then by `classType` and `/api/live` returns
+  `GetAll().Values.ToList()` — a flat list of per-class states. So the Track Mode
+  cache must be **keyed by classType and the `/api/live` equivalent must return the
+  list of all current class DTOs**, not a single one. `BroadcastInitialState` shows
+  the pattern for emitting a roster-only DTO so a class appears before its bracket
+  exists — Track Mode should cache those too.
+
+No engine access from request threads is needed: the cache holds pre-serialized JSON,
+refreshed on the controller thread during `QueueLiveUpdate`. Matches spec C6/§4.
+
+## 4. HttpListener plumbing — as expected
+
+- `System.Net.HttpListener` on net48 is the right call (spec C6). No port setting
+  exists yet in `AppSettings`; add one (default 5000) when Phase 1 lands.
+- Binding: prefer the **specific Wi-Fi Direct adapter IP** (`http://<go-ip>:5000/`)
+  over `http://+:5000/` so the listener is only reachable on the AP subnet, not on any
+  other network the PC might later join. But a specific-IP URL ACL can't be created at
+  install time (the IP isn't known until the GO starts). Practical resolution:
+  - Install-time: `netsh http add urlacl url=http://+:5000/ user="…"` (wildcard, so no
+    admin needed at runtime), **plus** a Windows Firewall inbound allow rule scoped to
+    **Private** networks only.
+  - Runtime: bind the listener to the wildcard prefix but the firewall + the fact that
+    only the AP subnet can route to the PC provides the boundary. Revisit if a tighter
+    bind is wanted.
+- Server start must self-check the bind and surface a plain-English status, never throw
+  to the UI thread (spec §4).
+
+## 5. Captive-portal behaviour — document, don't fight
+
+When a phone joins a Wi-Fi network with no internet:
+- **iOS** shows "No Internet Connection" and may pop a captive-portal sheet; the user
+  taps to confirm staying connected. Once dismissed, Safari to `http://<go-ip>:5000`
+  works.
+- **Android** shows "Internet may not be available / stay connected?" — tap keep.
+
+This is a **racer-instruction / UX** matter, not architecture. Put a one-line note on
+the QR screen ("Phone says no internet? Tap 'Keep / Stay connected'.") and verify both
+platforms in Phase 6. No captive-portal server needed for v1.
+
+---
+
+## Recommended decisions to unblock the build phases
+
+1. **SoftAP:** commit to **Wi-Fi Direct legacy GO** as the primary (and on this
+   hardware, only) mechanism. Treat Mobile Hotspot as a detection-time alternative;
+   drop hostednetwork as a named fallback. Keep the "Test Track Mode" pre-flight.
+2. **Frontend:** choose **Option A (port the renderer into the WinForms app)** for
+   Track Mode v1 unless Stew wants to invest in unification (Option C). This is the
+   one decision that blocks Phase 1.
+3. **Dial-in:** ship Track Mode v1 **read-only** (no phone dial-in submission); revisit.
+4. **iOS:** accept it as the top field risk; gate release on a real-iPhone test in
+   Phase 6.
+
+Once 1–3 are signed off, Phases 1–6 in the spec can proceed in order. Nothing in Phase
+0 contradicts the phase *sequencing* — only the frontend-bundling assumption and the
+SoftAP mechanism ranking.
+
+## Sources
+
+- [About the Wi-Fi Direct API — Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/nativewifi/about-the-wi-fi-direct-api)
+- [Wi-Fi Direct sample — Microsoft Learn](https://learn.microsoft.com/en-us/samples/microsoft/windows-universal-samples/wifidirect/)
+- [Windows.Devices.WiFiDirect WinRT API reference](https://github.com/MicrosoftDocs/winrt-api/blob/docs//windows.devices.wifidirect/windows_devices_wifidirect.md)
+- [Wi-Fi Direct / hotspot on iOS, Android, WP — 7labs](https://7labs.io/mobile/wi-fi-direct-hotspot-ios-android-windows-phone.html)
+- [iOS and Wi-Fi Direct — Apple Developer Forums](https://developer.apple.com/forums/thread/12885)

--- a/Docs/rcdm-recon-2026-05-27.md
+++ b/Docs/rcdm-recon-2026-05-27.md
@@ -1,0 +1,219 @@
+# RC Drag Manager Architectural Recon (2026-05-27)
+
+## 1. Solution structure
+- `src/RCDragManagerProd/RCDragManagerProd.csproj`
+  Project name: `RCDragManagerProd`
+  Target framework: `.NET Framework v4.8` (`<TargetFrameworkVersion>v4.8</TargetFrameworkVersion>`)
+  Project type: `WinForms` (`<OutputType>WinExe</OutputType>`, `System.Windows.Forms` reference)
+  Purpose: Main desktop application for race session setup, bracket flow, result entry, persistence, and live update publishing.
+- `src/RCDragManagerProd.Tests/RCDragManagerProd.Tests.csproj`
+  Project name: `RCDragManagerProd.Tests`
+  Target framework: `net48`
+  Project type: `Test` (MSTest)
+  Purpose: Unit/regression tests for race engines, controller flows, repositories, and bracket logic.
+- `src/RCDragManager.CodeStats/RCDragManager.CodeStats.csproj`
+  Project name: `RCDragManager.CodeStats`
+  Target framework: `net8.0`
+  Project type: `Console/Exe` (`<OutputType>Exe</OutputType>`)
+  Purpose: Auxiliary code-analysis/statistics utility project.
+
+## 2. Top-level folder map
+```text
+src/
+├─ ProjectAnalysis/
+├─ RCDragManager.CodeStats/
+│  ├─ Models/
+│  ├─ Modules/
+│  └─ ProjectAnalysis/
+├─ RCDragManagerProd/
+│  ├─ Assets/
+│  ├─ Config/
+│  ├─ Controllers/
+│  ├─ Domain/
+│  │  └─ Ladders/
+│  ├─ Helpers/
+│  ├─ Integration/
+│  ├─ Logging/
+│  ├─ RaceEngines/
+│  ├─ RandomMode/
+│  ├─ Repositories/
+│  ├─ RoundRobinMode/
+│  │  └─ RoundRobinScorecardLogger/
+│  ├─ UI/
+│  │  └─ Forms/
+│  ├─ Utils/
+│  └─ ViewModels/
+└─ RCDragManagerProd.Tests/
+   └─ Helpers/
+```
+- `src/ProjectAnalysis/`: Appears to hold analysis artifacts.
+- `src/RCDragManager.CodeStats/`: Code statistics utility (`Program`, model and module folders).
+- `src/RCDragManagerProd/Assets`: Application icons/images.
+- `src/RCDragManagerProd/Config`: Runtime app settings load/save (`AppSettings`).
+- `src/RCDragManagerProd/Controllers`: `RaceController` partials for round flow, results, persistence, stats, live updates.
+- `src/RCDragManagerProd/Domain`: Core domain objects (`Driver`, `Car`, `RaceSession`, ladder structures).
+- `src/RCDragManagerProd/Domain/Ladders`: Pro ladder shape definitions for ladder sizes.
+- `src/RCDragManagerProd/Helpers`: Utility helpers (asset paths, match lookup).
+- `src/RCDragManagerProd/Integration`: HTTP live update client and DTOs.
+- `src/RCDragManagerProd/Logging`: File logger.
+- `src/RCDragManagerProd/RaceEngines`: Engine interface/adapters/factory.
+- `src/RCDragManagerProd/RandomMode`: Random bracket + losers bracket logic.
+- `src/RCDragManagerProd/Repositories`: SQLite repositories + schema initializer.
+- `src/RCDragManagerProd/RoundRobinMode`: Round-robin engine, ranking, scorecard logging.
+- `src/RCDragManagerProd/UI/Forms`: WinForms UI for session setup, race operation, results, settings.
+- `src/RCDragManagerProd/Utils`: Small extension helpers.
+- `src/RCDragManagerProd/ViewModels`: UI-facing row/summary models.
+- `src/RCDragManagerProd.Tests/Helpers`: Test support classes.
+
+## 3. Data model
+- `Driver` — `src/RCDragManagerProd/Domain/Drivers.cs`
+  Public properties: `int Id`, `string Name`, `double? QualTime`, `string Notes`, `int TotalWins`, `int TotalLosses`, `int EventsEntered`, `int EventsWon`, `int? Seed`, `string State`, `List<Car> Cars`.
+- `Car` — `src/RCDragManagerProd/Domain/Car.cs`
+  Public properties: `int Id`, `int CarID`, `int DriverId`, `string CarName`, `string ClassType`, `double? DefaultDialIn`.
+- `MultiClassEvent` — `src/RCDragManagerProd/Domain/MultiClassEvent.cs`
+  Public properties: `int Id`, `string EventName`, `DateTime EventDate`, `List<RaceSession> ClassSessions`.
+- `RaceSession` — `src/RCDragManagerProd/Domain/RaceSession.cs`
+  Public properties: `int Id`, `Guid EventId`, `string EventName`, `DateTime EventDate`, `string RaceType`, `string ClassType`, `double? FixedDialIn`, `string RoundRobinVariant`, `int? RoundsToRun`, `List<RaceSessionDriverEntry> DriverEntries`, `List<int[]> PairingHistoryRaw`, `HashSet<(int, int)> PairingHistory`, `List<MatchResultSave> SavedResults`, `List<string> SavedRevealedRounds`, `List<RoundRobinMatch> RoundRobinMatches`, `List<RandomMatch> Matches`, `List<Driver> BuybackDrivers`, `List<Driver> TopDriversSnapshot`, `List<Driver> Drivers`.
+- `RaceSessionDriverEntry` — `src/RCDragManagerProd/Domain/RaceSession.cs`
+  Public properties: `int DriverID`, `string DriverName`, `int CarID`, `string CarName`, `string ClassType`, `double? DialIn`, `double? QualifyingTime`, `int? Seed`.
+- `MatchResultSave` (domain) — `src/RCDragManagerProd/Domain/RaceSession.cs`
+  Public properties: `int MatchId`, `int WinnerDriverId`, `int LoserDriverId`.
+- `ProLadder.LadderMatch` — `src/RCDragManagerProd/Domain/ProLadder.Structures.cs`
+  Public properties: `int MatchId`, `int? Seed1`, `int? Seed2`, `int? FromMatch1`, `int? FromMatch2`, `string RoundLabel`.
+- `MatchResult` — `src/RCDragManagerProd/Domain/MatchResult.cs`
+  Public properties: None (public behavior class wrapping an internal results dictionary).
+- `RandomMatch` — `src/RCDragManagerProd/RandomMode/RandomMatch.cs`
+  Public properties: `int MatchId`, `Driver Seed1`, `Driver Seed2`, `int? FromMatch1`, `int? FromMatch2`, `string RoundLabel`.
+- `RoundRobinMatch` — `src/RCDragManagerProd/RoundRobinMode/RoundRobinMatch.cs`
+  Public properties: `int MatchId`, `Driver Driver1`, `Driver Driver2`, `string RoundLabel`.
+- `EngineMatch` — `src/RCDragManagerProd/RaceEngines/IRaceEngine.cs`
+  Public properties: `int MatchId`, `Driver Driver1`, `Driver Driver2`, `string RoundLabel`, `int? FromMatch1`, `int? FromMatch2`, `bool HasResult`.
+- `DriverRankResult` — `src/RCDragManagerProd/RoundRobinMode/RoundRobinRanker.cs`
+  Public properties: `int DriverId`, `int Rank`, `double Points`, `int Wins`, `int Losses`, `int[] DefeatedIds`, `double OpponentStrength`.
+
+## 4. Persistence layer
+- Storage mechanism: `SQLite` via raw `System.Data.SQLite` ADO.NET repositories (`DriverRepository`, `CarRepository`, `RaceSessionRepository`, `MultiClassEventRepository`) in `src/RCDragManagerProd/Repositories/`.
+- Database path pattern: `%APPDATA%\RC_Drag_Manager\race_data.db` set in `src/RCDragManagerProd/Program.cs` (`ConnectionString = Data Source={dbPath};Version=3;`).
+- Connection string behavior: repository constructors accept either full connection string or file path; relative paths normalize under `%APPDATA%\RC_Drag_Manager`.
+- Schema definitions: inline SQL in `src/RCDragManagerProd/Repositories/DatabaseInitializer.cs` creating `Drivers`, `Cars`, `RaceSessions`, `MultiClassEvents` (+ index definitions).
+- Data shape in DB:
+  - `Drivers`/`Cars`: relational rows.
+  - `RaceSessions.SessionData`: JSON blob (`System.Text.Json` serialized `RaceSession`).
+  - `MultiClassEvents.EventData`: JSON blob (`System.Text.Json` serialized `MultiClassEvent`).
+- Seed data: not present.
+- Other persistent files:
+  - `%APPDATA%\RC_Drag_Manager\appsettings.json` via `src/RCDragManagerProd/Config/AppSettings.cs`.
+  - `%APPDATA%\RC_Drag_Manager\app.log` via `src/RCDragManagerProd/Logging/Logger.cs`.
+
+## 5. Race result flow
+- Manual result entry UI form:
+  - Primary entry point: `src/RCDragManagerProd/UI/Forms/Main/Form1.cs` + `Form1.WinnerButtons.cs` (`btnWinner1_Click`/`btnWinner2_Click` -> `HandleWinnerClick` -> `_controller.SubmitWinner`).
+  - Manual correction flow: `btnEditResult_Click` in `src/RCDragManagerProd/UI/Forms/Main/Form1.Events.cs` using in-form winner picker (`ShowWinnerPicker`) and `_controller.EditWinnerInActiveRound`.
+  - Additional dialog class exists: `src/RCDragManagerProd/UI/Forms/Results/EditWinnerDialog.cs`.
+- Controller/result write path:
+  - `RaceController.SubmitWinner` in `src/RCDragManagerProd/Controllers/RaceController.Results.cs` chooses winner/loser, calls engine (`EngineSetWinner`), stores in domain result store (`_matchResult.SetWinner`), updates `_winners`, advances round state, queues live update.
+  - Session persistence collects results into `RaceSession.SavedResults` in `src/RCDragManagerProd/Controllers/RaceController.Persistence.cs`.
+- File import functionality:
+  - `OpenFileDialog`: not present.
+  - `StreamReader`: not present.
+  - `FileSystemWatcher`: not present.
+  - Generic file IO present only for app settings/log files, not race-result ingestion.
+- Serial/COM port code:
+  - `SerialPort`, `System.IO.Ports`, `BaudRate`, COM listener code: not present.
+- Network listening code:
+  - `TcpListener`, `HttpListener`, Web API host, SignalR server: not present.
+  - Outbound HTTP client exists (`src/RCDragManagerProd/Integration/LiveApiClient.cs`) for live broadcast push/pull.
+- Conclusion: no automated result ingestion present.
+
+## 6. Existing extension points
+- `IRaceEngine` interface (`src/RCDragManagerProd/RaceEngines/IRaceEngine.cs`) with adapters (`ProLadderEngineAdapter`, `RandomEngineAdapter`, `RoundRobinEngineAdapter`) selected by `RaceEngineFactory`.
+- `IStandingsDialogService` interface (`src/RCDragManagerProd/Controllers/IStandingsDialogService.cs`) for standings presentation abstraction.
+- Event-based hooks inside controller/UI (C# events), e.g. `RaceController` exposes `BracketRedrawn`, `NextMatchReady`, `WinnersUpdated`, `CanAdvanceChanged`, `TournamentCompleted` and UI subscribes.
+- Dependency injection containers/plugin loaders/message buses (MEF, Unity, Autofac, MediatR, custom plugin loader): not present.
+- Generic result-provider/data-source interfaces for external timing feeds (`IDataSource`, `IResultProvider`): not present.
+
+## 7. External dependencies
+### Data access
+- `Stub.System.Data.SQLite.Core.NetFramework` `1.0.119.0`
+- `System.Data.SQLite.Core` `1.0.119.0`
+
+### UI
+- `QRCoder` `1.6.0`
+
+### Logging
+- Nothing found.
+
+### Networking
+- Nothing found.
+
+### Testing
+- `MSTest` `4.0.1`
+
+### Utility
+- `Microsoft.Bcl.AsyncInterfaces` `9.0.5`
+- `System.Buffers` `4.5.1`
+- `System.IO.Pipelines` `9.0.5`
+- `System.Memory` `4.5.5`
+- `System.Numerics.Vectors` `4.5.0`
+- `System.Resources.Extensions` `4.7.1`
+- `System.Runtime.CompilerServices.Unsafe` `6.0.0`
+- `System.Text.Encodings.Web` `9.0.5`
+- `System.Text.Json` `9.0.5`
+- `System.Threading.Tasks.Extensions` `4.5.4`
+- `System.ValueTuple` `4.5.0`
+
+### Integration-relevant package flags
+- Relevant: `System.Data.SQLite.Core` / `Stub.System.Data.SQLite.Core.NetFramework` (existing DB stack).
+- Paradox/BDE/ODBC-specific packages for `.db` timing files: not present.
+- Serial integration packages: not present.
+- File watcher/inbox integration packages: not present.
+
+## 8. Test coverage of result handling
+- Test project: `src/RCDragManagerProd.Tests/RCDragManagerProd.Tests.csproj`.
+- Result entry / bracket progression test classes:
+  - `RaceControllerFlowTests` — `src/RCDragManagerProd.Tests/RaceControllerFlowTests.cs`
+  - `RaceControllerRandomFlowTests` — `src/RCDragManagerProd.Tests/RaceControllerRandomFlowTests.cs`
+  - `RaceControllerRRStandardFlowTests` — `src/RCDragManagerProd.Tests/RaceControllerRRStandardFlowTests.cs`
+  - `RaceControllerQmdraFlowTests` — `src/RCDragManagerProd.Tests/RaceControllerQmdraFlowTests.cs`
+  - `RaceControllerResetTests` — `src/RCDragManagerProd.Tests/RaceControllerResetTests.cs`
+  - `RoundRobinEngineAdapterTests` — `src/RCDragManagerProd.Tests/RoundRobinEngineAdapterTests.cs`
+  - `ProLadderEngineAdapterTests` — `src/RCDragManagerProd.Tests/ProLadderEngineAdapterTests.cs`
+  - `RandomEngineAdapterTests` — `src/RCDragManagerProd.Tests/Test1.cs`
+  - `RoundRobinStandingsTests` — `src/RCDragManagerProd.Tests/RoundRobinStandingsTests.cs`
+  - `RoundRobinRoundClampingTests` — `src/RCDragManagerProd.Tests/RoundRobinRoundClampingTests.cs`
+  - `LosersBracketBuilderTests` — `src/RCDragManagerProd.Tests/LosersBracketBuilderTests.cs`
+  - `RandomBracketByeTrackerTests` — `src/RCDragManagerProd.Tests/RandomBracketByeTrackerTests.cs`
+  - `MatchResultTests` — `src/RCDragManagerProd.Tests/MatchResultTests.cs`
+- Racer management/repository test classes:
+  - `DriverRepositoryRegressionTests` — `src/RCDragManagerProd.Tests/DriverRepositoryRegressionTests.cs`
+  - `DriverRepositoryStatIncrementTests` — `src/RCDragManagerProd.Tests/DriverRepositoryStatIncrementTests.cs`
+  - `DriverCarEditBugTests` — `src/RCDragManagerProd.Tests/DriverCarEditBugTests.cs`
+  - `DriverManagerCarEditFlowTests` — `src/RCDragManagerProd.Tests/DriverManagerCarEditFlowTests.cs`
+  - `RaceSessionRepositoryTests` — `src/RCDragManagerProd.Tests/RaceSessionRepositoryTests.cs`
+  - `PairingHistorySerializationTests` — `src/RCDragManagerProd.Tests/PairingHistorySerializationTests.cs`
+  - `MultiClassEventRepositoryTests` — `src/RCDragManagerProd.Tests/MultiClassFeatureTests.cs`
+  - `RaceControllerMultiClassTests` — `src/RCDragManagerProd.Tests/MultiClassFeatureTests.cs`
+  - `MultiClassLbGateTests` — `src/RCDragManagerProd.Tests/MultiClassFeatureTests.cs`
+
+## 9. Build and deploy notes
+From `Installer/installer.iss`:
+- Install location pattern: `{localappdata}\Programs\RC Drag Manager` (`DefaultDirName`).
+- Files deployed: everything under `Installer/Payload/*` recursively to `{app}` excluding `README.txt`.
+- Database bundling behavior:
+  - Installer does not explicitly deploy `race_data.db`.
+  - Runtime creates `%APPDATA%\RC_Drag_Manager\race_data.db` on first run in `src/RCDragManagerProd/Program.cs` and initializes schema via `DatabaseInitializer`.
+- App data folder handling in installer: creates `{userappdata}\RC_Drag_Manager` and notes preserving roaming app data.
+- Pre-install action: .NET Framework 4.8+ prerequisite check in `[Code] InitializeSetup` (registry `Release >= 528040`), setup aborts with message if missing.
+- Post-install action: optional launch of app (`[Run]` entry with `postinstall`).
+
+## 10. Open questions
+1. `src/RCDragManagerProd/App.config` contains `LiveUpdateEnabled`, `LiveUpdateUrl`, and `ApiKey`, while runtime settings are also persisted in `%APPDATA%\RC_Drag_Manager\appsettings.json`; precedence/authoritative config source is not explicit.
+2. `src/RCDragManagerProd/UI/Forms/Results/EditWinnerDialog.cs` exists, but edit flow in `Form1` uses a separate in-form dynamic picker (`ShowWinnerPicker`); intended canonical edit UI is unclear.
+3. `src/RCDragManagerProd/Domain/Car.cs` has both `Id` and alias `CarID`; mixed identity naming could affect external mapping conventions.
+4. `src/RCDragManagerProd/Domain/RaceSession.cs` and `src/RCDragManagerProd/ViewModels/MatchResultSave.cs` both define `MatchResultSave` classes in different namespaces; intended long-term boundary between domain and UI save models is not explicit.
+5. `src/RCDragManagerProd/Controllers/RaceController.Persistence.cs` infers `RaceType` from engine/round labels when blank; expected persisted race-type source of truth is not explicit.
+6. `src/RCDragManagerProd/RoundRobinMode/RoundRobinMatch.cs` is declared in global namespace (no namespace block), unlike most project files; whether intentional or accidental is unclear.
+7. `src/RCDragManagerProd/Program.cs` includes comment `//claude agent test`; uncertain whether this marks unfinished cleanup or deliberate sentinel.
+8. `src/RCDragManagerProd/Integration/LiveApiClient.cs` provides outbound update transport, but there is no corresponding inbound ingestion contract for external timing systems; intended integration seam is not codified.
+9. `src/RCDragManagerProd/Logging/Logger.cs`, `Program.cs`, and `AppSettings.cs` contain swallowed exception paths (`catch {}`), which makes failure visibility behavior policy unclear.
+10. No `.db` file import/watcher pipeline exists in current code; expected orchestration point for third-party timing file reconciliation must be defined externally.


### PR DESCRIPTION
## What changed

Adds repository documentation and Claude/Codex routine notes:

- reusable `.github/claude-routines/*` worker, reviewer, fixer, reporter, and release-check instructions
- a `Docs/README.md` documentation index
- live-server integration and Portatree planning/setup notes
- Claude context research and session handover documents

## Why

Claude Code left these files locally as repo context and operating guidance. This PR moves them onto a fresh branch from current `main` so they can be reviewed separately from the already-merged `codex/improve-create-event-actions` work.

## Validation

- `git fetch --prune origin`
- confirmed `codex/improve-create-event-actions` was already merged as PR #374
- scanned new files for obvious secrets; new files use placeholders such as `X-API-KEY`
- `git diff --cached --check`

The .NET test suite was not run because this PR only adds markdown documentation and GitHub routine metadata.

## Notes

I left the handover documents as historical notes, including the existing exported filename `SESSION-HANDOVER (1).md`, so the PR preserves Claude's produced artifact set.