### PR TITLE
docs: add README, issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Something in the app doesn't work as it should
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences — what is wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / repro
+      description: >-
+        Steps to reproduce, and if known, the file/line responsible
+        (e.g. src/RCDragManagerProd/Controllers/RaceController.Results.cs:42).
+      placeholder: |
+        1. Start a single-class Pro Ladder event with 6 drivers
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who hits this and how bad is it on race day?
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Suggested fix
+      description: Optional — pointers for whoever (human or agent) picks this up.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How we know it's fixed.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,33 @@
+name: Enhancement
+description: New capability, UX improvement, performance or cleanup work
+title: "[Area] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should change, and why is it worth doing?
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: Detail
+      description: >-
+        Current behaviour, desired behaviour, and relevant files. Write enough
+        for another contributor (or an AI agent) to pick it up cold.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How we know it's done.
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: >-
+        Anything off-limits (see the "What Not to Touch" list in CLAUDE.md),
+        compatibility notes, or sequencing with other issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this PR change, and why? Reference the issue: Closes #NNN -->
+
+## Changes
+
+<!-- Bullet the notable changes. Call out anything touching the CLAUDE.md
+     "What Not to Touch" list explicitly. -->
+
+## Verify plan
+
+<!-- How was this verified? Test run results, build output, manual steps.
+     All tests must pass before merging. -->

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# RC Drag Manager
+
+A Windows desktop app that lets a Race Director run NHRA-style RC drag racing
+tournaments — one operator, one machine, no network required, and no
+auto-advancement: every step is a deliberate click.
+
+## Features
+
+- **Race modes**: NHRA Pro Ladder (seeded, 3–24 drivers), Random draw brackets,
+  and QMDRA-style Round Robin with standings, buybacks, Losers Bracket and Finals.
+- **Multi-class events**: run several classes side by side in one tabbed console,
+  with a shared round-robin gate and a combined event summary.
+- **Driver registry**: lifetime win/loss and events-won stats, cars with
+  per-class dial-ins, qualifying times.
+- **Save / resume**: events persist to a local SQLite database and resume
+  mid-bracket.
+- **Live scoreboard (optional)**: pushes bracket state to a companion web
+  scoreboard ([RCDragLiveServer](https://github.com/stewmac570)) so spectators
+  can follow along; supports remote dial-in submission.
+- **Dark / light theme**: flame-orange design system, switchable in Settings.
+
+The current UI is **WPF** (`RCDragManagerProd.WPF`, shipped since v2.0.0). The
+original WinForms UI remains in the solution as legacy.
+
+## Download
+
+Grab the latest installer (`RC-Drag-Manager-Setup-*.exe`) from
+[Releases](https://github.com/stewmac570/RC-Drag-Manager/releases). Data lives
+in `%APPDATA%\RC_Drag_Manager` (SQLite DB, settings, log).
+
+## Building from source
+
+- **Requirements**: Visual Studio 2022 (or Build Tools) with .NET Framework 4.8
+  targeting pack. This is .NET Framework — `dotnet build` will not work; use
+  MSBuild or Visual Studio.
+- Open the repo-root `RCDragManagerProd.sln`, restore NuGet packages, set
+  `RCDragManagerProd.WPF` as the startup project, F5.
+- Command line:
+  `MSBuild RCDragManagerProd.sln /t:Build /p:Configuration=Debug`
+- Tests: `dotnet test src/RCDragManagerProd.Tests/RCDragManagerProd.Tests.csproj`
+  (MSTest, in-memory/temp SQLite — no setup needed).
+- Installer: `Installer/build-installer.ps1` (Inno Setup 6).
+
+## Documentation
+
+Architecture, domain model, data layer and race-flow docs live in
+[`Docs/claude-context/`](Docs/claude-context/) — start with
+`PROJECT-OVERVIEW.md` and `ARCHITECTURE.md`. `CLAUDE.md` at the repo root
+defines the layering rules (Form → Service → Controller → Engine) that all
+changes must follow.
+
+## License
+
+All rights reserved. Personal project of Stew Mac (stewmac570); no license is
+currently granted for reuse or redistribution.


### PR DESCRIPTION
## Summary

Part of #387 — adds the creatable repo-hygiene pieces. Two items from the issue are deliberately **not** in this PR because they need your explicit decision (per the repo's own rules): the LICENSE choice, and deleting the ~60 merged remote branches (I'll post the candidate list as a comment on #387 for sign-off).

## Changes

- **`README.md`** — repo landing page: what the app is, feature list, download pointer to Releases, build-from-source instructions (including the "MSBuild, not dotnet build" gotcha), documentation index, and an explicit "all rights reserved" note so the legal status isn't ambiguous while unlicensed.
- **`.github/ISSUE_TEMPLATE/bug.yml` + `enhancement.yml`** — issue forms matching the conventions this repo's issues already follow (summary / evidence / impact / suggested fix / acceptance criteria / constraints), so human- and agent-filed issues stay consistent. Blank issues remain enabled (`config.yml`).
- **`.github/pull_request_template.md`** — summary / changes / verify plan, with a prompt to flag anything on the CLAUDE.md do-not-touch list.

## Verify plan

- Docs/templates only; no code. CI runs unchanged.
- After merge: README renders on the repo landing page; "New issue" offers the two forms; new PRs pre-fill the template.

Part of #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
