### PR TITLE
Stop double-writing new rows in SaveSession/SaveEvent

### DIFF
--- a/src/RCDragManagerProd.Tests/RepositorySaveRoundTripTests.cs
+++ b/src/RCDragManagerProd.Tests/RepositorySaveRoundTripTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Regression tests for issue #385 — SaveSession/SaveEvent used to INSERT a new
+/// row and then immediately UPDATE the same row with identical data, serializing
+/// the JSON blob twice per save. These tests pin the contract the split insert/
+/// update paths must keep: ids round-trip on first save, re-saves update in
+/// place (no extra rows), and loads return the latest data.
+/// </summary>
+[TestClass]
+public class RepositorySaveRoundTripTests
+{
+    [TestMethod]
+    public void SaveSession_NewThenResave_KeepsOneRowAndLatestData()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repo = new RaceSessionRepository(db.ConnectionString);
+
+        var session = new RaceSession
+        {
+            EventName = "First Save",
+            EventDate = new DateTime(2026, 7, 11, 18, 0, 0),
+            ClassType = "Open",
+            RaceType = "Pro Ladder"
+        };
+
+        var savedId = repo.SaveSession(session);
+        Assert.IsTrue(savedId > 0);
+        Assert.AreEqual(savedId, session.Id, "First save must assign the row id.");
+
+        session.EventName = "Renamed Event";
+        var resavedId = repo.SaveSession(session);
+
+        Assert.AreEqual(savedId, resavedId, "Re-save must update in place, not insert.");
+        Assert.AreEqual(1, CountRows(db.ConnectionString, "RaceSessions"));
+
+        var loaded = repo.LoadSession(savedId);
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual(savedId, loaded.Id, "Load must overwrite the embedded id with the row id.");
+        Assert.AreEqual("Renamed Event", loaded.EventName);
+    }
+
+    [TestMethod]
+    public void SaveEvent_NewThenResave_KeepsOneRowAndLatestData()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repo = new MultiClassEventRepository(db.ConnectionString);
+
+        var evt = new MultiClassEvent
+        {
+            EventName = "First Save",
+            EventDate = new DateTime(2026, 7, 11, 18, 0, 0)
+        };
+
+        repo.SaveEvent(evt);
+        var savedId = evt.Id;
+        Assert.IsTrue(savedId > 0, "First save must assign the row id.");
+
+        evt.EventName = "Renamed Event";
+        repo.SaveEvent(evt);
+
+        Assert.AreEqual(savedId, evt.Id, "Re-save must update in place, not insert.");
+        Assert.AreEqual(1, CountRows(db.ConnectionString, "MultiClassEvents"));
+
+        var loaded = repo.LoadEvent(savedId);
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual(savedId, loaded.Id, "Load must overwrite the embedded id with the row id.");
+        Assert.AreEqual("Renamed Event", loaded.EventName);
+    }
+
+    private static int CountRows(string connectionString, string table)
+    {
+        using var cn = new SQLiteConnection(connectionString);
+        cn.Open();
+        using var cmd = new SQLiteCommand($"SELECT COUNT(*) FROM {table}", cn);
+        return Convert.ToInt32(cmd.ExecuteScalar());
+    }
+
+    private sealed class TemporarySqliteDb : IDisposable
+    {
+        public TemporarySqliteDb()
+        {
+            DatabasePath = Path.Combine(
+                Path.GetTempPath(),
+                $"rcdragmanager-saveroundtrip-tests-{Guid.NewGuid():N}.db");
+        }
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try { if (File.Exists(DatabasePath)) File.Delete(DatabasePath); } catch { }
+        }
+    }
+}

--- a/src/RCDragManagerProd/Repositories/MultiClassEventRepository.cs
+++ b/src/RCDragManagerProd/Repositories/MultiClassEventRepository.cs
@@ -70,14 +70,19 @@ SELECT last_insert_rowid();";
                 {
                     if (evt.Id <= 0)
                     {
+                        // The embedded JSON id is 0 here; harmless — LoadEvent overwrites
+                        // evt.Id with the row id.
                         using (var cmd = new SQLiteCommand(insertSql, cn, tx))
                         {
                             AddSaveParameters(cmd, eventName, eventDate, classCount, Serialize(evt));
                             evt.Id = Convert.ToInt32(cmd.ExecuteScalar());
                         }
                     }
+                    else
+                    {
+                        UpdateExistingEvent(cn, tx, evt, eventName, eventDate, classCount);
+                    }
 
-                    UpdateExistingEvent(cn, tx, evt, eventName, eventDate, classCount);
                     tx.Commit();
                     Logger.Log("[TX] COMMIT SaveEvent");
                 }

--- a/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
+++ b/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
@@ -77,14 +77,19 @@ SELECT last_insert_rowid();";
                     {
                         if (session.Id <= 0)
                         {
+                            // The embedded JSON id is 0 here; harmless — every load path
+                            // overwrites session.Id with the row id (DeserializeSession).
                             using (var cmd = new SQLiteCommand(insertSql, cn, tx))
                             {
                                 AddSaveParameters(cmd, eventName, eventDate, classType, raceType, Serialize(session));
                                 session.Id = Convert.ToInt32(cmd.ExecuteScalar());
                             }
                         }
+                        else
+                        {
+                            UpdateExistingSession(cn, tx, session, eventName, eventDate, classType, raceType);
+                        }
 
-                        UpdateExistingSession(cn, tx, session, eventName, eventDate, classType, raceType);
                         tx.Commit();
                         Logger.Log("[TX] COMMIT SaveSession");
                     }


### PR DESCRIPTION
## Summary

Fixes #385 — `RaceSessionRepository.SaveSession` and `MultiClassEventRepository.SaveEvent` INSERTed new rows and then **unconditionally UPDATEd the same row with the same data**, serializing the session/event JSON twice per save. Multi-class mode persists both the session and the whole parent event after every action, so this doubled the heaviest write in the app.

## Why the redundant UPDATE existed — and why it's safe to drop

The second write re-serialized after `session.Id`/`evt.Id` was assigned so the stored JSON embedded the real id. But the embedded id is never trusted: `DeserializeSession` (`RaceSessionRepository.cs`) and `LoadEvent` (`MultiClassEventRepository.cs`) both overwrite the object's `Id` with the row id on every load. A first-save row now embeds `"id": 0`, which no code path reads (comment added at the insert site).

## Changes

- Both repositories: the post-insert `UpdateExisting*` call becomes the **else**-branch — new rows are a single INSERT (one `Serialize`), existing rows a single UPDATE (one `Serialize`).
- ⚠️ `RaceSessionRepository` is on the CLAUDE.md do-not-touch list — flagging explicitly, as anticipated in the issue. Public API unchanged; `RaceSessionRepositoryTests` (including the update-path and damaged-session tests) pass unmodified.
- New `RepositorySaveRoundTripTests.cs` (2 tests): first save assigns the row id; re-save updates in place (row count stays 1); loads return latest data with the row id.

## Verify plan

- `dotnet test src/RCDragManagerProd.Tests` — 324 passed / 0 failed / 11 pre-existing skips.

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)
