### PR TITLE
Fix double-counted driver stats in the single-class race console

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceConsoleServiceStatsSingleCountTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceConsoleServiceStatsSingleCountTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.AppServices;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Regression tests for issue #379 — win/loss and events-won stats were persisted
+/// per winner click AND again at tournament completion in the single-class WPF
+/// console, double-counting every match. Completion-time recording
+/// (<see cref="RaceConsoleService.RecordTournamentCompletion"/>) is now the only
+/// write path; these tests pin the exact totals a completed event must produce.
+/// </summary>
+[TestClass]
+public class RaceConsoleServiceStatsSingleCountTests
+{
+    [TestMethod]
+    public void RecordTournamentCompletion_MultiMatchEvent_CountsEachMatchExactlyOnce()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repo = new DriverRepository(db.ConnectionString);
+
+        var champ = AddDriver(repo, "Champ");
+        var second = AddDriver(repo, "Second");
+        var third = AddDriver(repo, "Third");
+
+        // Semifinals + final: Champ beats Third, Second beats no one, Champ beats Second.
+        var summary = new RaceController.RaceSummary
+        {
+            Winner = champ,
+            RunnerUp = second,
+            MatchResults = new List<(int, int)>
+            {
+                (champ.Id, third.Id),
+                (champ.Id, second.Id)
+            }
+        };
+
+        var controller = new RaceController(new RaceSession { EventName = "Finals Night", RaceType = "Pro Ladder" });
+        var svc = new RaceConsoleService(controller, null, repo);
+        svc.RecordTournamentCompletion(summary, new[] { champ, second, third });
+
+        var champDb = repo.GetDriverById(champ.Id);
+        var secondDb = repo.GetDriverById(second.Id);
+        var thirdDb = repo.GetDriverById(third.Id);
+
+        Assert.AreEqual(2, champDb.TotalWins, "Champion won exactly two matches.");
+        Assert.AreEqual(0, champDb.TotalLosses);
+        Assert.AreEqual(1, champDb.EventsWon, "Events won must increment exactly once.");
+        Assert.AreEqual(1, champDb.EventsEntered);
+
+        Assert.AreEqual(0, secondDb.TotalWins);
+        Assert.AreEqual(1, secondDb.TotalLosses);
+        Assert.AreEqual(0, secondDb.EventsWon);
+        Assert.AreEqual(1, secondDb.EventsEntered);
+
+        Assert.AreEqual(0, thirdDb.TotalWins);
+        Assert.AreEqual(1, thirdDb.TotalLosses);
+        Assert.AreEqual(1, thirdDb.EventsEntered);
+    }
+
+    [TestMethod]
+    public void RecordTournamentCompletion_CalledOnce_DoesNotDependOnPerMatchWrites()
+    {
+        // Drivers start at zero: no per-match write path may have run before completion.
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repo = new DriverRepository(db.ConnectionString);
+
+        var winner = AddDriver(repo, "Winner");
+        var loser = AddDriver(repo, "Loser");
+
+        Assert.AreEqual(0, repo.GetDriverById(winner.Id).TotalWins);
+
+        var controller = new RaceController(new RaceSession { EventName = "Single Final", RaceType = "Pro Ladder" });
+        var svc = new RaceConsoleService(controller, null, repo);
+        svc.RecordTournamentCompletion(
+            new RaceController.RaceSummary
+            {
+                Winner = winner,
+                MatchResults = new List<(int, int)> { (winner.Id, loser.Id) }
+            },
+            new[] { winner, loser });
+
+        Assert.AreEqual(1, repo.GetDriverById(winner.Id).TotalWins);
+        Assert.AreEqual(1, repo.GetDriverById(winner.Id).EventsWon);
+        Assert.AreEqual(1, repo.GetDriverById(loser.Id).TotalLosses);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static Driver AddDriver(DriverRepository repo, string name)
+    {
+        var d = new Driver { Name = name, Cars = new List<Car>() };
+        repo.AddDriver(d);
+        return repo.GetDriverById(d.Id);
+    }
+
+    private sealed class TemporarySqliteDb : IDisposable
+    {
+        public TemporarySqliteDb()
+        {
+            DatabasePath = Path.Combine(
+                Path.GetTempPath(),
+                $"rcdragmanager-singlecount-tests-{Guid.NewGuid():N}.db");
+        }
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try { if (File.Exists(DatabasePath)) File.Delete(DatabasePath); } catch { }
+        }
+    }
+}

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
@@ -516,21 +516,9 @@ namespace RCDragManagerProd.WPF.Views
             var round = _controller.GetMatch(matchId)?.RoundLabel ?? "?";
             Logger.Log($"[RESULT] M{matchId} ({round}): {winner?.Name ?? "?"} defeated {loser?.Name ?? "BYE"}");
 
-            // In hosted mode the multi-class window records win/loss stats on completion.
-            if (IsHostedMode) return;
-
-            if (winner != null && loser != null && !IsBye(winner.Name) && !IsBye(loser.Name))
-                PersistStats(winner, loser, matchId);
-        }
-
-        private void PersistStats(Driver winner, Driver loser, int matchId)
-        {
-            var match = _controller.GetMatch(matchId);
-            _controller.PersistMatchStats(winner, loser, App.ConnectionString);
-            var round = match?.RoundLabel ?? "";
-            if (string.Equals(round, "F", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(round, "Final", StringComparison.OrdinalIgnoreCase))
-                _controller.PersistEventWon(winner, App.ConnectionString);
+            // Stats are persisted once, at tournament completion (RecordTournamentCompletion,
+            // or the multi-class window in hosted mode) — never per match, so result edits
+            // before completion can't leave stale increments behind (#379).
         }
 
         private void BtnWinner1_RightClick(object sender, MouseButtonEventArgs e) => EditButtonDialIn(true);


### PR DESCRIPTION
## Summary

Fixes #379 — single-class (non-hosted) races double-counted driver stats.

Every accepted winner click in `RaceConsoleView.SubmitWinner` persisted +1 `TotalWins`/`TotalLosses` (and +1 `EventsWon` on the final), and then `OnTournamentCompleted` → `RecordTournamentCompletion` incremented the same matches **again** from `summary.MatchResults` (which is the full result set, `_matchResult.GetAllResults()`). Hosted multi-class mode only recorded at completion, so single-class totals were roughly double.

## Changes

- `RaceConsoleView.xaml.cs`: removed the per-match `PersistStats` call and the `PersistStats` helper. `RecordTournamentCompletion` (already wired in `OnTournamentCompleted`) is now the single stat-write path in both hosted and non-hosted modes.
  - Side benefits: result edits before completion now yield correct final stats (per-match increments were never reversed on edit), and the hardcoded `"F"`/`"Final"` round-label comparison (convention violation) is gone.
- `RaceController.Stats.cs` untouched — legacy WinForms `Form1.WinnerButtons.cs` still calls `PersistMatchStats`/`PersistEventWon` and Form1 is on the do-not-touch list.
- New `RaceConsoleServiceStatsSingleCountTests.cs` (2 tests) pinning exact totals for a completed multi-match event: N matches → exactly N wins + N losses, +1 EventsWon for the champion, +1 EventsEntered per participant.

## Verify plan

- `dotnet test src/RCDragManagerProd.Tests` — 309 passed / 0 failed / 11 pre-existing skips.
- `MSBuild RCDragManagerProd.WPF.csproj -p:Configuration=Release` — builds clean (the changed file is WPF code-behind, not covered by the test build).

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
