### PR TITLE
docs: correct stale claude-context docs and CI comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,9 @@ jobs:
       - name: Restore NuGet packages
         run: nuget restore $env:SOLUTION
 
-      # Release build of the WinForms app through real MSBuild — this is the actual
-      # release path and the app must compile before tests are worth running.
+      # Release build of both apps (legacy WinForms + the shipped WPF UI; the src
+      # solution includes both) through real MSBuild — this is the actual release
+      # path and the apps must compile before tests are worth running.
       - name: Build solution
         run: msbuild $env:SOLUTION -p:Configuration=$env:CONFIGURATION -m -v:minimal -nologo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,9 @@ Use MSBuild or Visual Studio only. Command-line example:
 `MSBuild RCDragManagerProd.sln /t:Build /p:Configuration=Debug`.
 
 > Note: there are two `.sln` files. The repo-root `RCDragManagerProd.sln` is the
-> one to use — it includes `RCDragManagerProd.WPF`. The older
-> `src/RCDragManagerProd/RCDragManagerProd.sln` predates the WPF project.
+> one to use — it includes the app projects **and** `RCDragManagerProd.Tests`.
+> The older `src/RCDragManagerProd/RCDragManagerProd.sln` also includes the WPF
+> project (CI builds it) but not the test project.
 
 > Gotcha: a clean rebuild of the WinForms project needs
 > `System.Resources.Extensions` present at its `HintPath`
@@ -153,13 +154,15 @@ deviation will be caught in code review.
   `"Round Robin"` → `"Losers Bracket"` → `"Finals"`. Code that reads
   `RaceType` must handle all three values.
 
-- **`RaceController` is a sealed partial class** split across 11 files.
+- **`RaceController` is a sealed partial class** split across ~19 files.
   Adding new methods to the controller means either adding to the most
   relevant existing partial file or creating a new partial file named
   `RaceController.{Concern}.cs`.
 
-- **All saves are INSERT, never UPDATE.** `RaceSessionRepository` and
-  (new) `MultiClassEventRepository` are append-only. This is by design.
+- **Saves are INSERT-on-first-save, then UPDATE in place.**
+  `RaceSessionRepository.SaveSession` and `MultiClassEventRepository.SaveEvent`
+  assign the row id on the first save and update the same row on later saves.
+  List/load paths never delete or overwrite damaged rows.
 
 - **`System.Text.Json` only** — no Newtonsoft.Json. For any type that
   `System.Text.Json` cannot serialize (e.g. `HashSet<(int,int)>`), add a

--- a/Docs/claude-context/CODEBASE-MAP.md
+++ b/Docs/claude-context/CODEBASE-MAP.md
@@ -1,6 +1,26 @@
 # RC Drag Manager — Codebase Map
 
