### PR TITLE
Validate session list rows by parsing, not full deserialization

### DIFF
--- a/src/RCDragManagerProd.Tests/RaceSessionListValidationTests.cs
+++ b/src/RCDragManagerProd.Tests/RaceSessionListValidationTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RCDragManagerProd.Domain;
+using RCDragManagerProd.Repositories;
+
+namespace RCDragManagerProd.Tests;
+
+/// <summary>
+/// Covers the cheap list-time validation introduced for issue #384.
+/// GetAllSessions used to fully deserialize every row's SessionData just to
+/// decide loadability; it now only parses. The observable contract: rows whose
+/// JSON parses are listed even if full deserialization would fail (the load
+/// path reports those with a friendly error), while empty/unparseable rows are
+/// still hidden exactly as before (#373 behaviour).
+/// </summary>
+[TestClass]
+public class RaceSessionListValidationTests
+{
+    [TestMethod]
+    public void GetAllSessions_ListsParseableRowsWithoutFullDeserialization()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repository = new RaceSessionRepository(db.ConnectionString);
+
+        // Valid JSON object, but full RaceSession binding would throw
+        // (driverEntries must be an array). If GetAllSessions still bound the
+        // POCO, this row would be skipped — listing it proves the cheap path.
+        int shapeInvalidId = InsertRawSession(db.ConnectionString,
+            "QA Shape Invalid", @"{""driverEntries"": ""not-an-array""}");
+
+        var sessions = repository.GetAllSessions();
+
+        Assert.IsTrue(sessions.Any(s => s.Id == shapeInvalidId),
+            "Parseable rows must be listed without binding the full RaceSession.");
+        Assert.AreEqual(
+            RaceSessionLoadStatus.InvalidData,
+            repository.TryLoadSession(shapeInvalidId).Status,
+            "The load path still reports the row as invalid, surfacing a friendly error.");
+    }
+
+    [TestMethod]
+    public void GetAllSessions_StillHidesEmptyAndUnparseableRows()
+    {
+        using var db = new TemporarySqliteDb();
+        DatabaseInitializer.InitializeDatabase(db.ConnectionString);
+        var repository = new RaceSessionRepository(db.ConnectionString);
+
+        int validId = repository.SaveSession(new RaceSession
+        {
+            EventName = "QA Valid",
+            EventDate = new DateTime(2026, 7, 11, 12, 0, 0),
+            ClassType = "Open",
+            RaceType = "Pro Ladder"
+        });
+        InsertRawSession(db.ConnectionString, "QA Empty", "");
+        InsertRawSession(db.ConnectionString, "QA Broken", "{not-json");
+        InsertRawSession(db.ConnectionString, "QA Not Object", "[1,2,3]");
+
+        var sessions = repository.GetAllSessions();
+
+        Assert.AreEqual(1, sessions.Count);
+        Assert.AreEqual(validId, sessions[0].Id);
+    }
+
+    private static int InsertRawSession(string connectionString, string eventName, string sessionData)
+    {
+        using var connection = new SQLiteConnection(connectionString);
+        connection.Open();
+        using var command = new SQLiteCommand(@"
+INSERT INTO RaceSessions (EventName, EventDate, ClassType, RaceType, SessionData)
+VALUES (@EventName, '2026-07-11 12:00:00', 'Open', 'Pro Ladder', @SessionData);
+SELECT last_insert_rowid();", connection);
+        command.Parameters.AddWithValue("@EventName", eventName);
+        command.Parameters.AddWithValue("@SessionData", sessionData);
+        return Convert.ToInt32(command.ExecuteScalar());
+    }
+
+    private sealed class TemporarySqliteDb : IDisposable
+    {
+        public TemporarySqliteDb()
+        {
+            DatabasePath = Path.Combine(
+                Path.GetTempPath(),
+                $"rcdragmanager-listvalidation-tests-{Guid.NewGuid():N}.db");
+        }
+
+        public string DatabasePath { get; }
+        public string ConnectionString => $"Data Source={DatabasePath};Version=3;";
+
+        public void Dispose()
+        {
+            try { if (File.Exists(DatabasePath)) File.Delete(DatabasePath); } catch { }
+        }
+    }
+}

--- a/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
+++ b/src/RCDragManagerProd/Repositories/RaceSessionRepository.cs
@@ -177,12 +177,14 @@ ORDER BY datetime(EventDate) DESC";
                     int id = rd.GetInt32(0);
                     string eventName = rd.IsDBNull(1) ? "" : rd.GetString(1);
                     string json = rd.IsDBNull(5) ? null : rd.GetString(5);
-                    var loadResult = DeserializeSession(id, json);
-                    if (!loadResult.Success)
+                    // Cheap parse-only validation: binding the full RaceSession here made
+                    // opening the list screens O(rows x JSON size) (#384). Rows that parse
+                    // but fail full deserialization surface a friendly error on load instead.
+                    if (!IsLoadableSessionJson(json))
                     {
                         Logger.Log(
                             $"[DB][SessionRepo][WARN] Skipping unloadable session " +
-                            $"Id={id}, EventName='{eventName}', Status={loadResult.Status}");
+                            $"Id={id}, EventName='{eventName}'");
                         continue;
                     }
 
@@ -231,6 +233,20 @@ ORDER BY datetime(EventDate) DESC";
                 }
 
                 return DeserializeSession(id, value as string);
+            }
+        }
+
+        private static bool IsLoadableSessionJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return false;
+            try
+            {
+                using (var doc = JsonDocument.Parse(json))
+                    return doc.RootElement.ValueKind == JsonValueKind.Object;
+            }
+            catch (JsonException)
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #384 — `RaceSessionRepository.GetAllSessions` deserialized every row's full `SessionData` JSON into a `RaceSession` (reflection binding of drivers, entries, pairing history, …) purely to decide whether to skip a damaged row, then discarded the object. The Landing page calls this on open **and on every return from a child window**, so list screens degraded linearly with saved history.

## Changes

- `RaceSessionRepository.cs`: list-time validation is now `IsLoadableSessionJson` — a `JsonDocument.Parse` (object root required) instead of `JsonSerializer.Deserialize<RaceSession>`. Parse-only is dramatically cheaper than POCO binding and preserves the #373 contract: empty and unparseable rows stay hidden, nothing is ever deleted or overwritten.
- ⚠️ `RaceSessionRepository` is on the do-not-touch list — flagged as required by the issue. Public API unchanged; all existing `RaceSessionRepositoryTests` (incl. `GetAllSessions_UnloadableRowsAreHiddenWithoutBeingDeleted`) pass unmodified.
- Behaviour delta (called out in the issue as desirable): a row whose JSON **parses but would fail full binding** (e.g. `{"driverEntries": "not-an-array"}`) is now *listed*; clicking it goes through `LoadSessionService` → `TryLoadSession`, which still reports `InvalidData` and shows the existing friendly error — the row becomes visible/deletable instead of silently hidden.
- New `RaceSessionListValidationTests.cs` (2 tests) pinning both sides: parseable-but-unbindable rows are listed (proof the cheap path is in use) and empty/unparseable/non-object rows stay hidden.

## Verify plan

- `dotnet test src/RCDragManagerProd.Tests` — 326 passed / 0 failed / 11 pre-existing skips.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
