### PR TITLE
[codex] Build installer on release

### DIFF
--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,0 +1,69 @@
+name: Release Installer
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-installer-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-installer:
+    name: Build Windows installer
+    runs-on: windows-latest
+
+    env:
+      SOLUTION: src/RCDragManagerProd/RCDragManagerProd.sln
+      INSTALLER_PATTERN: Installer/output/RC-Drag-Manager-Setup-*.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --yes --no-progress
+
+      - name: Restore NuGet packages
+        shell: pwsh
+        run: nuget restore $env:SOLUTION
+
+      - name: Build installer
+        shell: pwsh
+        run: ./Installer/build-installer.ps1
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rc-drag-manager-installer
+          path: ${{ env.INSTALLER_PATTERN }}
+          if-no-files-found: error
+
+      - name: Upload installer to GitHub Release
+        if: github.event_name == 'release'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          $installers = Get-ChildItem -Path "Installer/output" -Filter "RC-Drag-Manager-Setup-*.exe" -File
+          if (-not $installers) {
+            throw "No installer exe was produced in Installer/output."
+          }
+
+          $paths = $installers | ForEach-Object { $_.FullName }
+          gh release upload $env:TAG_NAME $paths --clobber


### PR DESCRIPTION
## What changed

Adds a dedicated `Release Installer` GitHub Actions workflow.

The workflow runs on:

- published GitHub releases
- pushed `v*` tags
- manual `workflow_dispatch`

It restores the solution, installs Inno Setup, runs `Installer/build-installer.ps1`, uploads the generated setup exe as a workflow artifact, and uploads the setup exe to the GitHub Release for `release` events.

## Why

Creating a release/tag should automatically produce the Windows installer instead of requiring a manual local Inno Setup build.

## Validation

- `git diff --check`
- local installer build via `powershell -ExecutionPolicy Bypass -File Installer\build-installer.ps1`
- produced `Installer/output/RC-Drag-Manager-Setup-2.0.0.0.exe`

## Notes

The local installer build completed with one existing compiler warning about obsolete `IRaceEngine.SetWinner(int, Driver)` usage, but the build and Inno Setup compile both succeeded.