-All source files in `src/RCDragManagerProd/`, organised by folder.
+All source files in `src/RCDragManagerProd/`, organised by folder. The WPF UI
+lives in `src/RCDragManagerProd.WPF/` (see the section at the end and the WPF
+UI section of `CLAUDE.md`).
+
+---
+
+## AppServices/
+
+UI-agnostic services extracted from the forms (issues #284–#291); both the
+legacy WinForms UI and the WPF UI bind to these.
+
+| File | Description |
+|------|-------------|
+| `RaceConsoleService.cs` | Race-console orchestration: winner submission, primary action, buybacks, edit-result validation, save/close, completion stats (`RecordTournamentCompletion`, `RecomputeEventsWon`) |
+| `RaceConsoleViewModel.cs` / `RaceConsoleViewModelBuilder.cs` | Console state snapshot + builder |
+| `LoadSessionService.cs` | Lists/loads saved sessions and multi-class events with typed failure results |
+| `MultiClassSetupService.cs` | Multi-class event setup validation and construction |
+| `MultiClassRaceService.cs` | Multi-class coordination helpers (per-class completion stats) |
+| `SessionRosterService.cs` | Roster validation/sync between the console grid and the session |
+| `DriverManagerService.cs` / `DriverStatsService.cs` | Driver registry and stats screens' logic |
+| `RaceResultsPresentationBuilder.cs` / `ClassCompletionPresentationBuilder.cs` | Build result/ladder presentations from a saved session |
 
 ---
 
@@ -36,7 +56,14 @@ All source files in `src/RCDragManagerProd/`, organised by folder.
 | `RaceController.Persistence.cs` | `SaveSession()` — collects match results and round state into the `RaceSession` object |
 | `RaceController.Logging.cs` | `TryLogCompletedRound()` — emits RR per-round scorecard logs |
 | `RaceController.EngineCalls.cs` | `EngineGetMatches()`, `EngineSetWinner()`, `EngineHasWinner()`, etc. — thin adapters isolating engine type casts |
-| `RaceController.LiveUpdate.cs` | `QueueLiveUpdate()`, `BuildLiveRaceUpdateDto()` — optional HTTP live feed push |
+| `RaceController.LiveUpdate.cs` | `QueueLiveUpdate()`, `BuildLiveRaceUpdateDto()`, `BroadcastLiveSnapshot()` — optional HTTP live feed push |
+| `RaceController.DialIn.cs` | Dial-in state: `GetDriverDialIn()`, `UpdateDriverDialIn()`, lock/unlock, live-site poll timer, `DialInsChanged` event |
+| `RaceController.Resume.cs` | `RestoreFromSave()` — rebuilds engine state from a saved session (mid-event resume) |
+| `RaceController.MultiClass.cs` | Multi-class coordination helpers (`IsRrComplete()`, pending-match queries) |
+| `RaceController.SaveClose.cs` | `SaveProgress()` / close-race orchestration |
+| `RaceController.ResultSnapshots.cs` | Captures completed-result snapshots for results-only viewing |
+| `RaceController.RoundFlow.Defer.cs` | `PushCurrentMatchToEndOfRound()` — "more time" deferral |
+| `RaceController.Stats.cs` | `PersistTournamentStats()`, `PersistMatchStats()`, `PersistEventWon()`, `RecomputeEventsWon()` (legacy Form1 path; WPF uses `RaceConsoleService`) |
 | `LaneFairnessManager.cs` | Tracks lane (left/right) history per driver; `GetLane()` returns the fairer assignment |
 | `IStandingsDialogService.cs` | Interface for showing the RR standings popup; default impl uses `ScrollableTextDialog` |
 
@@ -49,6 +76,7 @@ All source files in `src/RCDragManagerProd/`, organised by folder.
 | `Drivers.cs` | `Driver` entity: Id, Name, QualTime, TotalWins, TotalLosses, EventsEntered, EventsWon, Seed, State, Cars |
 | `Car.cs` | `Car` entity: Id/CarID alias, DriverId, CarName, ClassType, DefaultDialIn |
 | `RaceSession.cs` | `RaceSession` (full session state), `RaceSessionDriverEntry` (per-driver snapshot), `MatchResultSave` (serializable result record) |
+| `MultiClassEvent.cs` | Parent object for multi-class events: EventName, EventDate, `ClassSessions` (one `RaceSession` per class) |
 | `MatchResult.cs` | In-memory result store: `SetWinner`, `GetWinner`, `GetLoser`, `HasResult`, `ClearFromMatch`, `IsTournamentComplete` |
 | `ByePolicy.cs` | `IsBye(Driver d)` — true if `d == null` |
 | `RoundLabels.cs` | Round label normalization (`"R1"`, `"SF"`, `"F"`, `"LB-R1"`, `"LB-F"`, `"RR1"`, …), compare/sort keys |
@@ -92,7 +120,8 @@ One file per supported field size (3–24 drivers). Each defines a static partia
 
 | File | Description |
 |------|-------------|
-| `Logger.cs` | Static logger; writes timestamped lines to `%APPDATA%\RC_Drag_Manager\app.log`; respects `AppSettings.EnableLogging` |
+| `Logger.cs` | Static facade: `Log` (info) + `Debug` (gated by `AppSettings.VerboseLogging`); respects `AppSettings.EnableLogging` |
+| `LogWriter.cs` | Shared lock-guarded writer: one file handle, AutoFlush, 5 MB roll to `app.log.1` in `%APPDATA%\RC_Drag_Manager` |
 
 ---
 
@@ -125,10 +154,12 @@ One file per supported field size (3–24 drivers). Each defines a static partia
 
 | File | Description |
 |------|-------------|
-| `DatabaseInitializer.cs` | Idempotent schema creation: `CREATE TABLE IF NOT EXISTS` for Drivers, Cars, RaceSessions; `ALTER TABLE` for new columns |
+| `DatabaseInitializer.cs` | Idempotent schema creation: `CREATE TABLE IF NOT EXISTS` for Drivers, Cars, RaceSessions, MultiClassEvents |
 | `DriverRepository.cs` | Full CRUD for Drivers + Cars; stat increment methods; `ComputeEventsWonFromSavedSessions()` |
 | `CarRepository.cs` | Lightweight Car-only CRUD (partial overlap with DriverRepository) |
-| `RaceSessionRepository.cs` | `SaveSession()` (INSERT), `GetAllSessions()` (summary list), `LoadSession(id)` (deserialize JSON), `DeleteSession(id)` |
+| `RaceSessionRepository.cs` | `SaveSession()` (INSERT first save / UPDATE after), `GetAllSessions()` (summary list), `TryLoadSession(id)` (typed load result), `DeleteSession(id)` |
+| `MultiClassEventRepository.cs` | Same pattern for `MultiClassEvent` parent objects (`SaveEvent`/`GetAllEvents`/`LoadEvent`/`DeleteEvent`) |
+| `DbDate.cs` | Invariant-culture format/parse for stored EventDate strings |
 
 ---
 
@@ -272,3 +303,30 @@ Scans the main project's source files and generates Markdown/JSON reports of cla
 | `Models/` | Data models: `ClassInfo`, `MethodInfo`, `EventInfo`, `RepositoryInfo`, `UIControlInfo`, `DependencyInfo`, `ClassRelationInfo`, `ProjectMap` |
 | `Modules/` | Scanners and exporters: `ClassScanner`, `MethodScanner`, `EventScanner`, `RepositoryScanner`, `UIControlScanner`, `ClassRelationAnalyzer`, `DependencyGraphAnalyzer`, `CircularDependencyDetector`, `ProjectMapBuilder`, `JsonExporter`, `MarkdownExporter`, `UIEventMapExporter` |
 | `Program.cs` | Entry point: orchestrates scan and export |
+
+> `src/ProjectAnalysis/` holds this tool's **generated output** (ProjectMap.json,
+> Methods.md, …). It is a point-in-time snapshot and its line numbers drift from
+> the source — regenerate before trusting it; prefer reading the code directly.
+
+---
+
+## src/RCDragManagerProd.WPF/ (current UI — v2.0.0)
+
+The shipped WPF app. Views hold no race logic; they bind to the AppServices
+above and subscribe to `RaceController` events. See the "WPF UI" section of
+`CLAUDE.md` for conventions (themed dialogs, `Brush.*` resources, Dispatcher
+marshalling).
+
+| Path | Description |
+|------|-------------|
+| `App.xaml(.cs)` | Startup: settings, theme, DB init, global exception handler, opens `LandingWindow` |
+| `Windows/` | Top-level windows: Landing, Setup, LoadSession, DriverManager, DriverStats, RaceConsole, MultiClassRace, Settings, LiveScoreboard |
+| `Views/RaceConsoleView.xaml(.cs)` | One class's race console; hosted standalone or one-per-tab in `MultiClassRaceWindow` |
+| `Dialogs/` | Themed modal dialogs incl. `MessageDialog` (the dark `MessageBox` replacement), results/buyback/edit dialogs |
+| `ViewModels/` | INotifyPropertyChanged view models + display-row types |
+| `Resources/Theme.xaml` | Brushes (`Brush.*` bound to `C.*` colours), radii, font sizes |
+| `Resources/Styles.xaml` | Control styles (buttons, grids, title-bar traffic lights) |
+| `ThemeManager.cs` | Dark/light palette (`C.*` colour dictionary swap at runtime) |
+| `WindowSizing.cs` | Work-area clamping, borderless-maximize constraints, Win11 rounded corners |
+| `WpfStandingsDialogService.cs` | `IStandingsDialogService` implementation using themed dialogs |
+| `Converters.cs` | Value converters used by the XAML views |

