### PR TITLE
Move the live-server API key out of the repo

### DIFF
--- a/Docs/LiveIntegrationReview.md
+++ b/Docs/LiveIntegrationReview.md
@@ -60,7 +60,7 @@
   - Each trigger method calls `QueueLiveUpdate(...)` once at end of successful state transition.
 - Contract details to enforce in service:
   - `POST https://stewmacrc.com/api/update`
-  - Header `X-API-KEY: 86561451-e7cf-4c01-87f1-0ae7e34e26d0`
+  - Header `X-API-KEY: <your-api-key>`
   - Send full-state payload every time (replacement semantics).
 
 ## 5. Failure Handling Strategy

--- a/Docs/LiveIntegration_LocalServerButton.md
+++ b/Docs/LiveIntegration_LocalServerButton.md
@@ -30,7 +30,7 @@ Both launch paths now explicitly force local binding to `http://localhost:5005` 
 
 Both launch paths also inject:
 - `ASPNETCORE_ENVIRONMENT=Development`
-- `ApiKey=86561451-e7cf-4c01-87f1-0ae7e34e26d0`
+- `ApiKey=<your-api-key>`
 
 ## Startup Diagnostics Added
 During startup wait, all non-empty child process lines are captured and logged:

--- a/Docs/LiveIntegration_LocalSetupFix.md
+++ b/Docs/LiveIntegration_LocalSetupFix.md
@@ -32,12 +32,12 @@ Root cause:
   - Error message now explains where to configure key.
 - `C:\Users\Stewart McMillan\source\repos\RCDragLiveServer\src\RCDragLiveServer\Properties\launchSettings.json`
   - Added:
-    - `ApiKey=86561451-e7cf-4c01-87f1-0ae7e34e26d0`
+    - `ApiKey=<your-api-key>`
   - Updated:
     - `applicationUrl=http://localhost:5005`
 - `C:\Users\Stewart McMillan\source\repos\RCDragLiveServer\src\RCDragLiveServer\appsettings.Development.json`
   - Added:
-    - `"ApiKey": "86561451-e7cf-4c01-87f1-0ae7e34e26d0"`
+    - `"ApiKey": "<your-api-key>"`
 
 ## Where ApiKey Is Now Defined
 - Primary local source (A):
@@ -87,7 +87,7 @@ Expected local URL:
 2. Point RC Drag Manager to local server:
 - Edit `src/RCDragManagerProd/App.config`:
   - `LiveUpdateUrl = http://localhost:5005/api/update`
-  - `LiveUpdateApiKey = 86561451-e7cf-4c01-87f1-0ae7e34e26d0`
+  - `LiveUpdateApiKey = <your-api-key>`
 
 3. Run RC Drag Manager and trigger updates (Generate Bracket / Submit Winner / Advance Round).
 
@@ -100,11 +100,11 @@ curl -i http://localhost:5005/api/live
 ## How To Switch Local vs Production Endpoints
 ### Local
 - `LiveUpdateUrl = http://localhost:5005/api/update`
-- `LiveUpdateApiKey = 86561451-e7cf-4c01-87f1-0ae7e34e26d0`
+- `LiveUpdateApiKey = <your-api-key>`
 
 ### Production
 - `LiveUpdateUrl = https://stewmacrc.com/api/update`
-- `LiveUpdateApiKey = 86561451-e7cf-4c01-87f1-0ae7e34e26d0`
+- `LiveUpdateApiKey = <your-api-key>`
 
 No code changes are required in RC Drag Manager to switch endpoints; config-only change.
 

--- a/src/RCDragManagerProd.WPF/App.config
+++ b/src/RCDragManagerProd.WPF/App.config
@@ -4,12 +4,12 @@
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
 	</startup>
 
