### PR TITLE
Show the combined final-results summary when all classes finish

### DIFF
--- a/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
@@ -180,6 +180,7 @@ namespace RCDragManagerProd.WPF.Windows
             if (_completed.Count == _controllers.Count)
             {
                 Logger.Log($"[RESULT][EVENT] '{_multiEvent.EventName}' complete — all {_controllers.Count} classes finished");
+                ShowCombinedSummary();
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #380 — the combined "Event complete — final results" summary for multi-class events was dead code in the WPF port.

`MultiClassRaceWindow.OnClassCompleted` already tracked completion and had the `_completed.Count == _controllers.Count` branch, but it only wrote a log line; `ShowCombinedSummary()` (which builds the all-classes champion/runner-up text and shows `TextSummaryWindow`) had no callers.

## Changes

- `MultiClassRaceWindow.xaml.cs`: call `ShowCombinedSummary()` in the all-classes-complete branch. It runs after the final class's own `ClassCompletionWindow` dialog has closed (that `ShowDialog` happens earlier in `OnClassCompleted`), matching the WinForms behaviour.

One-line fix; classes without a recorded summary still render "(no result recorded)" — that handling was already in the method.

## Verify plan

- `MSBuild RCDragManagerProd.WPF.csproj -p:Configuration=Release` — builds clean.
- No logic moved into the view; UI-only wiring, so no new unit tests (the summary text builder is untestable-by-design view code — flagged in #289's extraction scope).
- Manual check (multi-class event, 2 classes, finish both): per-class popup for the last class, then the combined final-results window listing both classes.

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