--- a/Docs/claude-context/TECHNICAL-DEBT.md
+++ b/Docs/claude-context/TECHNICAL-DEBT.md
@@ -23,19 +23,15 @@ All 12 issues raised in March 2026 have been closed and merged.
 
 ## Known Architectural Weaknesses
 
-### 1. Session Save is Always INSERT (No Update)
+### 1. ~~Session Save is Always INSERT (No Update)~~ — RESOLVED
 
-`RaceSessionRepository.SaveSession` always does an INSERT. There is no UPDATE path. Saving an in-progress session multiple times creates multiple rows. The user must manually pick the correct (latest) row when resuming. Old rows accumulate indefinitely.
-
-**Impact:** Minor UX inconvenience; no data corruption. Fix would require an UPDATE path and a way to identify the "canonical" save for a session.
+`SaveSession` now INSERTs on first save (assigning the row id) and UPDATEs the same row on later saves; `MultiClassEventRepository.SaveEvent` follows the same pattern. Re-saving no longer creates duplicate rows (see `SaveSession_WhenAlreadyPersisted_UpdatesExistingRow` and `RepositorySaveRoundTripTests`).
 
 ---
 
-### 2. Bracket State Not Persisted — Sessions Don't Resume Mid-Bracket
+### 2. ~~Bracket State Not Persisted — Sessions Don't Resume Mid-Bracket~~ — RESOLVED
 