-	<!-- Live-broadcast settings are read via ConfigurationManager.AppSettings by
-	     LiveApiClient, so they must live in the running exe's config. Mirrors the
-	     WinForms project's App.config so live broadcast works from the WPF app. -->
+	<!-- The live-server API key is NOT stored here (public repo, #377). It lives
+	     in %APPDATA%\RC_Drag_Manager\appsettings.json (AppSettings.ApiKey) — set
+	     it via the Settings dialog. Installs that predate #377 are migrated from
+	     their old exe.config automatically on first run. -->
 	<appSettings>
 		<add key="LiveUpdateEnabled" value="true" />
 		<add key="LiveUpdateUrl" value="https://stewmacrc.com/api/update" />
-		<add key="ApiKey" value="86561451-e7cf-4c01-87f1-0ae7e34e26d0" />
 	</appSettings>
 </configuration>

--- a/src/RCDragManagerProd.WPF/Windows/SettingsWindow.xaml
+++ b/src/RCDragManagerProd.WPF/Windows/SettingsWindow.xaml
@@ -78,6 +78,14 @@
                           Content="Broadcast live results to stewmacrc.com" Margin="0,0,0,10"/>
                 <CheckBox x:Name="ChkDebugLogging" Style="{StaticResource Style.CheckBox}"
                           Content="Verbose live-broadcast logging" Margin="0,0,0,14"/>
+                <TextBlock Text="Live server API key"
+                           FontSize="{StaticResource FontSize.Xs}"
+                           Foreground="{StaticResource Brush.TextMuted}" Margin="0,0,0,4"/>
+                <TextBox x:Name="TxtApiKey" Style="{StaticResource Style.TextBox}"
+                         Margin="0,0,0,4"/>
+                <TextBlock Text="Stored locally in appsettings.json — required for broadcasting."
+                           FontSize="{StaticResource FontSize.Xs}"
+                           Foreground="{StaticResource Brush.TextHint}" Margin="0,0,0,14"/>
                 <Button Style="{StaticResource Style.Button.Toolbar}"
                         Content="Open live view ↗" Click="BtnOpenLiveView_Click"
                         HorizontalAlignment="Left" Padding="14,7"/>

--- a/src/RCDragManagerProd.WPF/Windows/SettingsWindow.xaml.cs
+++ b/src/RCDragManagerProd.WPF/Windows/SettingsWindow.xaml.cs
@@ -24,6 +24,7 @@ namespace RCDragManagerProd.WPF.Windows
             ChkLogging.IsChecked = AppSettings.EnableLogging;
             ChkLiveBroadcast.IsChecked = AppSettings.LiveBroadcastEnabled;
             ChkDebugLogging.IsChecked = AppSettings.LiveBroadcastDebugLogging;
+            TxtApiKey.Text = AppSettings.ApiKey;
             TxtLogPath.Text = AppSettings.LogFilePath;
         }
 
@@ -32,6 +33,7 @@ namespace RCDragManagerProd.WPF.Windows
             AppSettings.EnableLogging = ChkLogging.IsChecked == true;
             AppSettings.LiveBroadcastEnabled = ChkLiveBroadcast.IsChecked == true;
             AppSettings.LiveBroadcastDebugLogging = ChkDebugLogging.IsChecked == true;
+            AppSettings.ApiKey = TxtApiKey.Text;
             if (AppSettings.EnableLogging) Logger.Log("[SETTINGS] Logging enabled.");
 
             var newTheme = RbLight.IsChecked == true ? "Light" : "Dark";

--- a/src/RCDragManagerProd/App.config
+++ b/src/RCDragManagerProd/App.config
@@ -9,7 +9,9 @@
 		<add key="LogFilePath" value="%APPDATA%\RC_Drag_Manager\app.log"/>
 		<add key="LiveUpdateEnabled" value="true" />
 		<add key="LiveUpdateUrl" value="https://stewmacrc.com/api/update" />
-		<add key="ApiKey" value="86561451-e7cf-4c01-87f1-0ae7e34e26d0" />
+		<!-- The live-server API key is NOT stored here (public repo, #377).
+		     It lives in %APPDATA%\RC_Drag_Manager\appsettings.json — set it via
+		     the Settings dialog. -->
 		<!-- Optional: you can set a custom path; %APPDATA% will be expanded -->
 		<!-- <add key="LogFilePath" value="%APPDATA%\RC_Drag_Manager\app.log" /> -->
 	</appSettings>

--- a/src/RCDragManagerProd/Config/AppSettings.cs
+++ b/src/RCDragManagerProd/Config/AppSettings.cs
@@ -24,6 +24,12 @@ namespace RCDragManagerProd.Config
 
             // UI theme for the WPF app: "Dark" (default) or "Light".
             public string Theme { get; set; } = "Dark";
+
+            // X-API-KEY for the live scoreboard server. Deliberately NOT in
+            // App.config: the repo is public and a committed key was exposed
+            // (#377). Set once via the Settings dialog; empty disables auth'd
+            // live calls.
+            public string ApiKey { get; set; } = "";
         }
 
         private static readonly string AppFolder =
@@ -55,6 +61,24 @@ namespace RCDragManagerProd.Config
             {
                 _model = new Model(); // fail-safe defaults
             }
