### PR TITLE
Replace hardcoded UI colours with theme tokens

### DIFF
--- a/src/RCDragManagerProd.WPF/Resources/Theme.xaml
+++ b/src/RCDragManagerProd.WPF/Resources/Theme.xaml
@@ -19,6 +19,10 @@
 
     <SolidColorBrush x:Key="Brush.Success"        Color="{DynamicResource C.Success}"/>
     <SolidColorBrush x:Key="Brush.Danger"         Color="{DynamicResource C.Danger}"/>
+    <SolidColorBrush x:Key="Brush.Info"           Color="{DynamicResource C.Info}"/>
+
+    <SolidColorBrush x:Key="Brush.OnPrimary"       Color="{DynamicResource C.OnPrimary}"/>
+    <SolidColorBrush x:Key="Brush.OnPrimarySubtle" Color="{DynamicResource C.OnPrimarySubtle}"/>
 
     <SolidColorBrush x:Key="Brush.TextPrimary"    Color="{DynamicResource C.TextPrimary}"/>
     <SolidColorBrush x:Key="Brush.TextSecondary"  Color="{DynamicResource C.TextSecondary}"/>

--- a/src/RCDragManagerProd.WPF/ThemeManager.cs
+++ b/src/RCDragManagerProd.WPF/ThemeManager.cs
@@ -36,6 +36,12 @@ namespace RCDragManagerProd.WPF
 
                 ["C.Success"]        = ("#2A8E60", "#1D7A50"),
                 ["C.Danger"]         = ("#C84040", "#B83030"),
+                ["C.Info"]           = ("#3A6EA5", "#2F6398"),
+
+                // Text on Primary/flame-orange fills — the button stays orange in
+                // both themes, so these do not vary by theme.
+                ["C.OnPrimary"]       = ("#FFFFFF", "#FFFFFF"),
+                ["C.OnPrimarySubtle"] = ("#A6FFFFFF", "#A6FFFFFF"),
 
                 ["C.TextPrimary"]    = ("#F0F0F0", "#141414"),
                 ["C.TextSecondary"]  = ("#909090", "#5A5A5A"),

--- a/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/LandingWindow.xaml
@@ -116,11 +116,11 @@
                                 <TextBlock Text="Start new event"
                                            FontSize="{StaticResource FontSize.Xl}"
                                            FontWeight="Medium"
-                                           Foreground="White"
+                                           Foreground="{StaticResource Brush.OnPrimary}"
                                            Margin="0,0,0,4"/>
                                 <TextBlock Text="Create a new race session — single or multi-class"
                                            FontSize="{StaticResource FontSize.Sm}"
-                                           Foreground="#A6FFFFFF"/>
+                                           Foreground="{StaticResource Brush.OnPrimarySubtle}"/>
                             </StackPanel>
                         </Button>
 

--- a/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/MultiClassRaceWindow.xaml.cs
@@ -243,8 +243,8 @@ namespace RCDragManagerProd.WPF.Windows
         private Brush CompletedBrush => Res("Brush.TextHint");
         private Brush RrCompleteBrush => Res("Brush.Primary");
         private Brush NextActiveBrush => Res("Brush.Success");
-        private static readonly Brush StartedBrush = new SolidColorBrush(Color.FromRgb(0x3A, 0x6E, 0xA5));
-        private static readonly Brush IdleBrush = new SolidColorBrush(Color.FromRgb(0x40, 0x40, 0x40));
+        private Brush StartedBrush => Res("Brush.Info");
+        private Brush IdleBrush => Res("Brush.TextGhost");
 
         // ── Title bar ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #389 — the last hardcoded colours in WPF views outside the theme system.

- `MultiClassRaceWindow` tab-status dots: `StartedBrush`/`IdleBrush` were `static readonly SolidColorBrush(Color.FromRgb(...))` — they never re-themed (static instances, not DynamicResource-bound) and the `#404040` idle dot was near-invisible against light-theme tab headers. The other three dot states already resolved theme brushes via `FindResource`.
- `LandingWindow` CTA: `Foreground="White"` / `Foreground="#A6FFFFFF"` on the flame-orange primary button.

## Changes

- `ThemeManager.cs`: three new palette tokens — `C.Info` (started-state blue, dark `#3A6EA5` preserving today's dark look / light `#2F6398`), and `C.OnPrimary` / `C.OnPrimarySubtle` for text on primary-orange fills (identical in both themes by design, since primary buttons stay orange — documented inline).
- `Resources/Theme.xaml`: matching `Brush.Info`, `Brush.OnPrimary`, `Brush.OnPrimarySubtle` (DynamicResource-bound like every other brush, so they re-theme live).
- `MultiClassRaceWindow.xaml.cs`: `StartedBrush => Res("Brush.Info")`, `IdleBrush => Res("Brush.TextGhost")` — same lookup path as the other dot states; no more `Color.FromRgb` in the codebase's WPF views.
- `LandingWindow.xaml`: CTA title/subtitle use the new on-primary brushes.

## Verify plan

- `MSBuild RCDragManagerProd.WPF.csproj -p:Configuration=Release` — builds clean.
- Visual spot-check (dark + light): tab dots render all five states distinctly; landing CTA text unchanged in dark mode.
- The macOS-style traffic-light window buttons in `Styles.xaml` keep their fixed red/yellow/green — deliberate, out of scope per the issue.

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
