### PR TITLE
Refresh console dial-ins when the live-site poll applies changes

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceControllerDialInEventTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceControllerDialInEventTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.Controllers;
+using RCDragManagerProd.Domain;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Covers the <see cref="RaceController.DialInsChanged"/> event added for issue #381 —
+/// the race console relies on it to re-render dial-ins the background live-site poll
+/// (or a local edit) applies to the session.
+/// </summary>
+[TestClass]
+public class RaceControllerDialInEventTests
+{
+    private static RaceController NewControllerWithDriver(int driverId)
+    {
+        var session = new RaceSession
+        {
+            EventName = "DialIn Test",
+            RaceType = "Pro Ladder",
+            DriverEntries = new List<RaceSessionDriverEntry>
+            {
+                new RaceSessionDriverEntry { DriverID = driverId, DriverName = "Alice" }
+            }
+        };
+        return new RaceController(session);
+    }
+
+    [TestMethod]
+    public void UpdateDriverDialIn_KnownDriver_RaisesDialInsChangedAndStoresValue()
+    {
+        var controller = NewControllerWithDriver(1);
+        int raised = 0;
+        controller.DialInsChanged += () => raised++;
+
+        controller.UpdateDriverDialIn(1, 5.123);
+
+        Assert.AreEqual(1, raised, "DialInsChanged must fire once per applied change.");
+        Assert.AreEqual(5.123, controller.GetDriverDialIn(1));
+    }
+
+    [TestMethod]
+    public void UpdateDriverDialIn_UnknownDriver_DoesNotRaise()
+    {
+        var controller = NewControllerWithDriver(1);
+        int raised = 0;
+        controller.DialInsChanged += () => raised++;
+
+        controller.UpdateDriverDialIn(99, 5.123);
+
+        Assert.AreEqual(0, raised, "No event when no entry was updated.");
+        Assert.IsNull(controller.GetDriverDialIn(99));
+    }
+
+    [TestMethod]
+    public void UpdateDriverDialIn_ClearingValue_RaisesAndClears()
+    {
+        var controller = NewControllerWithDriver(1);
+        controller.UpdateDriverDialIn(1, 4.500);
+
+        int raised = 0;
+        controller.DialInsChanged += () => raised++;
+        controller.UpdateDriverDialIn(1, null);
+
+        Assert.AreEqual(1, raised);
+        Assert.IsNull(controller.GetDriverDialIn(1));
+    }
+}

--- a/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Views/RaceConsoleView.xaml.cs
@@ -82,6 +82,7 @@ namespace RCDragManagerProd.WPF.Views
             _controller.RoundRobinCompleted += OnRoundRobinCompleted;
             _controller.CanStartFinalsChanged += OnCanStartFinalsChanged;
             _controller.TournamentCompleted += OnTournamentCompleted;
+            _controller.DialInsChanged += OnDialInsChanged;
 
             if (!_controller.IsCompleted)
                 _controller.StartDialInPolling();
@@ -123,6 +124,7 @@ namespace RCDragManagerProd.WPF.Views
                 _controller.RoundRobinCompleted -= OnRoundRobinCompleted;
                 _controller.CanStartFinalsChanged -= OnCanStartFinalsChanged;
                 _controller.TournamentCompleted -= OnTournamentCompleted;
+                _controller.DialInsChanged -= OnDialInsChanged;
             }
             catch { }
             _controller.StopDialInPolling();
@@ -278,6 +280,15 @@ namespace RCDragManagerProd.WPF.Views
             }
             else _finalsPopupShown = false;
             UpdatePrimaryButtons();
+        });
+
+        // Fires for local edits and for changes the background live-site poll applies;
+        // without this the grid and winner buttons showed stale dial-ins until the
+        // operator touched them (#381).
+        private void OnDialInsChanged() => Run(() =>
+        {
+            RefreshDriverGrid();
+            RefreshWinnerButtonDialIns();
         });
 
         private void OnTournamentCompleted(RaceController.RaceSummary summary) => Run(() =>

--- a/src/RCDragManagerProd/Controllers/RaceController.DialIn.cs
+++ b/src/RCDragManagerProd/Controllers/RaceController.DialIn.cs
@@ -16,6 +16,11 @@ namespace RCDragManagerProd.Controllers
 
         public bool DialInLocked => _dialInLocked;
 
+        /// <summary>Raised after one or more driver dial-ins change, including changes
+        /// applied by the background live-site poll. May fire on a non-UI thread —
+        /// subscribers must marshal to their dispatcher.</summary>
+        public event Action DialInsChanged;
+
         public double? GetDriverDialIn(int driverId)
         {
             if (_session == null) return null;
@@ -37,6 +42,7 @@ namespace RCDragManagerProd.Controllers
                 entry.DialIn = dialIn;
             }
             Logger.Log($"[DIALIN] Updated driverId={driverId} dialIn={dialIn?.ToString("F3") ?? "null"}");
+            DialInsChanged?.Invoke();
             QueueLiveUpdate("dialin-edit");
         }
 
@@ -107,7 +113,10 @@ namespace RCDragManagerProd.Controllers
                 }
 
                 if (changed)
+                {
+                    DialInsChanged?.Invoke();
                     QueueLiveUpdate("dialin-poll");
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

Fixes #381 — dial-in changes submitted from the live site were applied to the session by the background poll and re-broadcast, but the Race Director's own console never re-rendered them: spectators saw the new dial-in while the operator's grid and winner buttons showed the old value.

## Changes

- `RaceController.DialIn.cs`: new `DialInsChanged` event (documented as possibly firing on a non-UI thread). Raised by `UpdateDriverDialIn` after an applied local edit and by `PollAndApplyAsync` when the poll changed at least one entry — fired outside `_dialInLock`, before the outbound `QueueLiveUpdate`.
- `RaceConsoleView.xaml.cs`: subscribes in the constructor, unsubscribes in `Teardown`, and on the event refreshes the driver grid and the winner-button dial-in suffixes via the existing `Run` dispatcher-marshalling helper. This follows the "controller emits events; UI only subscribes" rule — previously the view only refreshed after its own local edit dialogs.
- New `RaceControllerDialInEventTests.cs` (3 tests): event fires once per applied change, not at all for unknown driver ids, and on clearing a dial-in.

## Verify plan

- `dotnet test src/RCDragManagerProd.Tests` — 312 passed / 0 failed / 11 pre-existing skips.
- `MSBuild RCDragManagerProd.WPF.csproj -p:Configuration=Release` — builds clean.
- Manual (needs live server): with broadcast enabled, change a dial-in from the live site; console grid updates within one 15 s poll without touching the UI.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