+
+            MigrateApiKeyFromExeConfig();
+        }
+
+        // One-time adoption for installs that predate #377, where the key lived in
+        // the exe.config. Copies it into appsettings.json so removing it from the
+        // repo (and future installers) doesn't break an already-configured machine.
+        private static void MigrateApiKeyFromExeConfig()
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(_model.ApiKey)) return;
+                var legacy = System.Configuration.ConfigurationManager.AppSettings["ApiKey"];
+                if (string.IsNullOrWhiteSpace(legacy)) return;
+                _model.ApiKey = legacy;
+                Save();
+            }
+            catch { /* no exe.config access — nothing to migrate */ }
         }
 
         public static void Save()
@@ -90,6 +114,12 @@ namespace RCDragManagerProd.Config
         {
             get => _model.VerboseLogging;
             set { _model.VerboseLogging = value; Save(); }
+        }
+
+        public static string ApiKey
+        {
+            get => _model.ApiKey ?? "";
+            set { _model.ApiKey = (value ?? "").Trim(); Save(); }
         }
 
         public static string Theme

--- a/src/RCDragManagerProd/Integration/LiveApiClient.cs
+++ b/src/RCDragManagerProd/Integration/LiveApiClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -73,7 +72,7 @@ namespace RCDragManagerProd.Integration
         {
             try
             {
-                var apiKey = ConfigurationManager.AppSettings["ApiKey"];
+                var apiKey = AppSettings.ApiKey;
                 var isNull = apiKey == null;
                 var isEmpty = apiKey != null && apiKey.Length == 0;
                 var isWhiteSpace = string.IsNullOrWhiteSpace(apiKey);
@@ -123,7 +122,7 @@ namespace RCDragManagerProd.Integration
         {
             try
             {
-                var apiKey = ConfigurationManager.AppSettings["ApiKey"];
+                var apiKey = AppSettings.ApiKey;
                 if (string.IsNullOrWhiteSpace(apiKey)) return;
 
                 var body = new { eventId, eventName };
@@ -149,7 +148,7 @@ namespace RCDragManagerProd.Integration
         {
             try
             {
-                var apiKey = ConfigurationManager.AppSettings["ApiKey"];
+                var apiKey = AppSettings.ApiKey;
                 if (string.IsNullOrWhiteSpace(apiKey)) return null;
 
                 var url = DialInPollUrl + "?eventId=" + Uri.EscapeDataString(eventId ?? string.Empty);


### PR DESCRIPTION
## Summary

Fixes the app-side of #377 — the live-server X-API-KEY was committed in plain text in both `App.config` files (and quoted verbatim in three `Docs/` pages) of a **public** repo.

> ⚠️ **This PR does not un-leak the key.** The old value stays in git history; it is dead only once you rotate it on the server. Action needed after merge: rotate the key in RCDragLiveServer, then paste the new key into Settings → Live broadcast.

## Changes

- **`Config/AppSettings.cs`**: new `ApiKey` setting, persisted in `%APPDATA%\RC_Drag_Manager\appsettings.json` (machine-local, never committed). `Load()` performs a one-time migration: if `appsettings.json` has no key but the running exe.config does (installs that predate this PR), the key is adopted and saved — so an already-configured machine keeps broadcasting after updating.
- **`Integration/LiveApiClient.cs`**: all three call sites (`SendCoreAsync`, `ResetCoreAsync`, `GetDialInUpdatesAsync`) read `AppSettings.ApiKey` instead of `ConfigurationManager.AppSettings["ApiKey"]`.
- **`App.config` (both projects)**: `ApiKey` entry removed; a comment points at the new home. `LiveUpdateEnabled`/`LiveUpdateUrl` left as-is (not secrets).
- **`SettingsWindow` (XAML + code-behind)**: "Live server API key" text field in the Live broadcast section, loaded/saved with the other settings, with a hint that it is stored locally.
- **Docs**: the literal key in `LiveIntegrationReview.md`, `LiveIntegration_LocalServerButton.md`, `LiveIntegration_LocalSetupFix.md` replaced with `<your-api-key>`.

## Verify plan

- `dotnet test src/RCDragManagerProd.Tests` — 326 passed / 0 failed / 11 pre-existing skips.
- `MSBuild RCDragManagerProd.WPF.csproj -p:Configuration=Release` — builds clean.
- `git ls-files | xargs grep -l <key>` → no tracked file contains the key (local `bin`/`obj`/`Installer/Payload` copies are ignored artifacts that refresh on rebuild).
- Manual after merge: Settings shows the migrated key on this machine → broadcast still works; after server-side rotation, paste the new key.

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)