-When a session is loaded from the database, the `RaceSession` JSON is deserialized but the **engine state is not rebuilt**. The bracket (match tree, driver positions, seeds) is not stored — only the scalar match results (`SavedResults`) and revealed round labels are. Resuming a session effectively means restarting from scratch: the Race Director must regenerate the bracket and re-enter results.
-
-**Impact:** Significant for mid-event saves. Workaround: don't save until the event is done, or manually reconstruct.
+Mid-event resume now exists: `RaceController.Resume.cs` (`RestoreFromSave()`) rebuilds engine state from the saved session (`SavedResults`, `SavedRevealedRounds`, bracket snapshots) when a saved event is reopened — `MultiClassRaceWindow.OnLoadedRestore` calls it for every class on load.
 
 ---
 
@@ -57,7 +53,7 @@ Both `DriverRepository` and `CarRepository` handle car records. `DriverRepositor
 
 ### 5. `RaceController` Has Significant Length and Complexity
 
-The controller is split across 11 partial files. While the split helps navigate individual concerns, the total size and the number of distinct responsibilities (session lifecycle, RR standings, LB flow, finals injection, live feed, persistence) make it a complex class to reason about as a whole.
+The controller is split across ~19 partial files. While the split helps navigate individual concerns, the total size and the number of distinct responsibilities (session lifecycle, RR standings, LB flow, finals injection, live feed, persistence) make it a complex class to reason about as a whole.
 
 **Impact:** High cognitive load for new developers. Future refactor could extract the phase-transition logic (RR→LB→Finals) into a dedicated state machine.
 
@@ -71,11 +67,9 @@ Despite the controller layer, `Form1` still does some non-trivial things: it cal
 
 ---
 
-### 7. No Session Update / Resume Architecture
+### 7. ~~No Session Update / Resume Architecture~~ — RESOLVED
 
-Related to point 2: the architecture has no concept of "resume session". `LoadSession` deserializes the JSON and hands the `RaceSession` object to `Form1`, but `Form1` then calls `GenerateBracket` fresh. The `SavedResults` and `SavedRevealedRounds` fields exist on `RaceSession` but there is no code path that uses them to reconstruct the engine from a saved state.
-
-**Impact:** Sessions cannot be practically resumed mid-event.
+Superseded with point 2: save now updates in place, and `RaceController.RestoreFromSave()` reconstructs engine state from `SavedResults` / `SavedRevealedRounds` when a session is loaded (WPF flow; legacy `Form1` still regenerates fresh).
 
 ---
 
@@ -104,6 +98,6 @@ From the original `_PROJECT_STATUS_SUMMARY.md` Phase 7 plan:
 3. **Online Sync (optional)** — cloud backup of driver stats and session history.
 4. **UI Themes** — dark/light modes.
 5. **Performance Profiling** — especially for large driver registries.
-6. **Session Resume** — proper bracket reconstruction from saved state.
+6. ~~**Session Resume** — proper bracket reconstruction from saved state.~~ Done — `RaceController.Resume.cs`.
 7. **CarRepository consolidation** — retire `CarRepository`; all car logic in `DriverRepository`.
 8. **ProLadder extended to 32** — currently only up to L24 (24 drivers) has a tested template. Files L25–L32 may not exist or may need validation.


### PR DESCRIPTION
## Summary

Fixes #388 — docs-only PR correcting the stale statements in the claude-context docs (which drive every AI-agent session) and CI comments.

## Changes

- **CLAUDE.md**: the "All saves are INSERT, never UPDATE / append-only by design" convention is replaced with the real semantics (INSERT on first save, UPDATE in place after — see #385); the two-solutions note no longer claims the src solution "predates the WPF project" (it includes it and CI builds it); controller partial-file count updated.
- **TECHNICAL-DEBT.md**: items 1 (append-only saves), 2 and 7 (no mid-event resume) struck through as RESOLVED with pointers to `RaceController.Resume.cs` / `RestoreFromSave()` and the round-trip tests; Phase-7 "Session Resume" marked done.
- **ci.yml**: build-step comment says it compiles both apps (WinForms + WPF), not "the WinForms app".
- **CODEBASE-MAP.md**: added the missing `AppServices/` section, the seven newer `RaceController` partials (DialIn, Resume, MultiClass, SaveClose, ResultSnapshots, RoundFlow.Defer, Stats), `MultiClassEventRepository`/`DbDate`/`LogWriter`, `Domain/MultiClassEvent`, a `src/RCDragManagerProd.WPF/` section, and a warning that `src/ProjectAnalysis/` is point-in-time generated output whose line numbers drift (kept in place rather than deleted — regenerable via CodeStats; happy to remove it in a follow-up if preferred).

## Verify plan

- Docs + comment changes only; no code. CI re-runs build/tests unchanged.
- Cross-checked each corrected claim against current source (`RaceSessionRepository.SaveSession`, `RaceController.Resume.cs`, both `.sln` files, `Controllers/` listing).

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
